### PR TITLE
fix(ci): remove npm self-upgrade that breaks release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
## Summary

Removes `npm install -g npm@latest` from the release workflow. This line corrupts npm's dependency tree on GitHub Actions Node 22 runners, causing:

```
npm error Cannot find module 'promise-retry'
```

## Root cause

Node 22.22.2 on `ubuntu-latest` bundles npm 10.x. Running `npm install -g npm@latest` upgrades to npm 11.x which has a different dependency layout. The upgrade leaves stale references to `promise-retry` that break subsequent npm/pnpm operations.

## Why it's safe to remove

The comment said "for OIDC support" (npm provenance). Node 22's bundled npm already supports `--provenance` via OIDC. No upgrade needed.

## Test plan
- [x] Merge and verify release workflow runs successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release workflow configuration for improved build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->