### PR TITLE
fix(ci): use GITHUB_TOKEN + OIDC for npm publish, drop NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
   packages: write
   issues: write
   pull-requests: write
+  id-token: write # Required for npm provenance
 
 jobs:
   test:
@@ -36,6 +37,12 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+      pull-requests: write
+      id-token: write # Required for OIDC authentication with npm provenance
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,6 +60,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install
 
@@ -63,8 +73,7 @@ jobs:
         run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: '0'
 
       - name: Setup Node for GitHub Packages
         uses: actions/setup-node@v4
@@ -81,5 +90,4 @@ jobs:
             echo "Published to GitHub Packages successfully!"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -38,7 +38,12 @@
       }
     ],
     "@semantic-release/changelog",
-    "@semantic-release/npm",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": true
+      }
+    ],
     "@semantic-release/github",
     [
       "@semantic-release/git",


### PR DESCRIPTION
## Summary

- Release workflow was failing with `ENEEDAUTH` / `Invalid npm token` because `NPM_TOKEN` secret was missing
- Aligned with NeuroLink's working release pattern: use `GITHUB_TOKEN` + OIDC provenance instead of `NPM_TOKEN`
- No manual secret configuration needed

## Changes

- Removed `NPM_TOKEN` / `NODE_AUTH_TOKEN` from semantic-release env
- Added `id-token: write` permission for OIDC-based npm provenance
- Added `npm install -g npm@latest` step for OIDC support
- Added `HUSKY: '0'` to disable git hooks during release commits
- Updated `.releaserc.json` npm plugin config to match NeuroLink

## Test plan

- [x] Matches NeuroLink's working release workflow exactly
- [ ] Verify release workflow succeeds after merge