### PR TITLE
feat(ci): add smoke-test job — start server and test 12 endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [release]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -60,3 +63,134 @@ jobs:
 
       - name: Verify package contents
         run: pnpm pack --dry-run
+
+  smoke-test:
+    runs-on: ubuntu-latest
+    env:
+      SMOKE_API_KEY: ci-test-key
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Start server
+        run: |
+          API_KEY="$SMOKE_API_KEY" node --import tsx server.ts &
+          echo $! > /tmp/shooter.pid
+
+      - name: Wait for server
+        run: |
+          for i in $(seq 1 30); do
+            if curl --connect-timeout 2 --max-time 5 -sf http://localhost:54007/api/health > /dev/null 2>&1; then
+              echo "Server ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start within 30s"
+          cat ~/.shooter/logs/shooter.log 2>/dev/null || true
+          exit 1
+
+      - name: 'Test: health endpoint'
+        run: |
+          HEALTH=$(curl --connect-timeout 5 --max-time 10 -sf http://localhost:54007/api/health)
+          echo "$HEALTH" | jq .
+          echo "$HEALTH" | jq -e '.status == "healthy"'
+
+      - name: 'Test: home page loads (static assets served)'
+        run: |
+          CODE=$(curl --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" http://localhost:54007/)
+          echo "Home page: HTTP $CODE"
+          test "$CODE" = "200"
+
+      - name: 'Test: gzip request does not crash server'
+        run: |
+          CODE=$(curl --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" -H "Accept-Encoding: gzip" http://localhost:54007/)
+          echo "Gzip request: HTTP $CODE"
+          test "$CODE" = "200"
+          # Verify server is still alive after gzip request
+          curl --connect-timeout 5 --max-time 10 -sf http://localhost:54007/api/health | jq -e '.status == "healthy"'
+
+      - name: 'Test: auth enforcement (401 without key)'
+        run: |
+          CODE=$(curl --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" http://localhost:54007/api/sessions)
+          echo "No auth: HTTP $CODE"
+          test "$CODE" = "401"
+
+      - name: 'Test: auth enforcement (401 with wrong key)'
+        run: |
+          CODE=$(curl --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer wrong" http://localhost:54007/api/sessions)
+          echo "Wrong key: HTTP $CODE"
+          test "$CODE" = "401"
+
+      - name: 'Test: sessions endpoint with auth'
+        run: |
+          RESP=$(curl --connect-timeout 5 --max-time 10 -sf -H "Authorization: Bearer $SMOKE_API_KEY" http://localhost:54007/api/sessions)
+          echo "$RESP" | jq .
+          echo "$RESP" | jq -e '.projects | type == "array"'
+
+      - name: 'Test: terminals endpoint with auth'
+        run: |
+          RESP=$(curl --connect-timeout 5 --max-time 10 -sf -H "Authorization: Bearer $SMOKE_API_KEY" http://localhost:54007/api/terminals)
+          echo "$RESP" | jq -e '.terminals | type == "array"'
+
+      - name: 'Test: connect endpoint validates input (400 + error message)'
+        run: |
+          RESP=$(curl --connect-timeout 5 --max-time 10 -s -w '\n%{http_code}' -X POST -H "Authorization: Bearer $SMOKE_API_KEY" -H "Content-Type: application/json" -d '{}' http://localhost:54007/api/sessions/connect)
+          BODY=$(echo "$RESP" | sed '$d')
+          CODE=$(echo "$RESP" | tail -n1)
+          echo "Connect validation: HTTP $CODE"
+          test "$CODE" = "400"
+          echo "$BODY" | jq -e '.error | contains("sessionId")'
+
+      - name: 'Test: terminals endpoint validates input (400 + error message)'
+        run: |
+          RESP=$(curl --connect-timeout 5 --max-time 10 -s -w '\n%{http_code}' -X POST -H "Authorization: Bearer $SMOKE_API_KEY" -H "Content-Type: application/json" -d '{}' http://localhost:54007/api/terminals)
+          BODY=$(echo "$RESP" | sed '$d')
+          CODE=$(echo "$RESP" | tail -n1)
+          echo "Terminals validation: HTTP $CODE"
+          test "$CODE" = "400"
+          echo "$BODY" | jq -e '.error | contains("command")'
+
+      - name: 'Test: limit/offset clamping (NaN does not crash)'
+        run: |
+          RESP=$(curl --connect-timeout 5 --max-time 10 -sf -H "Authorization: Bearer $SMOKE_API_KEY" "http://localhost:54007/api/sessions?limit=abc&offset=-5")
+          echo "$RESP" | jq -e '.projects | type == "array"'
+
+      - name: 'Test: UI pages load'
+        run: |
+          for PAGE in / /terminals /config; do
+            CODE=$(curl --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" "http://localhost:54007${PAGE}")
+            echo "Page $PAGE: HTTP $CODE"
+            test "$CODE" = "200"
+          done
+
+      - name: 'Test: error page renders for unknown routes'
+        run: |
+          CODE=$(curl --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" http://localhost:54007/nonexistent)
+          echo "Unknown route: HTTP $CODE"
+          test "$CODE" = "404"
+          # Verify response body contains error content
+          BODY=$(curl --connect-timeout 5 --max-time 10 -s http://localhost:54007/nonexistent)
+          echo "$BODY" | grep -qi "not found\|error\|404"
+
+      - name: Stop server
+        if: always()
+        run: |
+          if [ -f /tmp/shooter.pid ]; then
+            kill "$(cat /tmp/shooter.pid)" 2>/dev/null || true
+          fi


### PR DESCRIPTION
## Summary

Adds a **smoke-test** job to CI that builds, starts the actual server, and runs 12 tests against it. This catches runtime crashes that build/lint/typecheck miss.

## What it tests

| # | Test | What it catches |
|---|------|----------------|
| 1 | Health endpoint | Server boots, binds port |
| 2 | Home page (HTTP 200) | Static assets served correctly |
| 3 | Gzip request + health after | **.gz ENOENT crash** (the bug that hit Parth) |
| 4 | 401 without auth | Auth middleware works |
| 5 | 401 with wrong key | Auth rejects bad keys |
| 6 | Sessions with auth | API returns valid JSON |
| 7 | Terminals with auth | API returns valid JSON |
| 8 | Connect input validation | Missing fields return error |
| 9 | Terminals input validation | Missing fields return error |
| 10 | NaN limit/offset | Clamping doesn't crash |
| 11 | UI pages load | /, /terminals, /config all 200 |
| 12 | Error page renders | Unknown routes don't crash |

## Why

The `.gz` ENOENT crash (#45) was never caught because:
- `pnpm build` only checks compilation
- `pnpm lint` / `pnpm run check` only check code quality/types
- No CI job ever started the server or made a browser-like request

Test #3 (`Accept-Encoding: gzip`) would have caught it.

## Test plan
- [ ] CI smoke-test job passes on this PR
- [ ] Verify all 12 test steps show green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added automated smoke test job to the CI/CD pipeline that validates server health, verifies API endpoint responses across core routes, enforces authentication on protected endpoints, checks error handling for invalid requests, and ensures proper HTTP status codes are returned during each build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->