### PR TITLE
fix(css): replace invalid :global() and tidy stylelint nits

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -280,7 +280,7 @@ body {
   .page-actions {
     width: 100%;
   }
-  .page-actions :global(button) {
+  .page-actions > * {
     flex: 1;
   }
 }
@@ -309,8 +309,15 @@ body {
 }
 
 @keyframes activity-pulse {
-  0%, 100% { transform: scale(1); opacity: 1; }
-  50% { transform: scale(1.5); opacity: 0.7; }
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.5);
+    opacity: 0.7;
+  }
 }
 
 /* Connection dot — for live session/terminal indicators */
@@ -336,8 +343,13 @@ body {
 }
 
 @keyframes pulse-dot {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
 }
 
 /* Cards */
@@ -685,7 +697,9 @@ body {
   gap: var(--space-3, 0.75rem);
   position: relative;
   text-decoration: none;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
 }
 
 .session-card::before {
@@ -705,7 +719,9 @@ body {
   border-color: rgba(34, 197, 94, 0.3);
   background: linear-gradient(135deg, rgba(25, 25, 28, 0.95) 0%, rgba(32, 32, 38, 0.95) 100%);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(34, 197, 94, 0.15) inset;
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(34, 197, 94, 0.15) inset;
 }
 
 .session-card:hover::before {

--- a/src/lib/theme.css
+++ b/src/lib/theme.css
@@ -547,6 +547,7 @@
   --relative-time-font-size: var(--text-xs);
   --relative-time-color: var(--text-tertiary);
   --relative-time-font-weight: 400;
+
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -563,6 +564,7 @@
   --pill-hover-background: var(--ds-green-100);
   --pill-hover-color: var(--ds-green-900);
   --pill-cursor: default;
+
   height: 26px;
   text-transform: uppercase;
   letter-spacing: 0.02em;
@@ -578,6 +580,7 @@
   --pill-hover-background: var(--ds-red-100);
   --pill-hover-color: var(--ds-red-900);
   --pill-cursor: default;
+
   height: 26px;
   text-transform: uppercase;
   letter-spacing: 0.02em;
@@ -593,6 +596,7 @@
   --pill-hover-background: var(--ds-amber-100);
   --pill-hover-color: var(--ds-amber-900);
   --pill-cursor: default;
+
   height: 26px;
   text-transform: uppercase;
   letter-spacing: 0.02em;
@@ -608,6 +612,7 @@
   --pill-hover-background: var(--ds-gray-300);
   --pill-hover-color: var(--text-secondary);
   --pill-cursor: default;
+
   height: 26px;
   text-transform: uppercase;
   letter-spacing: 0.02em;
@@ -622,7 +627,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: currentColor;
+  background: currentcolor;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary

Addresses two unresolved CodeRabbit review comments from #49 (which was merged before these fixes could be applied).

- **`src/app.css:283`** — `.page-actions :global(button)` uses Svelte-style syntax that does not apply in a plain global CSS file, so the selector was silently ignored and mobile action buttons never flexed. Replaced with `.page-actions > *`.
- **`src/lib/theme.css`** — Tidy stylelint nits:
  - Inserted blank lines between custom-property declarations and regular declarations (stylelint `declaration-empty-line-before`).
  - Lowercased `currentColor` → `currentcolor` (stylelint `value-keyword-case`).

## Test plan

- [x] `pnpm run build` succeeds
- [ ] Mobile viewport (≤480px): buttons in `.page-actions` flex to equal widths
- [ ] Status pill dots still render with the correct inherited color