### PR TITLE
fix(ci): pin npx semantic-release@25 for OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         run: pnpm run build
 
       - name: Release with semantic-release
-        run: npx semantic-release
+        run: npx semantic-release@25
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: '0'


### PR DESCRIPTION
npx was resolving to local v24.2.8 instead of v25. v24 fails npm whoami with E401 because it doesn't support OIDC in verifyConditions. Pinning to @25 explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use semantic-release version 25, ensuring consistent release automation behavior across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->