### PR TITLE
fix: session discovery fallback, dashboard UI, and message dedup

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -585,24 +585,44 @@ body {
    ============================================ */
 
 .session-card {
-  background: var(--bg-secondary, #141414);
-  border: 1px solid var(--border, #2a2a2a);
-  border-radius: var(--radius-lg, 12px);
-  padding: var(--space-4, 1rem) var(--space-5, 1.25rem);
+  background: linear-gradient(135deg, rgba(20, 20, 20, 0.9) 0%, rgba(28, 28, 32, 0.9) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg, 14px);
+  padding: var(--space-5, 1.25rem) var(--space-5, 1.25rem);
   cursor: pointer;
-  transition:
-    border-color var(--transition-fast, 150ms),
-    background var(--transition-fast, 150ms);
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   flex-direction: column;
   overflow: hidden;
   min-width: 0;
   gap: var(--space-3, 0.75rem);
+  position: relative;
+  text-decoration: none;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+}
+
+.session-card::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: linear-gradient(180deg, #22c55e 0%, #16a34a 100%);
+  border-radius: 3px 0 0 3px;
+  opacity: 0.7;
+  transition: opacity 0.25s;
 }
 
 .session-card:hover {
-  border-color: var(--gray-600, #525252);
-  background: var(--bg-tertiary, #1a1a1a);
+  border-color: rgba(34, 197, 94, 0.3);
+  background: linear-gradient(135deg, rgba(25, 25, 28, 0.95) 0%, rgba(32, 32, 38, 0.95) 100%);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(34, 197, 94, 0.15) inset;
+}
+
+.session-card:hover::before {
+  opacity: 1;
 }
 
 .session-card-header {
@@ -620,20 +640,21 @@ body {
 }
 
 .session-card-title {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text-primary, #fafafa);
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #f0f0f0;
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  letter-spacing: -0.01em;
 }
 
 .session-card-subtitle {
-  font-size: 0.8rem;
-  color: var(--text-tertiary, #737373);
+  font-size: 0.78rem;
+  color: rgba(163, 163, 163, 0.7);
   font-family: var(--font-mono, monospace);
-  margin-top: 2px;
+  margin-top: 4px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -645,13 +666,15 @@ body {
 .session-stats {
   display: flex;
   gap: var(--space-4, 1rem);
-  font-size: 0.8rem;
+  font-size: 0.82rem;
   color: var(--text-secondary, #a3a3a3);
+  align-items: center;
 }
 
 .session-stats strong {
-  color: var(--text-primary, #fafafa);
-  font-weight: 600;
+  color: #22c55e;
+  font-weight: 700;
+  font-size: 0.95rem;
 }
 
 .session-tools {

--- a/src/lib/modules/server/sessions/jsonl-reader.ts
+++ b/src/lib/modules/server/sessions/jsonl-reader.ts
@@ -103,16 +103,29 @@ export function getSessionConversation(
       }
     }
 
+    // Deduplicate messages by ID — JSONL files can contain duplicate entries
+    // (e.g., from compaction or streaming). Keep the last occurrence since it
+    // has the most complete content.
+    const seenIds = new Set<string>();
+    const deduped: ConversationMessage[] = [];
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (!seenIds.has(messages[i].id)) {
+        seenIds.add(messages[i].id);
+        deduped.push(messages[i]);
+      }
+    }
+    deduped.reverse();
+
     // If no explicit offset, return the LAST `limit` messages (most recent conversation)
-    if (offset === 0 && messages.length > limit) {
-      let startIdx = messages.length - limit;
+    if (offset === 0 && deduped.length > limit) {
+      let startIdx = deduped.length - limit;
       // Adjust to start at a 'user' message boundary so we don't clip mid-turn
-      while (startIdx > 0 && startIdx < messages.length && messages[startIdx].role !== 'user') {
+      while (startIdx > 0 && startIdx < deduped.length && deduped[startIdx].role !== 'user') {
         startIdx--;
       }
-      return messages.slice(startIdx);
+      return deduped.slice(startIdx);
     }
-    return messages.slice(offset, offset + limit);
+    return deduped.slice(offset, offset + limit);
   } catch (error) {
     console.error('[sessions] Failed to parse session JSONL:', error);
     return [];
@@ -225,37 +238,39 @@ function getProjectDir(): string {
 
 function listSessionsForProject(projectDir: string): SessionInfo[] {
   const indexPath = path.join(projectDir, 'sessions-index.json');
+  const hasIndex = fs.existsSync(indexPath);
 
-  if (!fs.existsSync(indexPath)) {
-    return [];
-  }
+  const indexedIds = new Set<string>();
+  const sessions: SessionInfo[] = [];
 
-  try {
-    const raw = fs.readFileSync(indexPath, 'utf-8');
-    const index = JSON.parse(raw) as {
-      entries: {
-        created?: string;
-        firstPrompt?: string;
-        gitBranch?: string;
-        isSidechain?: boolean;
-        messageCount?: number;
-        modified?: string;
-        projectPath?: string;
-        sessionId: string;
-        summary?: string;
-      }[];
-    };
+  // Phase 1: Read from sessions-index.json if it exists
+  if (hasIndex) {
+    try {
+      const raw = fs.readFileSync(indexPath, 'utf-8');
+      const index = JSON.parse(raw) as {
+        entries: {
+          created?: string;
+          firstPrompt?: string;
+          gitBranch?: string;
+          isSidechain?: boolean;
+          messageCount?: number;
+          modified?: string;
+          projectPath?: string;
+          sessionId: string;
+          summary?: string;
+        }[];
+      };
 
-    const indexedIds = new Set<string>();
-    const sessions: SessionInfo[] = index.entries
-      .filter((e) => !e.isSidechain)
-      .filter((e) => {
-        const jsonlFile = path.join(projectDir, `${e.sessionId}.jsonl`);
-        return fs.existsSync(jsonlFile);
-      })
-      .map((entry) => {
+      for (const entry of index.entries) {
+        if (entry.isSidechain) {
+          continue;
+        }
+        const jsonlFile = path.join(projectDir, `${entry.sessionId}.jsonl`);
+        if (!fs.existsSync(jsonlFile)) {
+          continue;
+        }
         indexedIds.add(entry.sessionId);
-        return {
+        sessions.push({
           created: entry.created || '',
           gitBranch: entry.gitBranch || '',
           id: entry.sessionId,
@@ -265,72 +280,68 @@ function listSessionsForProject(projectDir: string): SessionInfo[] {
           source: 'claude-code' as const,
           summary: entry.summary || '',
           title: cleanTitle(entry.firstPrompt || entry.summary || 'Untitled Session'),
-        };
-      });
-
-    // Also scan for JSONL files not in the index (e.g., active sessions)
-    try {
-      const files = fs.readdirSync(projectDir);
-      for (const file of files) {
-        if (!file.endsWith('.jsonl')) {
-          continue;
-        }
-        const sessionId = file.replace('.jsonl', '');
-        if (indexedIds.has(sessionId)) {
-          continue;
-        }
-        // Read first user message as title
-        const filePath = path.join(projectDir, file);
-        const stat = fs.statSync(filePath);
-        let firstPrompt = 'Active Session';
-        let messageCount = 0;
-        try {
-          const content = fs.readFileSync(filePath, 'utf-8');
-          // Count user + assistant messages by searching each line for the type field.
-          // The type field may appear anywhere on the line (after parentUuid, isSidechain, etc.)
-          // so a prefix-only check is not reliable with the current JSONL format.
-          let countPos = 0;
-          while (countPos < content.length) {
-            const nl = content.indexOf('\n', countPos);
-            const lineEnd = nl === -1 ? content.length : nl;
-            const line = content.substring(countPos, lineEnd);
-            if (line.includes('"type":"user"') || line.includes('"type":"assistant"')) {
-              messageCount++;
-            }
-            if (nl === -1) {
-              break;
-            }
-            countPos = nl + 1;
-          }
-          const prompt = findFirstUserPrompt(content);
-          if (prompt) {
-            firstPrompt = prompt;
-          }
-        } catch {
-          // ignore read errors
-        }
-
-        sessions.push({
-          created: stat.birthtime.toISOString(),
-          gitBranch: '',
-          id: sessionId,
-          messageCount,
-          modified: stat.mtime.toISOString(),
-          projectPath: '',
-          source: 'claude-code' as const,
-          summary: '',
-          title: cleanTitle(firstPrompt),
         });
       }
-    } catch {
-      // ignore scan errors
+    } catch (error) {
+      console.error('[sessions] Failed to read sessions index:', error);
     }
-
-    return sessions.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
-  } catch (error) {
-    console.error('[sessions] Failed to read sessions index:', error);
-    return [];
   }
+
+  // Phase 2: Scan for JSONL files not in the index (or all files when no index exists)
+  try {
+    const files = fs.readdirSync(projectDir);
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) {
+        continue;
+      }
+      const sessionId = file.replace('.jsonl', '');
+      if (indexedIds.has(sessionId)) {
+        continue;
+      }
+      const filePath = path.join(projectDir, file);
+      const stat = fs.statSync(filePath);
+      let firstPrompt = 'Active Session';
+      let messageCount = 0;
+      try {
+        const content = fs.readFileSync(filePath, 'utf-8');
+        let countPos = 0;
+        while (countPos < content.length) {
+          const nl = content.indexOf('\n', countPos);
+          const lineEnd = nl === -1 ? content.length : nl;
+          const line = content.substring(countPos, lineEnd);
+          if (line.includes('"type":"user"') || line.includes('"type":"assistant"')) {
+            messageCount++;
+          }
+          if (nl === -1) {
+            break;
+          }
+          countPos = nl + 1;
+        }
+        const prompt = findFirstUserPrompt(content);
+        if (prompt) {
+          firstPrompt = prompt;
+        }
+      } catch {
+        // ignore read errors
+      }
+
+      sessions.push({
+        created: stat.birthtime.toISOString(),
+        gitBranch: '',
+        id: sessionId,
+        messageCount,
+        modified: stat.mtime.toISOString(),
+        projectPath: '',
+        source: 'claude-code' as const,
+        summary: '',
+        title: cleanTitle(firstPrompt),
+      });
+    }
+  } catch {
+    // ignore scan errors
+  }
+
+  return sessions.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
 }
 
 function readCwdFromProjectDir(projectDir: string, sessions: SessionInfo[]): string {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -163,6 +163,24 @@
         </Button>
       </div>
     </div>
+    {#if projects.length > 0}
+      <div class="stats-bar">
+        <div class="stat-chip">
+          <span class="stat-value">{projects.length}</span>
+          <span class="stat-label">{projects.length === 1 ? 'project' : 'projects'}</span>
+        </div>
+        <div class="stat-chip">
+          <span class="stat-value">{totalSessionCount()}</span>
+          <span class="stat-label">{totalSessionCount() === 1 ? 'session' : 'sessions'}</span>
+        </div>
+        {#if cards.length > 0}
+          <div class="stat-chip stat-chip-active">
+            <span class="stat-value">{cards.length}</span>
+            <span class="stat-label">active</span>
+          </div>
+        {/if}
+      </div>
+    {/if}
   </div>
 
   {#if fetchError}
@@ -258,7 +276,7 @@
 
   .page-title {
     font-size: var(--text-2xl);
-    font-weight: 600;
+    font-weight: 700;
     letter-spacing: -0.03em;
     color: var(--text-primary);
     margin-bottom: var(--space-1);
@@ -273,6 +291,42 @@
     display: flex;
     gap: var(--space-2);
     flex-shrink: 0;
+  }
+
+  .stats-bar {
+    display: flex;
+    gap: 10px;
+    margin-top: var(--space-4);
+  }
+
+  .stat-chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 20px;
+    padding: 6px 14px;
+  }
+
+  .stat-chip-active {
+    background: rgba(34, 197, 94, 0.1);
+    border-color: rgba(34, 197, 94, 0.25);
+  }
+
+  .stat-value {
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: #f0f0f0;
+  }
+
+  .stat-chip-active .stat-value {
+    color: #22c55e;
+  }
+
+  .stat-label {
+    font-size: 0.78rem;
+    color: rgba(163, 163, 163, 0.8);
   }
 
   .dashboard-section {
@@ -291,7 +345,7 @@
   .projects-container {
     display: flex;
     flex-direction: column;
-    gap: var(--space-4);
+    gap: var(--space-3);
     animation: fadeIn 0.2s ease;
   }
 
@@ -299,6 +353,10 @@
     .page-header-content {
       flex-direction: column;
       gap: var(--space-4);
+    }
+
+    .stats-bar {
+      flex-wrap: wrap;
     }
   }
 


### PR DESCRIPTION
## Summary

Three fixes in one PR:

### 1. Discover sessions when `sessions-index.json` is missing
- `listSessionsForProject()` returned `[]` when `sessions-index.json` was absent
- Older Claude Code versions don't generate this index file — only raw `.jsonl` files exist
- Restructured into two phases: read index if exists, then scan for `.jsonl` files not covered by the index
- Both phases always run, so sessions are discovered regardless of index presence

### 2. Dashboard UI improvements
- Session cards with gradient backgrounds, green left accent bar, lift-on-hover with glow
- Bolder project names, muted path text, green session count for visual hierarchy
- Stats bar with pill-shaped chips showing project/session/active counts

### 3. Deduplicate session messages
- JSONL files can contain duplicate entries (from compaction or streaming)
- Duplicate message IDs caused Svelte's keyed `{#each}` to crash with `each_key_duplicate` error
- Session detail pages were stuck on infinite loading
- Added deduplication pass that keeps the last occurrence of each message ID

## Test plan
- [x] Removed all `sessions-index.json` files — all 20 sessions across 6 projects discovered via JSONL scan
- [x] With index files present — no regression, indexed sessions used, scan picks up extras
- [x] Dashboard cards render with new styling
- [x] Session detail page loads without `each_key_duplicate` crash (verified 0 duplicate IDs in API response)
- [x] Tested on both desktop browser and mobile via Cloudflare tunnel