### PR TITLE
fix: decode hyphenated project paths, wire FCM end-to-end, and harden android

### DIFF
--- a/android/app/src/main/kotlin/com/shooter/android/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/shooter/android/MainActivity.kt
@@ -45,10 +45,15 @@ class MainActivity : AppCompatActivity() {
         setupWebView()
         loadDashboard(intent)
 
-        // Proactively fetch and cache FCM token on startup
+        // Proactively fetch the FCM token on every launch and re-register it
+        // with the server. onNewToken() in ShooterFirebaseService only fires
+        // when the token changes (first install, rotation), so if the API key
+        // wasn't set at that moment the token would otherwise never reach the
+        // server. Re-POSTing on every launch is idempotent on the server side.
         FirebaseMessaging.getInstance().token
             .addOnSuccessListener { token ->
                 AppPreferences(this).fcmToken = token
+                ShooterFirebaseService.registerTokenWithServer(this, token)
             }
 
         // Pre-download scanner module so first scan is instant
@@ -126,6 +131,15 @@ class MainActivity : AppCompatActivity() {
         swipeRefresh.setOnRefreshListener {
             webView.reload()
         }
+
+        // Disable pull-to-refresh entirely. Shooter's mobile layout uses a
+        // fixed header + bottom nav, so the actual list scrolls inside an
+        // internal container — webView.scrollY is always 0. That makes it
+        // impossible for SwipeRefreshLayout to distinguish "user wants to
+        // refresh" from "user wants to scroll up through the list", and it
+        // intercepts every upward swipe. The Refresh button in the app header
+        // covers the refresh UX.
+        swipeRefresh.isEnabled = false
     }
 
     private fun loadDashboard(intent: Intent) {
@@ -279,6 +293,14 @@ class MainActivity : AppCompatActivity() {
                 if (obj.has("serverUrl")) prefs.serverUrl = obj.getString("serverUrl")
                 if (obj.has("apiKey")) prefs.apiKey = obj.getString("apiKey")
                 android.util.Log.d(TAG, "ShooterBridge.saveConfig: saved successfully")
+
+                // The API key may have just been entered for the first time.
+                // Re-POST the cached FCM token so the server can push to this
+                // device (onNewToken fired earlier when no key was set).
+                val cachedToken = prefs.fcmToken
+                if (!cachedToken.isNullOrBlank()) {
+                    ShooterFirebaseService.registerTokenWithServer(this@MainActivity, cachedToken)
+                }
             } catch (e: Exception) {
                 android.util.Log.e(TAG, "ShooterBridge.saveConfig failed", e)
             }

--- a/android/app/src/main/kotlin/com/shooter/android/ShooterFirebaseService.kt
+++ b/android/app/src/main/kotlin/com/shooter/android/ShooterFirebaseService.kt
@@ -1,5 +1,7 @@
 package com.shooter.android
 
+import android.content.Context
+import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import okhttp3.Call
@@ -15,44 +17,62 @@ import java.util.concurrent.TimeUnit
 
 class ShooterFirebaseService : FirebaseMessagingService() {
 
-    private val client = OkHttpClient.Builder()
-        .connectTimeout(10, TimeUnit.SECONDS)
-        .readTimeout(10, TimeUnit.SECONDS)
-        .build()
-
     override fun onNewToken(token: String) {
         val prefs = AppPreferences(this)
         prefs.fcmToken = token
-        registerTokenWithServer(prefs, token)
+        registerTokenWithServer(this, token)
     }
 
-    private fun registerTokenWithServer(prefs: AppPreferences, token: String) {
-        val serverUrl = prefs.serverUrl?.trimEnd('/') ?: return
-        val apiKey = prefs.apiKey ?: return
+    companion object {
+        private const val TAG = "ShooterFCM"
 
-        val json = JSONObject().apply {
-            put("token", token)
-            put("platform", "android")
-        }
-
-        val body = json.toString()
-            .toRequestBody("application/json; charset=utf-8".toMediaType())
-
-        val request = Request.Builder()
-            .url("$serverUrl/api/device-token")
-            .header("Authorization", "Bearer $apiKey")
-            .post(body)
+        private val client = OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
             .build()
 
-        client.newCall(request).enqueue(object : Callback {
-            override fun onFailure(call: Call, e: IOException) {
-                // Token will be re-sent on next refresh or app startup
+        /**
+         * POST the FCM token to /api/device-token so the server can push to this
+         * device. Safe to call from any thread. Returns silently if server URL or
+         * API key is not yet configured — callers should re-invoke whenever those
+         * change.
+         */
+        fun registerTokenWithServer(context: Context, token: String) {
+            val prefs = AppPreferences(context)
+            val serverUrl = prefs.serverUrl?.trimEnd('/')
+            val apiKey = prefs.apiKey
+            if (serverUrl.isNullOrBlank() || apiKey.isNullOrBlank()) {
+                Log.d(TAG, "registerTokenWithServer: skipping — url=${!serverUrl.isNullOrBlank()} key=${!apiKey.isNullOrBlank()}")
+                return
             }
 
-            override fun onResponse(call: Call, response: Response) {
-                response.close()
+            val json = JSONObject().apply {
+                put("token", token)
+                put("platform", "android")
             }
-        })
+
+            val body = json.toString()
+                .toRequestBody("application/json; charset=utf-8".toMediaType())
+
+            val request = Request.Builder()
+                .url("$serverUrl/api/device-token")
+                .header("Authorization", "Bearer $apiKey")
+                .post(body)
+                .build()
+
+            // Do not log token material — even a prefix is a stable device identifier.
+            Log.d(TAG, "POST $serverUrl/api/device-token (tokenLength=${token.length})")
+            client.newCall(request).enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    Log.w(TAG, "device-token POST failed: ${e.message}")
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    Log.d(TAG, "device-token POST → HTTP ${response.code}")
+                    response.close()
+                }
+            })
+        }
     }
 
     override fun onMessageReceived(message: RemoteMessage) {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-org.gradle.java.home=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
 org.gradle.parallel=true
 org.gradle.caching=true
 android.useAndroidX=true

--- a/src/lib/modules/server/sessions/jsonl-reader.ts
+++ b/src/lib/modules/server/sessions/jsonl-reader.ts
@@ -152,11 +152,13 @@ export function listProjectsWithSessions(): ProjectGroup[] {
     // Sort sessions by modified desc
     sessions.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
 
-    // Prefer projectPath from session index, then cwd from JSONL, then decoded dir name
+    // Prefer projectPath from session index, then cwd from JSONL, then
+    // filesystem-validated decoder, then last-resort naive decoding.
     const realPath =
       sessions.find((s) => s.projectPath && !s.projectPath.includes('.claude/projects'))
         ?.projectPath ||
       readCwdFromProjectDir(projectDir, sessions) ||
+      decodeClaudeProjectDir(dir) ||
       (dir.startsWith('-') ? dir.replace(/-/g, '/') : `/${dir.replace(/-/g, '/')}`);
     const pathSegments = realPath.split('/').filter(Boolean);
     const projectName = pathSegments.slice(-2).join('/');
@@ -179,6 +181,10 @@ export function listProjectsWithSessions(): ProjectGroup[] {
 export function listSessions(): SessionInfo[] {
   const projectDir = getProjectDir();
   return listSessionsForProject(projectDir);
+}
+
+function bytesReadEnded(chunk: string): boolean {
+  return chunk.length > 0 && chunk.charCodeAt(chunk.length - 1) === 10;
 }
 
 function cleanTitle(prompt: string): string {
@@ -214,6 +220,52 @@ function cleanTitle(prompt: string): string {
     return `${firstLine.slice(0, 77)}...`;
   }
   return firstLine;
+}
+
+/**
+ * Decode a Claude Code project directory name like "-home-parth-dogra-Desktop-Repo-pr-guardian"
+ * into the real filesystem path "/home/parth-dogra/Desktop/Repo/pr-guardian".
+ *
+ * Claude Code encodes paths by replacing "/" with "-", which is ambiguous when
+ * the original path contains hyphens (e.g. "parth-dogra", "pr-guardian"). This
+ * walks the filesystem from / and greedily matches the longest hyphen-joined
+ * segment that exists as a directory at each step.
+ *
+ * Returns null if no valid decoding exists on this filesystem.
+ */
+function decodeClaudeProjectDir(encoded: string): null | string {
+  if (!encoded.startsWith('-')) {
+    return null;
+  }
+  const parts = encoded.slice(1).split('-');
+  if (parts.length === 0) {
+    return null;
+  }
+
+  let currentPath = '/';
+  let i = 0;
+  while (i < parts.length) {
+    let matchedTo = -1;
+    // Try the longest possible segment first (greedy longest match)
+    for (let j = parts.length; j > i; j--) {
+      const segment = parts.slice(i, j).join('-');
+      const candidate = path.join(currentPath, segment);
+      try {
+        if (fs.statSync(candidate).isDirectory()) {
+          matchedTo = j;
+          break;
+        }
+      } catch {
+        // not a directory / doesn't exist — try a shorter segment
+      }
+    }
+    if (matchedTo === -1) {
+      return null;
+    }
+    currentPath = path.join(currentPath, parts.slice(i, matchedTo).join('-'));
+    i = matchedTo;
+  }
+  return currentPath;
 }
 
 function getProjectDir(): string {
@@ -334,33 +386,40 @@ function listSessionsForProject(projectDir: string): SessionInfo[] {
 }
 
 function readCwdFromProjectDir(projectDir: string, sessions: SessionInfo[]): string {
+  // Scan complete JSONL lines until we find one with cwd. Newer Claude Code
+  // versions write metadata lines (permission-mode, file-history-snapshot)
+  // first, so cwd only appears on line 2+.
+  const READ_BYTES = 65536;
   for (const session of sessions) {
     try {
       const filePath = path.join(projectDir, `${session.id}.jsonl`);
       if (!fs.existsSync(filePath)) {
         continue;
       }
-      // Only read the first 4KB — cwd appears on line 1
       const fd = fs.openSync(filePath, 'r');
-      let firstChunk: string;
+      let chunk: string;
       try {
-        const buf = Buffer.alloc(4096);
-        const bytesRead = fs.readSync(fd, buf, 0, 4096, 0);
-        firstChunk = buf.toString('utf-8', 0, bytesRead);
+        const buf = Buffer.alloc(READ_BYTES);
+        const bytesRead = fs.readSync(fd, buf, 0, READ_BYTES, 0);
+        chunk = buf.toString('utf-8', 0, bytesRead);
       } finally {
         fs.closeSync(fd);
       }
-      const firstLine = firstChunk.split('\n')[0];
-      if (!firstLine.trim()) {
-        continue;
-      }
-      try {
-        const entry = JSON.parse(firstLine) as Record<string, unknown>;
-        if (typeof entry.cwd === 'string' && entry.cwd) {
-          return entry.cwd;
+      const lines = chunk.split('\n');
+      // Drop the last line if the chunk was truncated mid-line
+      const completeLines = bytesReadEnded(chunk) ? lines : lines.slice(0, -1);
+      for (const line of completeLines) {
+        if (!line.trim()) {
+          continue;
         }
-      } catch {
-        // skip malformed first line
+        try {
+          const entry = JSON.parse(line) as Record<string, unknown>;
+          if (typeof entry.cwd === 'string' && entry.cwd) {
+            return entry.cwd;
+          }
+        } catch {
+          // skip malformed line and try the next one
+        }
       }
     } catch {
       // skip unreadable files

--- a/src/routes/api/notify/+server.ts
+++ b/src/routes/api/notify/+server.ts
@@ -9,8 +9,30 @@ import { isFCMConfigured, sendFCMNotification } from '$lib/modules/server/fcm/fc
 import { toErrorMessage } from '$lib/modules/server/utils/error';
 import { broadcastEvent } from '$lib/modules/server/ws/server';
 import { json } from '@sveltejs/kit';
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
 
 import type { RequestHandler } from './$types';
+
+// Reads tokens persisted by /api/device-token — populated automatically when
+// the Android or iOS app registers on first launch.
+function readPersistedDeviceToken(platform: 'android' | 'ios'): string | undefined {
+  const tokensFile = join(homedir(), '.shooter', 'device-tokens.json');
+  if (!existsSync(tokensFile)) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(tokensFile, 'utf-8'));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const value = (parsed as Record<string, unknown>)[platform];
+      return typeof value === 'string' && value ? value : undefined;
+    }
+  } catch {
+    // corrupt / unreadable — fall through
+  }
+  return undefined;
+}
 
 // Singleton APNs client - reuses HTTP/2 connection across requests
 let apnsSingleton: LibraryAPNsService | null = null;
@@ -376,15 +398,21 @@ export const POST: RequestHandler = async ({ request }) => {
         );
       }
 
-      // Honor request-scoped deviceToken, falling back to environment variables.
+      // Honor request-scoped deviceToken, then the Android-specific env var,
+      // then the token auto-registered by the Android app via /api/device-token.
+      // env.DEVICE_TOKEN is intentionally NOT in this chain: the iOS branch
+      // treats it as an APNs token (see below), and letting it bleed into the
+      // FCM path would ship an APNs token to FCM in mixed-platform setups.
       const androidToken =
-        requestDeviceToken?.trim() || (env.ANDROID_DEVICE_TOKEN || env.DEVICE_TOKEN)?.trim();
+        requestDeviceToken?.trim() ||
+        env.ANDROID_DEVICE_TOKEN?.trim() ||
+        readPersistedDeviceToken('android');
 
       if (!androidToken) {
         return json(
           {
             details:
-              'ANDROID_DEVICE_TOKEN or DEVICE_TOKEN environment variable is missing and no deviceToken in request body',
+              'No Android device token available — set ANDROID_DEVICE_TOKEN, pass deviceToken in the request body, or open the Android app so it can auto-register its FCM token.',
             error: 'No device token configured',
           },
           { status: 500 }


### PR DESCRIPTION
## Summary

Three independent bug fixes needed to make the mobile push-notification flow work end-to-end on a fresh install. Each is small and targeted; together they turn a setup that **cannot deliver any push notifications** into one that works out of the box.

- **Hyphenated project paths decode correctly** — directories like `/home/parth-dogra/Desktop/Repo/pr-guardian` no longer get mangled to `/home/parth/dogra/Desktop/Repo/pr/guardian` on the projects list
- **FCM pushes use the auto-registered Android token** — `/api/notify` now falls back to the token that `/api/device-token` persists, so pushes work without anyone setting `ANDROID_DEVICE_TOKEN` manually
- **Android app usability fixes** — pull-to-refresh no longer eats every upward scroll; FCM token registration recovers when the API key is entered after first launch; builds no longer require a macOS-specific JDK path

## Changes

### `src/lib/modules/server/sessions/jsonl-reader.ts`
- `readCwdFromProjectDir` previously read only the first line of the JSONL. Newer Claude Code versions write metadata (`permission-mode`, `file-history-snapshot`) on lines 0–1 with no `cwd` field, so the function always returned empty and callers fell through to a naive `dir.replace(/-/g, '/')` that mangled any path with hyphens. Now scans up to 64 KB and iterates all complete lines.
- Adds `decodeClaudeProjectDir(encoded)` — a filesystem-validated fallback that walks `/` and greedy-longest-matches each hyphen-joined segment against directories that actually exist. Resolves the inherent ambiguity of the `-` encoding.

### `src/routes/api/notify/+server.ts`
- `/api/device-token` writes tokens to `~/.shooter/device-tokens.json`, but `/api/notify` only read env vars (`ANDROID_DEVICE_TOKEN`, `DEVICE_TOKEN`) or the request body. After an Android app registers its token via the intended flow, pushes still failed with "No device token configured". Adds `readPersistedDeviceToken('android')` as the final fallback, matching the contract of `/api/device-token`.

### `android/app/src/main/kotlin/com/shooter/android/MainActivity.kt`
- **Disable `SwipeRefreshLayout`**. The mobile layout uses a fixed top header + bottom nav, so lists scroll inside an internal container and `webView.scrollY` is always 0. The standard workaround (`setOnChildScrollUpCallback { _, _ -> webView.scrollY > 0 }`) cannot distinguish "pull to refresh" from "scroll up", so every upward swipe triggers refresh — long lists are unusable. The existing **Refresh** button in the app header covers the refresh UX.
- **Re-register FCM token on every launch and after `saveConfig`**. `onNewToken` in `ShooterFirebaseService` only fires when FCM rotates the token (first install + rare rotations), and previously returned early when the API key wasn't configured. If a user entered the API key AFTER first launch — the default flow — the token was never POSTed to `/api/device-token`, so pushes silently failed forever.

### `android/app/src/main/kotlin/com/shooter/android/ShooterFirebaseService.kt`
- Extracts `registerTokenWithServer` into a companion object so both `onNewToken()` and `MainActivity` can call it. Adds structured `Log.d`/`Log.w` lines so the POST and its response are visible in `adb logcat` (previous impl swallowed all errors silently, making this class of bug hard to diagnose).

### `android/gradle.properties`
- Remove hardcoded `org.gradle.java.home=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home` which only exists on the original author's Mac. Any Linux or Windows clone fails with `Java home supplied is invalid` during `./gradlew wrapper`. Gradle's default toolchain / `JAVA_HOME` detection works fine on all platforms.

## Test plan

- [ ] Verify projects list shows correct hyphenated paths: `curl -H "Authorization: Bearer $API_KEY" $URL/api/sessions` — `fullPath` should match directories that actually exist on disk
- [ ] Verify `decodeClaudeProjectDir` on the edge case: a project named `-home-parth-dogra-Desktop-Repo-pr-guardian` decodes to `/home/parth-dogra/Desktop/Repo/pr-guardian`, not `/home/parth/dogra/Desktop/Repo/pr/guardian`
- [ ] Fresh-install the Android app WITHOUT setting `ANDROID_DEVICE_TOKEN`, open the app, enter API key in `/config`, close/reopen app, `cat ~/.shooter/device-tokens.json` — should contain the phone's FCM token
- [ ] With token registered, `POST /api/notify` with `{title, message}` → phone receives push
- [ ] On the mobile projects list, scroll down through a long list, then swipe up to return to the top — list scrolls normally; no accidental refresh
- [ ] `./gradlew wrapper` succeeds on Linux without any `org.gradle.java.home` override

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved push notification reliability with enhanced token registration and fallback mechanisms for device identification.
  * Disabled unintended pull-to-refresh gesture on the web interface.

* **Improvements**
  * Enhanced session and project directory resolution for better accuracy.
  * Added comprehensive logging for token registration and notification delivery diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->