### PR TITLE
feat(api): persist pending permission requests in SQLite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ The plans include comprehensive testing approaches:
 
 ### In-Memory State (Partial)
 
-Terminal state is now persisted via PTY holder processes + SQLite and survives server restarts. However, pending permission requests, WebSocket connections, and auth tickets are still in-memory. If the server restarts, in-flight permission requests are lost (but terminals reconnect automatically).
+Terminal state and pending permission requests are persisted in `~/.shooter/shooter.db` (see `terminal-store.ts` and `pending-requests.ts`) and survive server restarts. WebSocket connections and auth tickets remain in-memory — clients reconnect / re-acquire tickets automatically, so no recovery is needed there.
 
 ### Hook Completion Timer
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "format:generated": "prettier --write ./src/lib/types/generated/*",
     "quality:all": "pnpm run lint && pnpm run format:check && pnpm run check",
     "gen:types": "npx type-crafter generate typescript-with-decoders ./specs/types/index.yaml ./src/lib/types/generated SingleFile SingleFile && bash scripts/postgen-types.sh && pnpm run format:generated",
-    "test": "node tests/terminal-store.test.cjs",
+    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs",
     "setup": "node scripts/setup.cjs",
     "prepare": "husky || true",
     "prepublishOnly": "pnpm build"

--- a/src/lib/modules/server/apn/notification-history.ts
+++ b/src/lib/modules/server/apn/notification-history.ts
@@ -1,5 +1,6 @@
-// In-memory notification history store.
-// Same pattern as pending-requests.ts — suitable for single-instance deployments.
+// In-memory notification history store — bounded ring buffer of recent
+// pushes for the /api/notify GET endpoint. Intentionally not persisted:
+// history is a debug/observability aid, not a source of truth.
 
 export type { NotificationRecord } from '$lib/types';
 import type { NotificationRecord } from '$lib/types';

--- a/src/lib/modules/server/apn/pending-requests.ts
+++ b/src/lib/modules/server/apn/pending-requests.ts
@@ -1,21 +1,121 @@
-// Shared in-memory store for pending permission requests.
-// Used by /api/notify (creates entries) and /api/response (reads/updates).
+/**
+ * Pending Permission Requests Store — SQLite persistence.
+ *
+ * Persists in-flight permission requests so they survive server
+ * restarts. Used by `/api/notify` (creates entries) and `/api/response`
+ * (reads/updates decisions). notifier.cjs polls `/api/response` via
+ * HTTP, so persisting the row is sufficient — there are no in-process
+ * callbacks that need recovery.
+ *
+ * Database location: `~/.shooter/shooter.db` (shared with terminal-store).
+ */
 
 import type { PendingRequest } from '$lib/types';
 
+import Database from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+
 export type { PendingRequest };
 
-const MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_AGE_MS = 5 * 60 * 1000;
 
-const pendingRequests = new Map<string, PendingRequest>();
+const DB_DIR = path.join(process.env.HOME || '', '.shooter');
+const DB_PATH = path.join(DB_DIR, 'shooter.db');
 
