### PR TITLE
fix: config save, project path decode, and shift+enter newline support

### DIFF
--- a/src/lib/modules/client/terminal/ChatView.svelte
+++ b/src/lib/modules/client/terminal/ChatView.svelte
@@ -295,7 +295,8 @@
       <Input
         bind:value={inputText}
         dataType="text"
-        placeholder={sessionEnded ? 'Session ended' : 'Send a message...'}
+        useTextArea={true}
+        placeholder={sessionEnded ? 'Session ended' : 'Send a message... (Shift+Enter for new line)'}
         disable={sessionEnded || connectionState !== 'connected'}
         onKeyDown={handleKeydown}
         classes="chat-input-field"

--- a/src/lib/modules/server/sessions/jsonl-reader.ts
+++ b/src/lib/modules/server/sessions/jsonl-reader.ts
@@ -51,6 +51,34 @@ export function getSessionConversation(
   }
 }
 
+function readCwdFromProjectDir(projectDir: string, sessions: SessionInfo[]): string {
+  for (const session of sessions) {
+    try {
+      const jsonlPath = path.join(projectDir, `${session.id}.jsonl`);
+      if (!fs.existsSync(jsonlPath)) {
+        continue;
+      }
+      const content = fs.readFileSync(jsonlPath, 'utf-8');
+      for (const line of content.split('\n')) {
+        if (!line.trim()) {
+          continue;
+        }
+        try {
+          const entry = JSON.parse(line) as Record<string, unknown>;
+          if (typeof entry.cwd === 'string' && entry.cwd) {
+            return entry.cwd;
+          }
+        } catch {
+          // skip malformed lines
+        }
+      }
+    } catch {
+      // skip unreadable files
+    }
+  }
+  return '';
+}
+
 export function listProjectsWithSessions(): ProjectGroup[] {
   if (!fs.existsSync(CLAUDE_PROJECTS_DIR)) {
     return [];
@@ -74,8 +102,6 @@ export function listProjectsWithSessions(): ProjectGroup[] {
 
   for (const dir of projectDirs) {
     const projectDir = path.join(CLAUDE_PROJECTS_DIR, dir);
-    // Decode project path (fallback, prefer session's projectPath)
-    const decodedPath = dir.startsWith('-') ? dir.replace(/-/g, '/') : `/${dir.replace(/-/g, '/')}`;
 
     // Get sessions for this project
     const sessions = listSessionsForProject(projectDir);
@@ -86,10 +112,12 @@ export function listProjectsWithSessions(): ProjectGroup[] {
     // Sort sessions by modified desc
     sessions.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
 
-    // Get real project path from session data instead of decoding directory name
+    // Prefer projectPath from session index, then cwd from JSONL, then decoded dir name
     const realPath =
       sessions.find((s) => s.projectPath && !s.projectPath.includes('.claude/projects'))
-        ?.projectPath || decodedPath;
+        ?.projectPath ||
+      readCwdFromProjectDir(projectDir, sessions) ||
+      (dir.startsWith('-') ? dir.replace(/-/g, '/') : `/${dir.replace(/-/g, '/')}`);
     const pathSegments = realPath.split('/').filter(Boolean);
     const projectName = pathSegments.slice(-2).join('/');
 

--- a/src/routes/config/+page.svelte
+++ b/src/routes/config/+page.svelte
@@ -217,7 +217,7 @@
         JSON.stringify({
           apiKey: apiKey.trim(),
           deviceToken: deviceToken.trim(),
-          lastUpdated: Date.now(),
+          lastUpdated: new Date().toISOString(),
           serverUrl: trimmedUrl || getDefaultServerUrl(),
         } satisfies ShooterConfig)
       );

--- a/src/routes/terminals/[id]/+page.svelte
+++ b/src/routes/terminals/[id]/+page.svelte
@@ -41,7 +41,7 @@
 
   // DOM references
   let termContainer = $state<HTMLDivElement | null>(null);
-  const inputRef = $state<HTMLInputElement | null>(null);
+  let inputRef = $state<{ focus: () => void } | null>(null);
 
   // WebSocket and terminal instance refs (not reactive)
   let termInstance: null | {
@@ -546,7 +546,7 @@
   }
 
   function handleInputKeydown(e: KeyboardEvent): void {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleRawInput();
     }
@@ -741,8 +741,10 @@
         <div class="term-input-bar">
           <Input
             bind:value={inputText}
+            bind:this={inputRef}
             dataType="text"
-            placeholder="Type command..."
+            useTextArea={true}
+            placeholder="Type command... (Shift+Enter for new line)"
             classes="input-mono term-input-field"
             onKeyDown={handleInputKeydown}
           />


### PR DESCRIPTION
 ## Summary                                   
  - **Config save broken**: `lastUpdated: Date.now()` stored a number but `isShooterConfig` requires a
  string — validation silently failed and wiped credentials on every page load. Fixed to `new          
  Date().toISOString()`.
  - **Wrong project paths**: Naive dash-decode turned `parth.dogra` → `parth/dogra` and `juspay-portal`
   → `juspay/portal`. Now reads the `cwd` field directly from JSONL entries as a reliable fallback.    
  - **Shift+Enter sends instead of newline**: Replaced single-line `Input` components with `<textarea>`
   in ChatView and the raw terminal input bar. Shift+Enter now inserts a newline; Enter sends.         
                                                                    
  ## Test plan                                                                                         
  - [ ] Save API key in `/config` → navigate to home → projects load without re-entering key
  - [ ] Project paths in terminal LaunchSheet show correct paths (e.g. `/Users/parth.dogra/...`)
  - [ ] Shift+Enter in chat input adds a new line, Enter sends                                         
  - [ ] Shift+Enter in raw terminal input adds a new line, Enter sends