### PR TITLE
fix: enable precompress to prevent .gz ENOENT crash

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,7 +4,7 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   kit: {
-    adapter: adapter(),
+    adapter: adapter({ precompress: true }),
     alias: {
       $generated: './src/generated',
     },


### PR DESCRIPTION
## Summary

- Fixes server crash: `ENOENT: no such file or directory, open '...nodes/0.J67pNAbN.js.gz'`
- Reported by Parth after running latest `install.sh`

## Root cause

`adapter-node` bundles `sirv` for static file serving. When a browser sends `Accept-Encoding: gzip`, sirv probes for `filename.gz`. Without `precompress: true`, no `.gz` files are generated during build, so sirv opens a non-existent file and the unhandled ReadStream error crashes the server.

## Fix

One-line change in `svelte.config.js`:
```js
adapter: adapter({ precompress: true })
```

This generates `.gz` and `.br` files during `pnpm build`, so sirv can serve them.

## Test plan
- [x] `pnpm build` generates `.gz` files (44 files confirmed)
- [x] Server starts without crash
- [x] Build, lint, typecheck all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized asset delivery by enabling precompression for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->