### PR TITLE
feat(cli): add daemon mode, auto-tunnel, and tunnel lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,17 +144,19 @@ The `shooter` CLI (via `bin/shooter.cjs`) supports the following commands:
 
 | Command           | Description                                        |
 | ----------------- | -------------------------------------------------- |
-| `start`           | Start the server (default if no command given)     |
-| `stop`            | Stop the running server (via PID file)             |
-| `status`          | Show server status, PID, port, autostart state     |
-| `autostart on`    | Enable autostart on login (LaunchAgent / systemd)  |
-| `autostart off`   | Disable autostart                                  |
+| `start`           | Start server + tunnel (foreground, default)         |
+| `start -d`        | Start in background (daemon mode)                   |
+| `start --no-tunnel` | Start without Cloudflare Tunnel                   |
+| `stop`            | Stop server and tunnel                              |
+| `status`          | Show server status, PID, port, tunnel URL           |
+| `autostart on`    | Enable autostart on login (LaunchAgent / systemd)   |
+| `autostart off`   | Disable autostart                                   |
 | `logs`            | Tail server logs (LaunchAgent log file or journalctl) |
 | `setup`           | Run the interactive setup wizard (`--auto` for non-interactive) |
-| `version`         | Show version number                                |
-| `help`            | Show help message                                  |
+| `version`         | Show version number                                 |
+| `help`            | Show help message                                   |
 
-PID file: `~/.shooter/shooter.pid`. Logs: `~/.shooter/logs/shooter.log`.
+PID file: `~/.shooter/shooter.pid`. Tunnel PID: `~/.shooter/tunnel.pid`. Logs: `~/.shooter/logs/shooter.log`. Tunnel logs: `~/.shooter/logs/tunnel.log`.
 
 ## Security Requirements
 

