### PR TITLE
chore(ci): enable CodeRabbit auto-review on every PR push

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,56 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/reference/yaml-template
+#
+# Repo-level config takes precedence over the CodeRabbit dashboard. We want
+# automatic re-review on every commit pushed to an open PR (incremental
+# reviews) so contributors don't have to manually @coderabbitai full review
+# after each force-push or fix-up.
+
+language: en-US
+early_access: false
+
+reviews:
+  # Tone: 'chill' (informational, non-blocking) vs 'assertive' (more critical).
+  profile: chill
+
+  # Don't have CodeRabbit auto-request changes — humans drive that decision.
+  request_changes_workflow: false
+
+  # Keep the walkthrough summary at the top of the PR.
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+
+  auto_review:
+    # Run a review automatically when a PR is opened.
+    enabled: true
+
+    # Run a review again on every new commit pushed to the PR branch
+    # (default true on most plans; we set it explicitly so it can't be
+    # silently disabled via the dashboard).
+    auto_incremental_review: true
+
+    # Skip PRs marked as draft — we'll request a review manually when ready.
+    drafts: false
+
+    # Regex patterns matching base branches that should be reviewed. Default
+    # CodeRabbit behaviour with an empty list is to only review PRs targeting
+    # the default branch (`release` in this repo) — that would skip stacked
+    # PRs aimed at feature branches. ".*" explicitly opts every base branch
+    # in.
+    base_branches:
+      - '.*'
+
+    # No label gating — review every PR regardless of labels.
+    labels: []
+
+    # Skip PRs whose title contains any of these keywords.
+    ignore_title_keywords:
+      - WIP
+      - DO NOT MERGE
+
+chat:
+  # Allow replies in PR threads without requiring an explicit @coderabbitai
+  # mention every time. Manual @coderabbitai full review still works for
+  # forcing a fresh review.
+  auto_reply: true


### PR DESCRIPTION
## Summary

Adds a repo-level `.coderabbit.yaml` so CodeRabbit reviews:
- Every PR when it's opened (`reviews.auto_review.enabled: true`)
- Every subsequent commit pushed to the PR branch (`reviews.auto_review.auto_incremental_review: true`)

We currently have to comment `@coderabbitai full review` after every force-push to get a fresh review. The fact that this is needed implies the CodeRabbit dashboard has `auto_incremental_review` turned off for this repo. Adding a repo-level config overrides the dashboard, so this can't be silently turned off again.

## Why this fixes it

CodeRabbit precedence (per [docs](https://docs.coderabbit.ai/getting-started/configure-coderabbit/)): **repo `.coderabbit.yaml` > dashboard settings > defaults**. So even if the dashboard has incremental review disabled, this file takes over.

## What's in the config

| Setting | Value | Why |
| ------- | ----- | --- |
| `reviews.auto_review.enabled` | `true` | review on PR open |
| `reviews.auto_review.auto_incremental_review` | `true` | review on every new commit |
| `reviews.auto_review.drafts` | `false` | skip drafts; we'll trigger manually when ready |
| `reviews.auto_review.ignore_title_keywords` | `[WIP, DO NOT MERGE]` | skip clearly-not-ready PRs |
| `reviews.profile` | `chill` | informational tone, not assertive |
| `reviews.request_changes_workflow` | `false` | humans drive merge gating |
| `chat.auto_reply` | `true` | CodeRabbit replies in threads without needing `@coderabbitai` every time |

Manual `@coderabbitai full review` still works when we want to force a fresh review (e.g. after a rebase that changes context substantively).

## Test plan

- [x] `node -e "yaml.parse(...)"` — config parses cleanly with expected boolean values
- [ ] After merge: open a test PR, push a commit, confirm CodeRabbit re-reviews automatically without manual trigger
- [ ] Confirm draft PRs are skipped (no review on draft → marking ready triggers one)
- [ ] Confirm `@coderabbitai full review` still works when explicitly invoked

## Notes

- File location: repo root (`/Users/.../shooter/.coderabbit.yaml`). CodeRabbit looks here first.
- Schema reference: https://docs.coderabbit.ai/reference/yaml-template
- Existing PRs (e.g. #57) won't retroactively get auto-reviewed — they're already past the open event. New pushes after this lands will trigger the new behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CodeRabbit configuration file to optimize code review workflows, including automated PR analysis, high-level summaries, and enhanced chat functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/shooter/pull/60)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->