### PR TITLE
fix(ci): use GITHUB_TOKEN + OIDC for npm publish, drop NPM_TOKEN requ…

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -41,7 +41,8 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": true
+        "npmPublish": true,
+        "provenance": true
       }
     ],
     "@semantic-release/github",


### PR DESCRIPTION
…irement

Aligned release workflow with NeuroLink's working pattern:
- Removed NPM_TOKEN secret dependency (was missing/expired, causing ENEEDAUTH)
- Added id-token: write permission for OIDC-based npm provenance
- Added npm upgrade step for OIDC support
- Use GITHUB_TOKEN only (auto-provided, no manual secret needed)
- Disabled git hooks during release commits (HUSKY=0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced npm package publishing configuration to enable provenance tracking, improving supply chain security and package authenticity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->