### PR TITLE
fix(ci): add npm provenance for OIDC-based publishing

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -41,7 +41,8 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": true
+        "npmPublish": true,
+        "provenance": true
       }
     ],
     "@semantic-release/github",


### PR DESCRIPTION
## Summary

Adds `provenance: true` to `@semantic-release/npm` config. This enables OIDC token auth with npmjs.org — no `NPM_TOKEN` secret needed. Matches NeuroLink's working pattern exactly.

## Change

`.releaserc.json`: `npmPublish: true` → `npmPublish: true, provenance: true`

## Test plan

- [ ] Merge and verify release workflow succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to enable enhanced security measures for npm package distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->