-export function cleanup(maxAgeMs: number = MAX_AGE_MS): void {
-  const now = Date.now();
-  for (const [id, entry] of pendingRequests.entries()) {
-    if (now - entry.createdAt > maxAgeMs) {
-      pendingRequests.delete(id);
+export class PendingRequestsStore {
+  private db: Database.Database;
+
+  constructor() {
+    fs.mkdirSync(DB_DIR, { recursive: true });
+    this.db = new Database(DB_PATH);
+    this.db.pragma('journal_mode = WAL');
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS pending_requests (
+        request_id  TEXT PRIMARY KEY,
+        session_id  TEXT NOT NULL,
+        tool_name   TEXT NOT NULL,
+        tool_input  TEXT NOT NULL DEFAULT '{}',
+        decision    TEXT,
+        created_at  INTEGER NOT NULL,
+        decided_at  INTEGER
+      )
+    `);
+  }
+
+  cleanup(maxAgeMs: number): number {
+    const cutoff = Date.now() - maxAgeMs;
+    const result = this.db.prepare('DELETE FROM pending_requests WHERE created_at < ?').run(cutoff);
+    return result.changes;
+  }
+
+  delete(requestId: string): void {
+    this.db.prepare('DELETE FROM pending_requests WHERE request_id = ?').run(requestId);
+  }
+
+  get(requestId: string): null | PendingRequest {
+    const row = this.db
+      .prepare('SELECT * FROM pending_requests WHERE request_id = ?')
+      .get(requestId) as Record<string, unknown> | undefined;
+    return row ? rowToRecord(row) : null;
+  }
+
+  insert(
+    requestId: string,
+    data: { sessionId: string; toolInput: Record<string, unknown>; toolName: string }
+  ): void {
+    // INSERT OR REPLACE matches the old Map.set semantics: a second
+    // create with the same requestId silently overwrites instead of
+    // erroring on UNIQUE constraint.
+    this.db
+      .prepare(
+        `INSERT OR REPLACE INTO pending_requests
+         (request_id, session_id, tool_name, tool_input, decision, created_at, decided_at)
+         VALUES (?, ?, ?, ?, NULL, ?, NULL)`
+      )
+      .run(requestId, data.sessionId, data.toolName, JSON.stringify(data.toolInput), Date.now());
+  }
+
+  setDecision(requestId: string, decision: 'allow' | 'deny'): boolean {
+    const result = this.db
+      .prepare('UPDATE pending_requests SET decision = ?, decided_at = ? WHERE request_id = ?')
+      .run(decision, Date.now(), requestId);
+    return result.changes > 0;
+  }
+}
+
+function rowToRecord(row: Record<string, unknown>): PendingRequest {
+  let toolInput: Record<string, unknown> = {};
+  if (typeof row.tool_input === 'string' && row.tool_input.length > 0) {
+    try {
+      const parsed: unknown = JSON.parse(row.tool_input);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        toolInput = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Corrupt JSON — fall back to empty.
     }
   }
+  return {
+    createdAt: row.created_at as number,
+    decidedAt: (row.decided_at as null | number) ?? null,
+    decision: (row.decision as null | PendingRequest['decision']) ?? null,
+    sessionId: row.session_id as string,
+    toolInput,
+    toolName: row.tool_name as string,
+  };
+}
+
+// Singleton via globalThis (matches terminal-store.ts pattern so SvelteKit's
+// module loaders don't accidentally produce multiple instances).
+const PR_GLOBAL_KEY = '__shooter_pending_requests_store';
+const pendingRequestsStore: PendingRequestsStore =
+  ((globalThis as Record<string, unknown>)[PR_GLOBAL_KEY] as PendingRequestsStore) ||
+  new PendingRequestsStore();
+(globalThis as Record<string, unknown>)[PR_GLOBAL_KEY] = pendingRequestsStore;
+
+export function cleanup(maxAgeMs: number = MAX_AGE_MS): void {
+  pendingRequestsStore.cleanup(maxAgeMs);
 }
 
 export function createPendingRequest(
@@ -23,38 +123,26 @@ export function createPendingRequest(
   data: { sessionId: string; toolInput: Record<string, unknown>; toolName: string }
 ): void {
   cleanup();
-  pendingRequests.set(requestId, {
-    createdAt: Date.now(),
-    decidedAt: null,
-    decision: null,
-    sessionId: data.sessionId,
-    toolInput: data.toolInput,
-    toolName: data.toolName,
-  });
+  pendingRequestsStore.insert(requestId, data);
 }
 
 export function getDecision(requestId: string): {
   decision?: 'allow' | 'deny';
   status: 'decided' | 'not_found' | 'pending';
 } {
-  const entry = pendingRequests.get(requestId);
+  const entry = pendingRequestsStore.get(requestId);
   if (!entry) {
     return { status: 'not_found' };
   }
   if (entry.decision) {
-    // Clean up after reading a decided response
-    pendingRequests.delete(requestId);
+    // Match the old in-memory behavior: delete on first decided read so
+    // the polling client only ever sees the decision once.
+    pendingRequestsStore.delete(requestId);
     return { decision: entry.decision, status: 'decided' };
   }
   return { status: 'pending' };
 }
 
 export function setDecision(requestId: string, decision: 'allow' | 'deny'): boolean {
-  const entry = pendingRequests.get(requestId);
-  if (!entry) {
-    return false;
-  }
-  entry.decision = decision;
-  entry.decidedAt = Date.now();
-  return true;
+  return pendingRequestsStore.setDecision(requestId, decision);
 }

--- a/tests/pending-requests.test.cjs
+++ b/tests/pending-requests.test.cjs
@@ -1,0 +1,315 @@
+/**
+ * Unit tests for PendingRequestsStore SQLite module.
+ *
+ * Uses better-sqlite3 directly against /tmp/shooter-test-pending.db
+ * to replicate the exact schema and operations from pending-requests.ts,
+ * avoiding TypeScript / path-alias complications.
+ */
+
+'use strict';
+
+const Database = require('better-sqlite3');
+const fs = require('fs');
+
+const DB_PATH = '/tmp/shooter-test-pending.db';
+
+const MAX_AGE_MS = 5 * 60 * 1000;
+
+function rowToRecord(row) {
+  let toolInput = {};
+  if (typeof row.tool_input === 'string' && row.tool_input.length > 0) {
+    try {
+      const parsed = JSON.parse(row.tool_input);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        toolInput = parsed;
+      }
+    } catch (_) {
+      /* corrupt JSON — fall back */
+    }
+  }
+  return {
+    createdAt: row.created_at,
+    decidedAt: row.decided_at ?? null,
+    decision: row.decision ?? null,
+    sessionId: row.session_id,
+    toolInput,
+    toolName: row.tool_name,
+  };
+}
+
+class PendingRequestsStore {
+  constructor(dbPath) {
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS pending_requests (
+        request_id  TEXT PRIMARY KEY,
+        session_id  TEXT NOT NULL,
+        tool_name   TEXT NOT NULL,
+        tool_input  TEXT NOT NULL DEFAULT '{}',
+        decision    TEXT,
+        created_at  INTEGER NOT NULL,
+        decided_at  INTEGER
+      )
+    `);
+  }
+
+  insert(requestId, data) {
+    this.db
+      .prepare(
+        `INSERT OR REPLACE INTO pending_requests
+         (request_id, session_id, tool_name, tool_input, decision, created_at, decided_at)
+         VALUES (?, ?, ?, ?, NULL, ?, NULL)`
+      )
+      .run(
+        requestId,
+        data.sessionId,
+        data.toolName,
+        JSON.stringify(data.toolInput),
+        data.createdAt ?? Date.now()
+      );
+  }
+
+  get(requestId) {
+    const row = this.db
+      .prepare('SELECT * FROM pending_requests WHERE request_id = ?')
+      .get(requestId);
+    return row ? rowToRecord(row) : null;
+  }
+
+  delete(requestId) {
+    this.db.prepare('DELETE FROM pending_requests WHERE request_id = ?').run(requestId);
+  }
+
+  setDecision(requestId, decision) {
+    const result = this.db
+      .prepare(
+        'UPDATE pending_requests SET decision = ?, decided_at = ? WHERE request_id = ?'
+      )
+      .run(decision, Date.now(), requestId);
+    return result.changes > 0;
+  }
+
+  cleanup(maxAgeMs) {
+    const cutoff = Date.now() - maxAgeMs;
+    const result = this.db
+      .prepare('DELETE FROM pending_requests WHERE created_at < ?')
+      .run(cutoff);
+    return result.changes;
+  }
+
+  close() {
+    this.db.close();
+  }
+}
+
+// ── Test Helpers ─────────────────────────────────────────────────────
+
+function assertEqual(actual, expected, label) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(`${label}: expected ${e}, got ${a}`);
+  }
+}
+
+function assertNotNull(value, label) {
+  if (value === null || value === undefined) {
+    throw new Error(`${label}: expected non-null value`);
+  }
+}
+
+function freshStore() {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try {
+      fs.unlinkSync(DB_PATH + suffix);
+    } catch (_) {
+      /* ignore */
+    }
+  }
+  return new PendingRequestsStore(DB_PATH);
+}
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+  let store;
+  try {
+    store = freshStore();
+    fn(store);
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  } finally {
+    if (store) store.close();
+  }
+}
+
+console.log('\nPendingRequestsStore unit tests\n');
+
+// ── Test 1: Insert and Get ───────────────────────────────────────────
+
+runTest('Test 1: Insert and Get', (store) => {
+  store.insert('req-1', {
+    sessionId: 'sess-abc',
+    toolName: 'Bash',
+    toolInput: { command: 'ls -la', timeout: 5000 },
+  });
+
+  const got = store.get('req-1');
+  assertNotNull(got, 'get result');
+  assertEqual(got.sessionId, 'sess-abc', 'sessionId');
+  assertEqual(got.toolName, 'Bash', 'toolName');
+  assertEqual(got.toolInput, { command: 'ls -la', timeout: 5000 }, 'toolInput round-trip');
+  assertEqual(got.decision, null, 'initial decision is null');
+  assertEqual(got.decidedAt, null, 'initial decidedAt is null');
+
+  if (typeof got.createdAt !== 'number' || got.createdAt <= 0) {
+    throw new Error(`createdAt should be a positive epoch ms, got ${got.createdAt}`);
+  }
+});
+
+// ── Test 2: setDecision flips decision + decidedAt ───────────────────
+
+runTest('Test 2: setDecision flips decision + decidedAt', (store) => {
+  store.insert('req-2', {
+    sessionId: 'sess-2',
+    toolName: 'Edit',
+    toolInput: { file_path: '/tmp/foo' },
+  });
+
+  const before = Date.now();
+  const ok = store.setDecision('req-2', 'allow');
+  assertEqual(ok, true, 'setDecision returns true for existing row');
+
+  const got = store.get('req-2');
+  assertNotNull(got, 'row still present after setDecision');
+  assertEqual(got.decision, 'allow', 'decision is allow');
+  if (typeof got.decidedAt !== 'number' || got.decidedAt < before) {
+    throw new Error(`decidedAt should be a number >= ${before}, got ${got.decidedAt}`);
+  }
+
+  // 'deny' should also work
+  store.insert('req-2b', {
+    sessionId: 'sess-2',
+    toolName: 'Bash',
+    toolInput: {},
+  });
+  store.setDecision('req-2b', 'deny');
+  assertEqual(store.get('req-2b').decision, 'deny', 'decision is deny');
+});
+
+// ── Test 3: setDecision on missing requestId returns false ───────────
+
+runTest('Test 3: setDecision on missing requestId returns false', (store) => {
+  const ok = store.setDecision('does-not-exist', 'allow');
+  assertEqual(ok, false, 'setDecision returns false when row absent');
+});
+
+// ── Test 4: delete + get after delete ────────────────────────────────
+
+runTest('Test 4: delete + get after delete', (store) => {
+  store.insert('req-del', {
+    sessionId: 's',
+    toolName: 'Bash',
+    toolInput: {},
+  });
+  assertNotNull(store.get('req-del'), 'row exists before delete');
+  store.delete('req-del');
+  assertEqual(store.get('req-del'), null, 'row gone after delete');
+});
+
+// ── Test 5: INSERT OR REPLACE — second insert overwrites ─────────────
+
+runTest('Test 5: INSERT OR REPLACE on duplicate requestId', (store) => {
+  store.insert('dup', {
+    sessionId: 'first',
+    toolName: 'Bash',
+    toolInput: { command: 'echo hi' },
+  });
+  // Second insert with same id should not throw and should overwrite
+  store.insert('dup', {
+    sessionId: 'second',
+    toolName: 'Edit',
+    toolInput: { file_path: '/tmp/bar' },
+  });
+
+  const got = store.get('dup');
+  assertNotNull(got, 'row still present');
+  assertEqual(got.sessionId, 'second', 'sessionId overwritten');
+  assertEqual(got.toolName, 'Edit', 'toolName overwritten');
+  assertEqual(got.toolInput, { file_path: '/tmp/bar' }, 'toolInput overwritten');
+});
+
+// ── Test 6: cleanup removes only expired rows ────────────────────────
+
+runTest('Test 6: cleanup removes only expired rows', (store) => {
+  const now = Date.now();
+  // Insert an "old" row by passing an explicit createdAt 10 min ago.
+  store.insert('old', {
+    sessionId: 's',
+    toolName: 'Bash',
+    toolInput: {},
+    createdAt: now - 10 * 60 * 1000,
+  });
+  store.insert('recent', {
+    sessionId: 's',
+    toolName: 'Bash',
+    toolInput: {},
+  });
+
+  const removed = store.cleanup(MAX_AGE_MS); // 5 minute window
+  assertEqual(removed, 1, 'cleanup removed 1 stale row');
+  assertEqual(store.get('old'), null, 'old row gone');
+  assertNotNull(store.get('recent'), 'recent row survives');
+});
+
+// ── Test 7: Tool input round-trip preserves nested structure ─────────
+
+runTest('Test 7: Tool input round-trip preserves nested values', (store) => {
+  const input = {
+    command: 'curl https://example.com',
+    flags: ['-sS', '--http2'],
+    nested: { headers: { 'Content-Type': 'application/json' }, retries: 3 },
+  };
+  store.insert('nested', {
+    sessionId: 's',
+    toolName: 'Bash',
+    toolInput: input,
+  });
+
+  const got = store.get('nested');
+  assertEqual(got.toolInput, input, 'nested toolInput round-trip');
+});
+
+// ── Test 8: Corrupt JSON in tool_input column falls back to {} ───────
+
+runTest('Test 8: Corrupt tool_input JSON falls back to empty object', (store) => {
+  // Directly insert a row with malformed JSON to verify rowToRecord doesn't throw.
+  store.db
+    .prepare(
+      `INSERT INTO pending_requests (request_id, session_id, tool_name, tool_input, created_at) VALUES (?, ?, ?, ?, ?)`
+    )
+    .run('bad', 's', 'Bash', '{this is not valid JSON', Date.now());
+  const got = store.get('bad');
+  assertNotNull(got, 'row still readable');
+  assertEqual(got.toolInput, {}, 'toolInput defaults to {} on parse failure');
+});
+
+// ── Summary ──────────────────────────────────────────────────────────
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total\n`);
+
+for (const suffix of ['', '-wal', '-shm']) {
+  try {
+    fs.unlinkSync(DB_PATH + suffix);
+  } catch (_) {
+    /* ignore */
+  }
+}
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- **Closes the documented \"In-Memory State\" known-limitation** for pending permission requests.
- Pending requests were a \`Map<string, PendingRequest>\` — a server restart mid-permission-flow lost the row + the eventual Allow/Deny answer. Now persisted in \`~/.shooter/shooter.db\` so restarts are transparent.

## Why this is safe / small

The whole permission flow already talks over HTTP — \`notifier.cjs\` polls \`GET /api/response?requestId=…\` every ~1s. No in-process Promise resolvers / callbacks to recover. The fix is purely a storage swap:

| Before | After |
| ------ | ----- |
| \`Map<string, PendingRequest>\` in \`pending-requests.ts\` | SQLite table \`pending_requests\` in \`~/.shooter/shooter.db\` |
| Lost on restart | Survives restart; warm row on next poll |

Module public API (\`createPendingRequest\`, \`getDecision\`, \`setDecision\`, \`cleanup\`) is **unchanged** — zero caller edits.

## Implementation

- Mirrors \`terminal-store.ts\` (same \`better-sqlite3\` + globalThis singleton + WAL mode + same DB file).
- Schema: \`request_id PK, session_id, tool_name, tool_input (JSON), decision NULL|allow|deny, created_at, decided_at\`.
- \`INSERT OR REPLACE\` matches the previous \`Map.set\` overwrite-on-duplicate semantics.
- \`getDecision\` deletes on first \"decided\" read (matches old behavior).
- New: \`tests/pending-requests.test.cjs\` — 8 cases (insert/get, decision-flip, missing-row, delete, duplicate-overwrite, expiry cleanup, nested toolInput round-trip, corrupt-JSON fallback). Wired into \`pnpm test\`.
- \`CLAUDE.md\` known-limitation updated.

## Test plan

- [x] \`pnpm install --frozen-lockfile\` clean
- [x] \`pnpm run lint\` clean
- [x] \`pnpm run check\` — 0 errors, 0 warnings
- [x] \`pnpm test\` — **14/14 pass** (6 terminal-store + 8 pending-requests)
- [x] \`pnpm run build\` succeeds
- [ ] CI green
- [ ] After merge: a server restart during an in-flight \`/permission\` notification still resolves correctly when the iOS user taps Allow/Deny

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pending permission requests now persist across server restarts in `~/.shooter/shooter.db`, preventing loss of request state
  * Terminal state is now persisted to disk

* **Documentation**
  * Updated documentation clarifying persistence behavior: terminal state and pending requests survive restarts, while WebSocket connections and authentication tickets remain temporary in-memory

* **Tests**
  * Added comprehensive test suite validating pending requests storage, retrieval, and cleanup functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/shooter/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->