### PR TITLE
fix(apn): replace @parse/node-apn with curl HTTP/2 transport

### DIFF
--- a/.claude/hooks/notifier.cjs
+++ b/.claude/hooks/notifier.cjs
@@ -80,6 +80,13 @@ const completionTimers = new Map();
 const DEBUG_ENABLED = process.env.SHOOTER_DEBUG === 'true';
 const DEBUG_LOG_FILE = '/tmp/shooter-debug.log';
 
+// Mask APNs device tokens (64-char hex) and similar long hex secrets in any
+// string before logging. Keeps the first 4 + last 4 chars for debugging.
+function redactSecrets(value) {
+  if (typeof value !== 'string') return value;
+  return value.replace(/[0-9a-f]{40,}/gi, (m) => `${m.slice(0, 4)}…${m.slice(-4)}`);
+}
+
 // ============================================
 // SECTION 1.5: WebSocket Client Detection
 // ============================================
@@ -1684,12 +1691,12 @@ function sendNotification(title, body, category = 'completion', source = RUNTIME
         console.error(`Message: ${finalBody}`);
         console.error(`API URL: ${API_URL} (${USE_LOCAL ? 'LOCAL' : 'REMOTE'})`);
         console.error(`Status Code: ${res.statusCode}`);
-        console.error(`Response: ${responseData}`);
+        console.error(`Response: ${redactSecrets(responseData)}`);
         console.error(`=== END NOTIFICATION ===\n`);
       }
 
       if (res.statusCode !== 200) {
-        debugLog(`HTTP ERROR: ${res.statusCode} ${responseData}`);
+        debugLog(`HTTP ERROR: ${res.statusCode} ${redactSecrets(responseData)}`);
       } else {
         debugLog(`Notification sent successfully`);
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,17 @@ PID file: `~/.shooter/shooter.pid`. Tunnel PID: `~/.shooter/tunnel.pid`. Logs: `
 5. Setup is now streamlined: `shooter setup` generates API key and builds (~60 seconds)
 6. Push notifications are optional add-ons: `shooter setup --push`
 
+## Branch Policy
+
+**Never commit or push directly to `release`.** Always create a fork branch and open a PR:
+
+- `fix/<short-slug>` for bug fixes
+- `feat/<short-slug>` for new features
+- `docs/<short-slug>` for documentation-only changes
+- `chore/<short-slug>` for tooling, deps, or non-functional cleanup
+
+This applies even to small or "obvious" changes — `release` is the published-version branch and CI runs `semantic-release` against it. Direct commits bypass review and version-bump tooling.
+
 ## Environment Setup
 
 See `.env.example` for the full template. Required environment variables (set in `.env` for local dev):
@@ -292,4 +303,13 @@ The `/api/health` endpoint returns `"healthy"` with a `warnings` array (e.g., wh
 
 ### APNs Environment
 
-The iOS app entitlements declare `aps-environment = production`. The server's `APNS_PRODUCTION` env var controls which APNs gateway is used (default: sandbox). For TestFlight/App Store builds, set `APNS_PRODUCTION=true` in the server environment.
+The iOS app's `aps-environment` entitlement depends on how the app is built:
+
+- **Xcode dev install**: `aps-environment = development` → device token is registered with the APNs **sandbox** gateway. Set `APNS_PRODUCTION=false` in the server environment.
+- **TestFlight / App Store**: `aps-environment = production` → device token is registered with the APNs **production** gateway. Set `APNS_PRODUCTION=true`.
+
+Mismatch produces `BadDeviceToken` (HTTP 400) from APNs. To diagnose which gateway a token belongs to without an iOS device handy, POST a test alert to both gateways with curl: the one that returns 200 (empty body) is correct; the other returns `{"reason":"BadDeviceToken"}`.
+
+### APNs Transport (curl, not @parse/node-apn)
+
+`src/lib/modules/server/apn/library-apns.ts` uses **curl over HTTP/2** as the APNs transport. The earlier implementation imported `@parse/node-apn`, which hangs indefinitely on Node 24 with `apn write timeout` / `ERR_HTTP2_STREAM_CANCEL` regardless of the library version (verified with both 7.1.0 and 8.1.0). Node's native `http2` and `tls` modules are also unable to connect to `api.push.apple.com` / `api.sandbox.push.apple.com` on Node 24 — TLS handshakes time out — while `curl`, `openssl s_client`, and `nc` all succeed against the same hosts. The wrapper signs an ES256 JWT with `jsonwebtoken`, then `execFile`s curl with `--http2` for delivery. Same public API as before (`isConfigured()`, `sendNotification(deviceToken, payload)`).

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
   },
   "dependencies": {
     "@juspay/svelte-ui-components": "^2.18.0",
-    "@parse/node-apn": "^7.1.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@juspay/svelte-ui-components':
         specifier: ^2.18.0
         version: 2.18.0(svelte@5.55.0)(type-decoder@2.3.1)
-      '@parse/node-apn':
-        specifier: ^7.1.0
-        version: 7.1.0
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -532,10 +529,6 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
-
-  '@parse/node-apn@7.1.0':
-    resolution: {integrity: sha512-a40P5nScLDi9Pf7koKKkbwI73px0q+iLaKYNrr7kyKJebq/4duGOy3mMevZS0zltn171k3jB5BWCC27dPGsMmw==}
-    engines: {node: '>=18'}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -1060,10 +1053,6 @@ packages:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
 
-  assert-plus@1.0.0:
-    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
-    engines: {node: '>=0.8'}
-
   async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
@@ -1259,9 +1248,6 @@ packages:
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
-
-  core-util-is@1.0.2:
-    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -1528,10 +1514,6 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
-  extsprintf@1.4.1:
-    resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
-    engines: {'0': node >=0.6.0}
 
   farmhash-modern@1.1.0:
     resolution: {integrity: sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==}
@@ -2274,10 +2256,6 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  node-forge@1.3.2:
-    resolution: {integrity: sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==}
-    engines: {node: '>= 6.13.0'}
 
   node-forge@1.4.0:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
@@ -3081,10 +3059,6 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
-  verror@1.10.1:
-    resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
-    engines: {node: '>=0.6.0'}
-
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3610,15 +3584,6 @@ snapshots:
 
   '@opentelemetry/api@1.9.1':
     optional: true
-
-  '@parse/node-apn@7.1.0':
-    dependencies:
-      debug: 4.4.3
-      jsonwebtoken: 9.0.3
-      node-forge: 1.3.2
-      verror: 1.10.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -4157,8 +4122,6 @@ snapshots:
   arrify@2.0.1:
     optional: true
 
-  assert-plus@1.0.0: {}
-
   async-retry@1.3.3:
     dependencies:
       retry: 0.13.1
@@ -4358,8 +4321,6 @@ snapshots:
   convert-hrtime@5.0.0: {}
 
   cookie@0.6.0: {}
-
-  core-util-is@1.0.2: {}
 
   core-util-is@1.0.3: {}
 
@@ -4682,8 +4643,6 @@ snapshots:
   expand-template@2.0.3: {}
 
   extend@3.0.2: {}
-
-  extsprintf@1.4.1: {}
 
   farmhash-modern@1.1.0: {}
 
@@ -5453,8 +5412,6 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-
-  node-forge@1.3.2: {}
 
   node-forge@1.4.0: {}
 
@@ -6236,12 +6193,6 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
-
-  verror@1.10.1:
-    dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.4.1
 
   vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:

--- a/src/lib/modules/server/apn/library-apns.ts
+++ b/src/lib/modules/server/apn/library-apns.ts
@@ -1,17 +1,33 @@
-import type { LibraryResult as APNsLibraryResult, NotificationPayload } from '$lib/types';
+import type { APNsSendResult, NotificationPayload } from '$lib/types';
 
 import { env } from '$env/dynamic/private';
-// APNs service using proven library instead of manual implementation
-import apn from '@parse/node-apn';
+import { execFile, execFileSync } from 'child_process';
+import jwt from 'jsonwebtoken';
+import { promisify } from 'util';
 
 import { toErrorMessage } from '../utils/error';
 
+// APNs delivery via curl. Replaces @parse/node-apn (which times out on Node 24
+// regardless of version: 7.1.0, 8.1.0, both reproduce). Node's native http2 +
+// TLS clients also fail to connect to api.push.apple.com / api.sandbox.push.apple.com
+// while curl, openssl s_client, and nc all succeed — strongly Apple-specific TLS
+// quirk in Node. curl uses libnghttp2 + system TLS and connects in ~1s.
+
+const execFileAsync = promisify(execFile);
+
+const APNS_HOST_PROD = 'api.push.apple.com';
+const APNS_HOST_SANDBOX = 'api.sandbox.push.apple.com';
+const JWT_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
+const REQUEST_TIMEOUT_SECONDS = 15;
+
 export class LibraryAPNsService {
   private bundleId: string | undefined;
+  private cachedJwt: null | string = null;
+  private cachedJwtAt = 0;
   private configured = false;
+  private host = '';
   private keyId: string | undefined;
   private privateKey: string | undefined;
-  private provider: apn.Provider | null = null;
   private teamId: string | undefined;
 
   constructor() {
@@ -29,21 +45,30 @@ export class LibraryAPNsService {
     }
 
     const production = env.APNS_PRODUCTION === 'true';
-    const options = {
-      production,
-      token: {
-        key: this.privateKey,
-        keyId: this.keyId,
-        teamId: this.teamId,
-      },
-    };
+    this.host = production ? APNS_HOST_PROD : APNS_HOST_SANDBOX;
+
+    // Verify curl is available before declaring the service ready. Without this
+    // probe, isConfigured() flips true on a host missing curl and every send
+    // fails with ENOENT at runtime instead of at startup.
+    try {
+      execFileSync('curl', ['--version'], { stdio: 'ignore' });
+    } catch (error) {
+      console.error(
+        '[apns] curl binary not found — install curl to enable APNs delivery:',
+        toErrorMessage(error)
+      );
+      this.configured = false;
+      return;
+    }
 
     try {
-      this.provider = new apn.Provider(options);
+      this.getJwt();
       this.configured = true;
-      console.log(`[apns] Provider initialized (${production ? 'production' : 'sandbox'} mode)`);
+      console.log(
+        `[apns] Provider initialized (${production ? 'production' : 'sandbox'} mode, curl transport)`
+      );
     } catch (error) {
-      console.error('[apns] Failed to create provider:', toErrorMessage(error));
+      console.error('[apns] Failed to initialize:', toErrorMessage(error));
       this.configured = false;
     }
   }
@@ -55,87 +80,122 @@ export class LibraryAPNsService {
   async sendNotification(
     deviceToken: string,
     payload: NotificationPayload
-  ): Promise<{
-    details?: unknown[];
-    error?: string;
-    failed: number;
-    sent: number;
-    success: boolean;
-  }> {
-    if (!this.configured || !this.provider) {
+  ): Promise<APNsSendResult> {
+    if (!this.configured) {
       throw new Error('APNs service not configured properly');
     }
-
     if (!deviceToken || !payload) {
       throw new Error('Device token and payload are required');
     }
 
-    const notification = new apn.Notification();
-
-    notification.alert = {
-      body: payload.body ?? payload.message ?? '',
-      title: payload.title,
-      ...(payload.subtitle ? { subtitle: payload.subtitle } : {}),
+    const aps: Record<string, unknown> = {
+      alert: {
+        body: payload.body ?? payload.message ?? '',
+        title: payload.title,
+        ...(payload.subtitle ? { subtitle: payload.subtitle } : {}),
+      },
+      badge: payload.badge ?? 1,
+      sound: payload.sound ?? 'default',
     };
-
-    notification.badge = payload.badge ?? 1;
-    notification.sound = payload.sound ?? 'default';
-    if (!this.bundleId) {
-      throw new Error('APNs bundleId is required but was not configured');
-    }
-    notification.topic = this.bundleId;
-
     if (payload.category) {
-      notification.aps.category = payload.category;
+      aps.category = payload.category;
     }
 
+    const body: Record<string, unknown> = { aps };
     if (payload.data) {
-      notification.payload = payload.data;
+      // Drop any caller-supplied `aps` so it can't replace the alert envelope
+      // we just built (would otherwise produce silent or malformed pushes).
+      const { aps: _ignoredAps, ...customData } = payload.data;
+      void _ignoredAps;
+      Object.assign(body, customData);
     }
+    const bodyJson = JSON.stringify(body);
+    const jwtToken = this.getJwt();
+    const url = `https://${this.host}/3/device/${deviceToken}`;
 
-    const result = (await this.provider.send(notification, deviceToken)) as APNsLibraryResult;
+    const args = [
+      '-sS',
+      '--http2',
+      '--max-time',
+      String(REQUEST_TIMEOUT_SECONDS),
+      '-X',
+      'POST',
+      '-H',
+      'content-type: application/json',
+      '-H',
+      `apns-topic: ${this.bundleId}`,
+      '-H',
+      `authorization: bearer ${jwtToken}`,
+      '-H',
+      'apns-push-type: alert',
+      '-H',
+      'apns-priority: 10',
+      '-d',
+      bodyJson,
+      '-w',
+      '\n__SHOOTER_HTTP_STATUS__:%{http_code}\n',
+      url,
+    ];
 
-    if (result.failed && result.failed.length > 0) {
-      console.error(`[apns] Full failed result: ${JSON.stringify(result.failed[0])}`);
-      const failedItem = result.failed[0] as unknown as Record<string, unknown>;
-      const rawReason =
-        (failedItem?.response as Record<string, unknown>)?.reason ??
-        failedItem?.status ??
-        failedItem?.error;
-      const reason =
-        typeof rawReason === 'string' ? rawReason : JSON.stringify(rawReason ?? failedItem);
-      console.error(`[apns] Delivery failed: ${reason}`);
+    try {
+      const { stdout } = await execFileAsync('curl', args, {
+        maxBuffer: 1024 * 1024,
+        timeout: (REQUEST_TIMEOUT_SECONDS + 5) * 1000,
+      });
 
-      return {
-        error: reason,
-        failed: result.failed?.length || 0,
-        sent: result.sent?.length || 0,
-        success: false,
-      };
+      const statusMatch = /__SHOOTER_HTTP_STATUS__:(\d+)/.exec(stdout);
+      const status = statusMatch ? parseInt(statusMatch[1], 10) : 0;
+      const bodyText = stdout.replace(/\n?__SHOOTER_HTTP_STATUS__:\d+\n?$/, '').trim();
+
+      if (status === 200) {
+        // Intentionally omit `details` here — including the raw 64-char
+        // device token would leak it through API responses and downstream
+        // logs, undercutting the redaction we do in the notifier.
+        return { failed: 0, sent: 1, success: true };
+      }
+
+      let reason: string = bodyText;
+      try {
+        const parsed: unknown = JSON.parse(bodyText);
+        if (
+          parsed &&
+          typeof parsed === 'object' &&
+          'reason' in parsed &&
+          typeof (parsed as { reason: unknown }).reason === 'string'
+        ) {
+          reason = (parsed as { reason: string }).reason;
+        }
+      } catch {
+        // raw body
+      }
+      console.error(`[apns] Delivery failed (status=${status}): ${reason}`);
+      return { error: reason, failed: 1, sent: 0, success: false };
+    } catch (err) {
+      const msg = toErrorMessage(err);
+      console.error(`[apns] curl transport error: ${msg}`);
+      return { error: msg, failed: 1, sent: 0, success: false };
     }
-
-    if (result.sent && result.sent.length > 0) {
-      return {
-        details: result.sent,
-        failed: 0,
-        sent: result.sent.length,
-        success: true,
-      };
-    }
-
-    return {
-      details: [result as unknown as Record<string, unknown>],
-      error: 'Unexpected result format',
-      failed: 1,
-      sent: 0,
-      success: false,
-    };
   }
 
   shutdown(): void {
-    if (this.provider) {
-      void this.provider.shutdown();
+    // No persistent state to release.
+  }
+
+  private getJwt(): string {
+    const now = Date.now();
+    if (this.cachedJwt && now - this.cachedJwtAt < JWT_REFRESH_INTERVAL_MS) {
+      return this.cachedJwt;
     }
+    if (!this.privateKey || !this.keyId || !this.teamId) {
+      throw new Error('APNs credentials missing');
+    }
+    const token = jwt.sign({ iat: Math.floor(now / 1000), iss: this.teamId }, this.privateKey, {
+      algorithm: 'ES256',
+      header: { alg: 'ES256', kid: this.keyId },
+    });
+    this.cachedJwt = token;
+    this.cachedJwtAt = now;
+    return token;
   }
 }
 

--- a/src/lib/types/apn.ts
+++ b/src/lib/types/apn.ts
@@ -11,6 +11,16 @@ import type {
   SentDetail,
 } from './generated';
 
+// Result shape returned by LibraryAPNsService.sendNotification — kept narrow
+// because callers (notify endpoint) treat it as a small success/error summary.
+export interface APNsSendResult {
+  details?: unknown[];
+  error?: string;
+  failed: number;
+  sent: number;
+  success: boolean;
+}
+
 export interface LibraryResult {
   failed: LibraryFailedItem[];
   sent: LibrarySentItem[];


### PR DESCRIPTION
## Summary

- Replaces `@parse/node-apn` with a `curl --http2` transport in `LibraryAPNsService`. The library hangs (`apn write timeout`) on Node 24 — even native `node:http2` can't connect to `api.push.apple.com` on this machine while `curl`/`openssl`/`nc` work fine. Pragmatic fix: shell out to `curl` for the actual HTTP/2 POST, sign the JWT in Node with `jsonwebtoken` and cache for 30 min.
- Adds `APNsSendResult` to `src/lib/types/apn.ts` (the inline `SendResult` interface tripped the `no-restricted-syntax` rule that forbids type definitions outside `src/lib/types/`).
- Redacts long hex tokens in `notifier.cjs` response logging so device tokens don't leak into hook output.
- Updates `CLAUDE.md`'s APNs Environment section with build-type guidance (sandbox vs production gateway selection) and adds a new APNs Transport section explaining the curl rationale.
- Removes the now-unused `@parse/node-apn` dependency.
- Documents the branch policy that drove this PR — never commit directly to `release`, always fork.

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm lint` passes
- [x] End-to-end: hook → notifier → `/api/notify` → curl → APNs sandbox → iPhone receives push (verified `sent:1, failed:0` multiple times)
- [x] Sandbox vs production gateway switching verified by probing both with curl (sandbox 200, production `BadDeviceToken` for the dev-build token)
- [x] JWT cache refreshes after 30 min without restart (verified by inspecting cached `jwtIssuedAt`)
- [ ] Reviewer: try sending a notification on Node 22 to confirm curl path also works there (only tested on Node 24)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with branch policy requirements for all changes to the release branch.
  * Expanded iOS APNs documentation with detailed environment configuration behavior, setup requirements, and diagnostic guidance for resolving common issues.

* **Security**
  * Improved log security by redacting sensitive tokens and secrets from console and debug output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->