### PR TITLE
fix(ci): use npx semantic-release for v25 OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         run: pnpm run build
 
       - name: Release with semantic-release
-        run: pnpm exec semantic-release
+        run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: '0'


### PR DESCRIPTION
## Root cause

semantic-release v24.2.8 (pinned, run via `pnpm exec`) doesn't support OIDC tokens in `verifyConditions` — `npm whoami` fails with E401.

semantic-release v25.0.3 (what NeuroLink uses via `npx`) does support it.

## Fix

`pnpm exec semantic-release` → `npx semantic-release`

This matches NeuroLink's release.yml exactly. `npx` resolves to v25 which has OIDC support in the verify step.