--- a/bin/shooter.cjs
+++ b/bin/shooter.cjs
@@ -103,6 +103,69 @@ switch (command) {
 
 // ── start ───────────────────────────────────────────────────────────
 
+function hasFlag(flag) {
+  return args.includes(flag);
+}
+
+function isCloudflaredAvailable() {
+  try {
+    execSync('which cloudflared', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function startTunnel(port) {
+  const tunnelLog = path.join(LOG_DIR, 'tunnel.log');
+  fs.mkdirSync(LOG_DIR, { recursive: true });
+
+  const cf = spawn('cloudflared', ['tunnel', '--url', `http://localhost:${port}`], {
+    cwd: PKG_ROOT,
+    detached: true,
+    stdio: ['ignore', fs.openSync(tunnelLog, 'w'), fs.openSync(tunnelLog, 'w')],
+  });
+
+  const tunnelPidFile = path.join(SHOOTER_HOME, 'tunnel.pid');
+  fs.writeFileSync(tunnelPidFile, String(cf.pid));
+  cf.unref();
+
+  // Poll for the tunnel URL (up to 15s)
+  const tunnelUrlFile = path.join(SHOOTER_HOME, '.tunnel_url');
+  let waited = 0;
+  const poll = setInterval(() => {
+    try {
+      const log = fs.readFileSync(tunnelLog, 'utf8');
+      const match = log.match(/https:\/\/[a-z0-9-]+\.trycloudflare\.com/);
+      if (match) {
+        clearInterval(poll);
+        fs.writeFileSync(tunnelUrlFile, match[0]);
+        console.log(`Tunnel active: ${match[0]}`);
+      }
+    } catch {}
+    waited += 1;
+    if (waited > 15) {
+      clearInterval(poll);
+      console.log('Tunnel is starting in the background. Check logs: ' + tunnelLog);
+    }
+  }, 1000);
+
+  return cf.pid;
+}
+
+function stopTunnel() {
+  const tunnelPidFile = path.join(SHOOTER_HOME, 'tunnel.pid');
+  const tunnelUrlFile = path.join(SHOOTER_HOME, '.tunnel_url');
+  try {
+    const pid = parseInt(fs.readFileSync(tunnelPidFile, 'utf8').trim(), 10);
+    if (!isNaN(pid)) {
+      try { process.kill(pid, 'SIGTERM'); } catch {}
+    }
+    try { fs.unlinkSync(tunnelPidFile); } catch {}
+    try { fs.unlinkSync(tunnelUrlFile); } catch {}
+  } catch {}
+}
+
 function startServer() {
   const serverEntry = path.join(PKG_ROOT, 'server.ts');
 
@@ -120,36 +183,109 @@ function startServer() {
     process.exit(0);
   }
 
-  const child = spawn(process.execPath, ['--import', 'tsx', serverEntry, ...args.slice(1)], {
-    cwd: PKG_ROOT,
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      SHOOTER_PKG_ROOT: PKG_ROOT,
-      SHOOTER_HOME,
-    },
-  });
+  const daemon = hasFlag('--daemon') || hasFlag('-d');
+  const noTunnel = hasFlag('--no-tunnel');
+  const port = resolvePort();
 
-  // Write PID file for status/stop commands
-  writePid(child.pid);
+  if (daemon) {
+    // ── Daemon mode: detach, redirect to log file ──
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+    const logFd = fs.openSync(LOG_FILE, 'a');
 
-  child.on('error', (err) => {
-    removePid();
-    console.error('Failed to start Shooter server:', err.message);
-    process.exit(1);
-  });
-
-  child.on('exit', (code, signal) => {
-    removePid();
-    if (signal) {
-      process.exit(128 + (signalCode(signal) || 1));
+    // Use tsx's register hook via --import so the child is the actual server process
+    // (not a wrapper that spawns another child)
+    const tsxLoader = path.join(PKG_ROOT, 'node_modules', 'tsx', 'dist', 'loader.mjs');
+    const tsxPreflight = path.join(PKG_ROOT, 'node_modules', 'tsx', 'dist', 'preflight.cjs');
+    const nodeArgs = [];
+    if (fs.existsSync(tsxPreflight)) {
+      nodeArgs.push('--require', tsxPreflight);
     }
-    process.exit(code ?? 1);
-  });
+    if (fs.existsSync(tsxLoader)) {
+      nodeArgs.push('--import', `file://${tsxLoader}`);
+    } else {
+      nodeArgs.push('--import', 'tsx');
+    }
+    nodeArgs.push(serverEntry);
 
-  // Forward signals to the child so graceful shutdown works
-  for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
-    process.on(sig, () => child.kill(sig));
+    const child = spawn(process.execPath, nodeArgs, {
+      cwd: PKG_ROOT,
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+      env: {
+        ...process.env,
+        SHOOTER_PKG_ROOT: PKG_ROOT,
+        SHOOTER_HOME,
+      },
+    });
+
+    writePid(child.pid);
+    child.unref();
+    fs.closeSync(logFd);
+
+    console.log(`Shooter started in background (PID ${child.pid}).`);
+    console.log(`  URL:   http://localhost:${port}`);
+    console.log(`  Logs:  ${LOG_FILE}`);
+
+    // Wait briefly for server to be ready before starting tunnel
+    if (!noTunnel && isCloudflaredAvailable()) {
+      setTimeout(() => {
+        startTunnel(port);
+      }, 3000);
+      // Keep process alive long enough for tunnel URL to appear
+      setTimeout(() => process.exit(0), 20000);
+    } else {
+      if (!noTunnel && !isCloudflaredAvailable()) {
+        console.log('  (cloudflared not found — no tunnel. Install: brew install cloudflared)');
+      }
+      process.exit(0);
+    }
+  } else {
+    // ── Foreground mode: inherit stdio ──
+    const child = spawn(process.execPath, ['--import', 'tsx', serverEntry], {
+      cwd: PKG_ROOT,
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        SHOOTER_PKG_ROOT: PKG_ROOT,
+        SHOOTER_HOME,
+      },
+    });
+
+    writePid(child.pid);
+
+    // Start tunnel in foreground mode too (unless --no-tunnel)
+    let tunnelStarted = false;
+    if (!noTunnel && isCloudflaredAvailable()) {
+      // Give server 3s to start before launching tunnel
+      setTimeout(() => {
+        startTunnel(port);
+        tunnelStarted = true;
+      }, 3000);
+    }
+
+    child.on('error', (err) => {
+      removePid();
+      if (tunnelStarted) stopTunnel();
+      console.error('Failed to start Shooter server:', err.message);
+      process.exit(1);
+    });
+
+    child.on('exit', (code, signal) => {
+      removePid();
+      stopTunnel();
+      if (signal) {
+        process.exit(128 + (signalCode(signal) || 1));
+      }
+      process.exit(code ?? 1);
+    });
+
+    // Forward signals to the child so graceful shutdown works
+    for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
+      process.on(sig, () => {
+        child.kill(sig);
+        stopTunnel();
+      });
+    }
   }
 }
 
@@ -158,11 +294,14 @@ function startServer() {
 function stopServer() {
   const pid = readPid();
   if (!pid) {
+    // Still try to stop tunnel even if server isn't running
+    stopTunnel();
     console.log('Shooter is not running.');
     process.exit(0);
   }
 
   console.log(`Stopping Shooter (PID ${pid})...`);
+  stopTunnel();
   try {
     process.kill(pid, 'SIGTERM');
     // Wait briefly for clean shutdown
@@ -208,11 +347,17 @@ function showStatus() {
   const pid = readPid();
   const port = resolvePort();
   const autostartEnabled = isAutostartInstalled();
+  const tunnelUrlFile = path.join(SHOOTER_HOME, '.tunnel_url');
+  let tunnelUrl = null;
+  try { tunnelUrl = fs.readFileSync(tunnelUrlFile, 'utf8').trim(); } catch {}
 
   if (pid) {
     console.log(`Shooter is running`);
     console.log(`  PID:        ${pid}`);
     console.log(`  URL:        http://localhost:${port}`);
+    if (tunnelUrl) {
+      console.log(`  Tunnel:     ${tunnelUrl}`);
+    }
     console.log(`  Autostart:  ${autostartEnabled ? 'enabled' : 'disabled'}`);
     console.log(`  Logs:       ${LOG_FILE}`);
     console.log(`  Home:       ${SHOOTER_HOME}`);
@@ -476,12 +621,12 @@ function showHelp() {
     `
 Shooter v${pkg.version}
 
-Usage: shooter [command]
+Usage: shooter [command] [options]
 
 Commands:
-  start            Start the server (default)
-  stop             Stop the running server
-  status           Show server status
+  start            Start the server (default, foreground)
+  stop             Stop the running server and tunnel
+  status           Show server status and tunnel URL
   autostart on     Start automatically on login (macOS/Linux)
   autostart off    Disable autostart
   logs             Tail server logs
@@ -489,9 +634,15 @@ Commands:
   version          Show version number
   help             Show this help message
 
+Start options:
+  -d, --daemon     Run in background (detach from terminal)
+  --no-tunnel      Don't start a Cloudflare Tunnel
+
 Examples:
-  shooter                  Start the server
-  shooter status           Check if server is running
+  shooter                  Start the server + tunnel (foreground)
+  shooter start -d         Start in background (daemon mode)
+  shooter start --no-tunnel  Start without Cloudflare Tunnel
+  shooter status           Check status and tunnel URL
   shooter autostart on     Enable autostart on login
   shooter logs             Follow server logs
   shooter setup            Configure credentials


### PR DESCRIPTION
## Summary

- `shooter start` now auto-starts a Cloudflare Tunnel when `cloudflared` is installed
- `shooter start -d` / `--daemon` runs the server in the background (detached, logs to `~/.shooter/logs/shooter.log`)
- `shooter start --no-tunnel` skips tunnel creation
- `shooter stop` kills both server and tunnel processes
- `shooter status` shows the tunnel URL when active
- Tunnel PID tracked in `~/.shooter/tunnel.pid` for clean lifecycle management

Fixes the complaints that:
1. Manual `shooter start` didn't create a tunnel
2. After reboot, autostart via LaunchAgent didn't recreate the tunnel
3. No daemon mode — `shooter start` blocked the terminal

## Files changed
- `bin/shooter.cjs` — daemon mode, tunnel lifecycle, updated help
- `CLAUDE.md` — updated CLI commands table

## Test plan
- [x] `shooter start -d --no-tunnel` — starts in background, returns immediately
- [x] `shooter start -d` — starts server + tunnel, captures URL
- [x] `shooter status` — shows PID, URL, tunnel URL
- [x] `shooter stop` — kills both server and tunnel, cleans PID files
- [x] `shooter help` — shows updated options
- [x] Build, lint (0 errors), typecheck (0 errors) all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Cloudflare Tunnel with `shooter` CLI: `start` command now establishes a public tunnel URL alongside the local server by default.
  * Added daemon mode option (`-d`/`--daemon`) to run the server in the background.
  * Added `--no-tunnel` flag to disable tunnel startup.

* **Bug Fixes**
  * `status` command now displays the tunnel URL for public access.
  * `stop` command now properly manages both server and tunnel shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->