### PR TITLE
feat(cli): auto-discover and self-heal named cloudflared tunnels

### DIFF
--- a/bin/lib/tunnel-discovery.cjs
+++ b/bin/lib/tunnel-discovery.cjs
@@ -1,0 +1,519 @@
+// Named-tunnel auto-discovery and self-heal for cloudflared.
+//
+// On macOS, scans ~/.cloudflared/*.yml for tunnel configs that proxy a
+// shooter-matching localhost port, then correlates them with LaunchAgents
+// in ~/Library/LaunchAgents/*.plist that run `cloudflared tunnel ... run`
+// against the same config. If a discovered LaunchAgent points to a stale
+// cloudflared binary (e.g. an Intel Homebrew path after migrating to
+// Apple Silicon), the plist is rewritten in-place against `which
+// cloudflared` and reloaded via `launchctl bootout` + `bootstrap`.
+//
+// The Linux variant is intentionally limited to discovery (no auto-heal
+// of systemd units yet); shooter on Linux primarily uses the quick-tunnel
+// flow today.
+
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+
+const CLOUDFLARED_DIR = path.join(os.homedir(), '.cloudflared');
+const LAUNCH_AGENTS_DIR = path.join(os.homedir(), 'Library', 'LaunchAgents');
+const SYSTEMD_USER_DIR = path.join(os.homedir(), '.config', 'systemd', 'user');
+
+// ── YAML parsing (intentionally minimal) ────────────────────────────
+//
+// Cloudflared tunnel configs are flat enough that we don't need a full
+// YAML library. We extract only:
+//   - tunnel: <uuid>
+//   - credentials-file: <path>
+//   - ingress: [{ hostname, service, path? }, ...]
+function parseCloudflaredConfig(yamlText) {
+  const lines = yamlText.split(/\r?\n/);
+  const out = { tunnel: null, credentialsFile: null, ingress: [] };
+  let inIngress = false;
+  let current = null;
+
+  for (const raw of lines) {
+    const line = raw.replace(/\s+#.*$/, '').trimEnd();
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+
+    if (!inIngress) {
+      const tunnel = line.match(/^tunnel:\s*(\S+)/);
+      if (tunnel) {
+        out.tunnel = tunnel[1].replace(/^["']|["']$/g, '');
+        continue;
+      }
+      const creds = line.match(/^credentials-file:\s*(\S+)/);
+      if (creds) {
+        out.credentialsFile = creds[1].replace(/^["']|["']$/g, '');
+        continue;
+      }
+      if (/^ingress:\s*$/.test(line)) {
+        inIngress = true;
+        continue;
+      }
+      continue;
+    }
+
+    // We're inside ingress:
+    if (/^[A-Za-z]/.test(line)) {
+      // A new top-level key terminates the ingress block.
+      if (current) out.ingress.push(current);
+      current = null;
+      inIngress = false;
+      continue;
+    }
+    const itemStart = line.match(/^\s*-\s*(\S+):\s*(.*)$/);
+    if (itemStart) {
+      if (current) out.ingress.push(current);
+      current = {};
+      current[itemStart[1]] = itemStart[2].replace(/^["']|["']$/g, '');
+      continue;
+    }
+    const cont = line.match(/^\s+(\S+):\s*(.*)$/);
+    if (cont && current) {
+      current[cont[1]] = cont[2].replace(/^["']|["']$/g, '');
+    }
+  }
+  if (current) out.ingress.push(current);
+  return out;
+}
+
+// ── plist parsing (intentionally minimal) ───────────────────────────
+//
+// Apple's plist format supports XML and binary; LaunchAgents written by
+// hand or by `cloudflared service install` are XML. We extract:
+//   - Label
+//   - ProgramArguments[] (array of string children of the array)
+//
+// Entities (&amp;, &lt;, &gt;, &quot;, &apos;) are decoded so the
+// captured values round-trip with rewritePlistBinaryPath (which encodes
+// the same five) and compare correctly against on-disk paths used by
+// e.g. `programArguments.includes(cfg.path)`.
+function xmlUnescapeText(s) {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&'); // last so we don't double-decode
+}
+
+function parseLaunchAgentPlist(xml) {
+  const out = { label: null, programArguments: [] };
+
+  const labelMatch = xml.match(/<key>\s*Label\s*<\/key>\s*<string>([^<]*)<\/string>/);
+  if (labelMatch) out.label = xmlUnescapeText(labelMatch[1]);
+
+  const argsBlock = xml.match(/<key>\s*ProgramArguments\s*<\/key>\s*<array>([\s\S]*?)<\/array>/);
+  if (argsBlock) {
+    const strs = argsBlock[1].matchAll(/<string>([^<]*)<\/string>/g);
+    for (const m of strs) out.programArguments.push(xmlUnescapeText(m[1]));
+  }
+  return out;
+}
+
+// ── filesystem scans ────────────────────────────────────────────────
+
+function listCloudflaredConfigs() {
+  try {
+    return fs
+      .readdirSync(CLOUDFLARED_DIR)
+      .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+      .map((f) => path.join(CLOUDFLARED_DIR, f));
+  } catch {
+    return [];
+  }
+}
+
+function listLaunchAgents() {
+  try {
+    return fs
+      .readdirSync(LAUNCH_AGENTS_DIR)
+      .filter((f) => f.endsWith('.plist'))
+      .map((f) => path.join(LAUNCH_AGENTS_DIR, f));
+  } catch {
+    return [];
+  }
+}
+
+function listSystemdUserUnits() {
+  try {
+    return fs
+      .readdirSync(SYSTEMD_USER_DIR)
+      .filter((f) => f.endsWith('.service'))
+      .map((f) => path.join(SYSTEMD_USER_DIR, f));
+  } catch {
+    return [];
+  }
+}
+
+// ── matching ────────────────────────────────────────────────────────
+
+function ingressMatchesPort(ingress, port) {
+  if (!ingress) return false;
+  const wanted = parseInt(port, 10);
+  if (isNaN(wanted)) return false;
+  for (const item of ingress) {
+    const svc = item.service || '';
+    // Only http[s] ingress with localhost / 127.0.0.1 host; compare the
+    // port numerically to avoid substring false-positives (e.g. port 80
+    // matching localhost:8080).
+    const m = svc.match(/^https?:\/\/(localhost|127\.0\.0\.1):(\d+)(?:\/|\?|#|$)/);
+    if (m && parseInt(m[2], 10) === wanted) return true;
+  }
+  return false;
+}
+
+// When `port` is supplied, return the hostname of the ingress entry whose
+// service actually targets that port — important when one tunnel routes
+// several hostnames to several local ports. Falls back to the first
+// hostname only if no entry matches (preserves the old behavior for
+// callers that don't pass a port).
+function hostnameFromIngress(ingress, port) {
+  if (!ingress) return null;
+  if (port != null) {
+    for (const item of ingress) {
+      if (item.hostname && ingressMatchesPort([item], port)) return item.hostname;
+    }
+  }
+  for (const item of ingress) {
+    if (item.hostname) return item.hostname;
+  }
+  return null;
+}
+
+// ── launchctl state ─────────────────────────────────────────────────
+
+// Launchd labels are reverse-DNS strings; restrict to a conservative
+// charset so a hostile plist Label can't influence argv parsing even
+// though we already avoid the shell.
+const LAUNCHD_LABEL_RE = /^[A-Za-z0-9._-]+$/;
+
+function getLaunchctlState(label) {
+  if (!label || !LAUNCHD_LABEL_RE.test(label)) {
+    return { loaded: false, state: null, pid: null, lastExitCode: null };
+  }
+  try {
+    const uid = process.getuid
+      ? process.getuid()
+      : execFileSync('id', ['-u'], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+    const out = execFileSync('launchctl', ['print', `gui/${uid}/${label}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const stateMatch = out.match(/^\s*state\s*=\s*(\S+)/m);
+    const pidMatch = out.match(/^\s*pid\s*=\s*(\d+)/m);
+    const exitMatch = out.match(/^\s*last exit code\s*=\s*(.+)$/m);
+    return {
+      loaded: true,
+      state: stateMatch ? stateMatch[1] : null,
+      pid: pidMatch ? parseInt(pidMatch[1], 10) : null,
+      lastExitCode: exitMatch ? exitMatch[1] : null,
+    };
+  } catch {
+    return { loaded: false, state: null, pid: null, lastExitCode: null };
+  }
+}
+
+// ── binary path validation ──────────────────────────────────────────
+
+function isExecutable(p) {
+  try {
+    // Resolve through symlinks; if the chain dangles, fs.statSync throws.
+    fs.statSync(p);
+    fs.accessSync(p, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveCloudflaredBinary() {
+  // Prefer `which`, falling back to common Homebrew prefixes. We never
+  // return a path that doesn't actually exist.
+  try {
+    const p = execFileSync('which', ['cloudflared'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (p && isExecutable(p)) return p;
+  } catch {}
+  for (const candidate of [
+    '/opt/homebrew/bin/cloudflared',
+    '/usr/local/bin/cloudflared',
+    '/usr/bin/cloudflared',
+    path.join(os.homedir(), '.local', 'bin', 'cloudflared'),
+  ]) {
+    if (isExecutable(candidate)) return candidate;
+  }
+  return null;
+}
+
+// ── discovery (public) ──────────────────────────────────────────────
+//
+// Returns an array of NamedTunnel records:
+// {
+//   kind: 'launchd' | 'systemd',
+//   label,
+//   unitPath,               // .plist on macOS, .service on Linux
+//   configPath,
+//   hostname, port,
+//   binaryPath,             // what the unit *currently* says
+//   binaryPathHealthy,      // does that file exist + execute?
+//   tunnelUuid, credentialsFile,
+//   launch: { loaded, state, pid, lastExitCode } | null,
+// }
+function discoverNamedTunnels(port) {
+  const platform = os.platform();
+  const configs = listCloudflaredConfigs()
+    .map((p) => {
+      try {
+        return { path: p, data: parseCloudflaredConfig(fs.readFileSync(p, 'utf8')) };
+      } catch {
+        return null;
+      }
+    })
+    .filter((c) => c && ingressMatchesPort(c.data.ingress, port));
+
+  if (configs.length === 0) return [];
+
+  if (platform === 'darwin') {
+    const agents = listLaunchAgents()
+      .map((p) => {
+        try {
+          return { path: p, data: parseLaunchAgentPlist(fs.readFileSync(p, 'utf8')) };
+        } catch {
+          return null;
+        }
+      })
+      .filter(
+        (a) =>
+          a && a.data.programArguments.length > 0 && /cloudflared$/.test(a.data.programArguments[0])
+      );
+
+    const tunnels = [];
+    for (const cfg of configs) {
+      const agent = agents.find((a) => a.data.programArguments.includes(cfg.path));
+      if (!agent) continue;
+      const binaryPath = agent.data.programArguments[0];
+      const launch = agent.data.label ? getLaunchctlState(agent.data.label) : null;
+      tunnels.push({
+        kind: 'launchd',
+        label: agent.data.label,
+        unitPath: agent.path,
+        configPath: cfg.path,
+        hostname: hostnameFromIngress(cfg.data.ingress, port),
+        port,
+        binaryPath,
+        binaryPathHealthy: isExecutable(binaryPath),
+        tunnelUuid: cfg.data.tunnel,
+        credentialsFile: cfg.data.credentialsFile,
+        launch,
+      });
+    }
+    return tunnels;
+  }
+
+  if (platform === 'linux') {
+    const units = listSystemdUserUnits()
+      .map((p) => {
+        try {
+          return { path: p, contents: fs.readFileSync(p, 'utf8') };
+        } catch {
+          return null;
+        }
+      })
+      .filter((u) => u && /cloudflared\b.*\btunnel\b/.test(u.contents));
+
+    const tunnels = [];
+    for (const cfg of configs) {
+      const unit = units.find((u) => u.contents.includes(cfg.path));
+      if (!unit) continue;
+      const execMatch = unit.contents.match(/ExecStart\s*=\s*(\S+)/);
+      const rawBinary = execMatch ? execMatch[1] : 'cloudflared';
+      // systemd unit files commonly use a bare command name
+      // (`ExecStart=cloudflared …`) and resolve it via $PATH at exec
+      // time. `isExecutable` does a literal stat, so a bare name would
+      // always report unhealthy. Resolve to a real path first.
+      const binaryPath = rawBinary.includes('/')
+        ? rawBinary
+        : resolveCloudflaredBinary() || rawBinary;
+      tunnels.push({
+        kind: 'systemd',
+        label: path.basename(unit.path, '.service'),
+        unitPath: unit.path,
+        configPath: cfg.path,
+        hostname: hostnameFromIngress(cfg.data.ingress, port),
+        port,
+        binaryPath,
+        binaryPathHealthy: isExecutable(binaryPath),
+        tunnelUuid: cfg.data.tunnel,
+        credentialsFile: cfg.data.credentialsFile,
+        launch: null, // systemctl status integration is deferred
+      });
+    }
+    return tunnels;
+  }
+
+  return [];
+}
+
+// ── self-heal ───────────────────────────────────────────────────────
+//
+// Rewrites the plist's first <string> under ProgramArguments (the
+// program path) to `newPath`. We write a `.bak` copy first; the
+// rewrite uses a string slice rather than an XML library to preserve
+// the file's exact formatting / quirks. `newPath` is XML-escaped so a
+// filesystem path containing `&`, `<`, or `>` can't corrupt the plist.
+function xmlEscapeText(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function rewritePlistBinaryPath(plistPath, oldPath, newPath) {
+  const xml = fs.readFileSync(plistPath, 'utf8');
+  // Locate the first <string>...</string> inside ProgramArguments.
+  const argsStart = xml.indexOf('<key>ProgramArguments</key>');
+  if (argsStart < 0) {
+    throw new Error(`No ProgramArguments key in ${plistPath}`);
+  }
+  const arrayOpen = xml.indexOf('<array>', argsStart);
+  if (arrayOpen < 0) throw new Error(`No <array> after ProgramArguments`);
+  const firstStringOpen = xml.indexOf('<string>', arrayOpen);
+  const firstStringClose = xml.indexOf('</string>', firstStringOpen);
+  if (firstStringOpen < 0 || firstStringClose < 0) {
+    throw new Error(`Malformed ProgramArguments array`);
+  }
+  const existingRaw = xml.slice(firstStringOpen + '<string>'.length, firstStringClose);
+  // Compare in the decoded domain so paths containing XML special chars
+  // round-trip with parseLaunchAgentPlist (which decodes the same entities).
+  const existing = xmlUnescapeText(existingRaw);
+  if (existing !== oldPath) {
+    throw new Error(`ProgramArguments[0] is ${existing}, expected ${oldPath} — refusing to heal`);
+  }
+  const next =
+    xml.slice(0, firstStringOpen + '<string>'.length) +
+    xmlEscapeText(newPath) +
+    xml.slice(firstStringClose);
+
+  fs.writeFileSync(plistPath + '.bak', xml);
+  fs.writeFileSync(plistPath, next);
+}
+
+function reloadLaunchAgent(plistPath, label) {
+  const uid = process.getuid
+    ? process.getuid()
+    : execFileSync('id', ['-u'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+  // bootout may fail if not loaded; ignore.
+  try {
+    execFileSync('launchctl', ['bootout', `gui/${uid}/${label}`], {
+      stdio: 'ignore',
+    });
+  } catch {}
+  execFileSync('launchctl', ['bootstrap', `gui/${uid}`, plistPath], {
+    stdio: 'ignore',
+  });
+}
+
+function kickstartLaunchAgent(label) {
+  const uid = process.getuid
+    ? process.getuid()
+    : execFileSync('id', ['-u'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+  try {
+    execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${label}`], {
+      stdio: 'ignore',
+    });
+  } catch {}
+}
+
+// Heal-and-ensure-running. Returns one of:
+//   { action: 'healed', from, to }
+//   { action: 'reloaded' }   - was loaded, kickstarted
+//   { action: 'started' }    - was not loaded, bootstrapped
+//   { action: 'ok' }         - already running, nothing done
+//   { action: 'failed', reason }
+function healAndEnsureRunning(tunnel) {
+  if (tunnel.kind !== 'launchd') {
+    return { action: 'ok' }; // systemd auto-heal is out of scope
+  }
+  try {
+    if (!tunnel.binaryPathHealthy) {
+      const realPath = resolveCloudflaredBinary();
+      if (!realPath) {
+        return {
+          action: 'failed',
+          reason: 'cloudflared binary not found on PATH',
+        };
+      }
+      rewritePlistBinaryPath(tunnel.unitPath, tunnel.binaryPath, realPath);
+      reloadLaunchAgent(tunnel.unitPath, tunnel.label);
+      return { action: 'healed', from: tunnel.binaryPath, to: realPath };
+    }
+
+    if (!tunnel.launch || !tunnel.launch.loaded) {
+      reloadLaunchAgent(tunnel.unitPath, tunnel.label);
+      return { action: 'started' };
+    }
+    if (tunnel.launch.state !== 'running') {
+      kickstartLaunchAgent(tunnel.label);
+      return { action: 'reloaded' };
+    }
+    return { action: 'ok' };
+  } catch (err) {
+    return { action: 'failed', reason: err.message };
+  }
+}
+
+// ── reachability ────────────────────────────────────────────────────
+//
+// Curl the public URL with a short timeout. We use curl directly for
+// the same reason apn.ts does: native http modules occasionally fail
+// at TLS on this user's Node.
+function probeReachability(url, timeoutMs = 5000) {
+  try {
+    const out = execFileSync(
+      'curl',
+      [
+        '-s',
+        '-o',
+        '/dev/null',
+        '-w',
+        '%{http_code}',
+        '--max-time',
+        String(Math.ceil(timeoutMs / 1000)),
+        url,
+      ],
+      { encoding: 'utf8', timeout: timeoutMs + 2000 }
+    ).trim();
+    const code = parseInt(out, 10);
+    return { ok: code >= 200 && code < 500, status: isNaN(code) ? null : code };
+  } catch {
+    return { ok: false, status: null };
+  }
+}
+
+module.exports = {
+  discoverNamedTunnels,
+  healAndEnsureRunning,
+  probeReachability,
+  resolveCloudflaredBinary,
+  xmlEscapeText,
+  // exported for tests
+  parseCloudflaredConfig,
+  parseLaunchAgentPlist,
+  rewritePlistBinaryPath,
+  ingressMatchesPort,
+  hostnameFromIngress,
+};

--- a/bin/shooter.cjs
+++ b/bin/shooter.cjs
@@ -7,8 +7,14 @@
 
 const os = require('os');
 const path = require('path');
-const { spawn, execSync } = require('child_process');
+const { spawn, execSync, execFileSync } = require('child_process');
 const fs = require('fs');
+const {
+  discoverNamedTunnels,
+  healAndEnsureRunning,
+  probeReachability,
+  xmlEscapeText,
+} = require('./lib/tunnel-discovery.cjs');
 
 // ── Resolve paths ───────────────────────────────────────────────────
 const PKG_ROOT = path.resolve(__dirname, '..');
@@ -176,7 +182,7 @@ function parsePortFlag() {
 
 function isCloudflaredAvailable() {
   try {
-    execSync('which cloudflared', { stdio: 'ignore' });
+    execFileSync('which', ['cloudflared'], { stdio: 'ignore' });
     return true;
   } catch {
     return false;
@@ -222,6 +228,23 @@ function startTunnel(port) {
   return cf.pid;
 }
 
+// Polls for ~/.shooter/.tunnel_url written by the URL detector inside
+// startTunnel. Async so it yields control to the event loop between
+// reads — letting startTunnel's setInterval actually fire to write the
+// file. Resolves to the URL on success, or null on timeout.
+async function waitForPersistedTunnelUrl(timeoutMs) {
+  const file = path.join(SHOOTER_HOME, '.tunnel_url');
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const url = fs.readFileSync(file, 'utf8').trim();
+      if (url) return url;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return null;
+}
+
 function stopTunnel() {
   const tunnelPidFile = path.join(SHOOTER_HOME, 'tunnel.pid');
   const tunnelUrlFile = path.join(SHOOTER_HOME, '.tunnel_url');
@@ -239,6 +262,48 @@ function stopTunnel() {
       fs.unlinkSync(tunnelUrlFile);
     } catch {}
   } catch {}
+}
+
+// Returns:
+//   { kind: 'named', url, label }  – a pre-configured named tunnel is now
+//                                    managed (healed/started as needed)
+//   { kind: 'quick' }              – no named tunnel found; caller should
+//                                    fall back to startTunnel()
+function ensureNamedTunnelOrFallback(port) {
+  let tunnels;
+  try {
+    tunnels = discoverNamedTunnels(parseInt(port, 10));
+  } catch (err) {
+    console.warn(`(named-tunnel discovery failed: ${err.message})`);
+    return { kind: 'quick' };
+  }
+  if (!tunnels.length) return { kind: 'quick' };
+
+  // Prefer the first match — port + hostname combination is typically unique.
+  const tunnel = tunnels[0];
+  const result = healAndEnsureRunning(tunnel);
+
+  if (result.action === 'failed') {
+    console.warn(`Named tunnel ${tunnel.label} could not be managed: ${result.reason}`);
+    console.warn('Falling back to a quick tunnel.');
+    return { kind: 'quick' };
+  }
+  if (result.action === 'healed') {
+    console.log(`Tunnel plist binary path updated: ${result.from} → ${result.to}`);
+  } else if (result.action === 'started') {
+    console.log(`Tunnel ${tunnel.label} started.`);
+  } else if (result.action === 'reloaded') {
+    console.log(`Tunnel ${tunnel.label} kickstarted.`);
+  }
+
+  const url = tunnel.hostname ? `https://${tunnel.hostname}` : null;
+  if (url) {
+    try {
+      fs.mkdirSync(SHOOTER_HOME, { recursive: true });
+      fs.writeFileSync(path.join(SHOOTER_HOME, '.tunnel_url'), url);
+    } catch {}
+  }
+  return { kind: 'named', url, label: tunnel.label };
 }
 
 function startServer() {
@@ -319,11 +384,21 @@ function startServer() {
     console.log(`  API key: ${apiKey ? '(set)' : '(not set — run shooter setup)'}`);
     console.log(`  Logs:    ${LOG_FILE}`);
 
-    // Start tunnel in background if available; it writes URL to ~/.shooter/.tunnel_url
+    // Start tunnel in background if available; it writes URL to ~/.shooter/.tunnel_url.
+    // startTunnel spawns cloudflared detached + unref'd, so the child survives the
+    // CLI's process.exit(0) below — a setTimeout would have been killed before it
+    // fires. For the quick-tunnel branch we briefly wait for the URL-detection
+    // poller inside startTunnel to write .tunnel_url so `shooter status` and the
+    // user can see the URL after the daemon detaches.
+    let waitForQuickTunnel = false;
     if (!noTunnel && isCloudflaredAvailable()) {
-      setTimeout(() => {
+      const t = ensureNamedTunnelOrFallback(port);
+      if (t.kind === 'named') {
+        if (t.url) console.log(`  Tunnel:  ${t.url} (named: ${t.label})`);
+      } else {
         startTunnel(port);
-      }, 3000);
+        waitForQuickTunnel = true;
+      }
     } else if (!noTunnel && !isCloudflaredAvailable()) {
       console.log('  (cloudflared not found — no tunnel. Install: brew install cloudflared)');
     }
@@ -331,8 +406,15 @@ function startServer() {
     // Spawn auto-update guard (detached) — only when launchd is managing
     spawnGuard(child.pid, port);
 
-    // Exit immediately — daemon is running, tunnel starts async
-    process.exit(0);
+    if (waitForQuickTunnel) {
+      // Hand control back to the event loop so the URL poller inside
+      // startTunnel can write .tunnel_url. The poller has its own 15s
+      // ceiling and will clearInterval itself; once it does, no event
+      // sources remain and the daemon process exits naturally.
+      waitForPersistedTunnelUrl(15000).then(() => process.exit(0));
+    } else {
+      process.exit(0);
+    }
   } else {
     // ── Foreground mode: inherit stdio ──
     const tsxLoader = path.join(PKG_ROOT, 'node_modules', 'tsx', 'dist', 'loader.mjs');
@@ -355,20 +437,38 @@ function startServer() {
     // Clean up any stale tunnel from previous run (important for LaunchAgent restart)
     stopTunnel();
 
-    // Start tunnel in foreground mode too (unless --no-tunnel)
+    // Start tunnel in foreground mode too (unless --no-tunnel). We capture
+    // the timer handle so signal/exit/error paths can cancel it — otherwise
+    // a Ctrl-C between t=0 and t=3s would let the deferred startTunnel fire
+    // after the server has begun shutting down, spawning a cloudflared that
+    // points at a dead local port (the eventual exit handler reaps it via
+    // pidfile, but the brief spawn is wasteful and confusing in logs).
     let tunnelStarted = false;
+    let tunnelTimer = null;
     if (!noTunnel && isCloudflaredAvailable()) {
-      // Give server 3s to start before launching tunnel
-      setTimeout(() => {
-        startTunnel(port);
-        tunnelStarted = true;
-      }, 3000);
+      const t = ensureNamedTunnelOrFallback(port);
+      if (t.kind === 'named') {
+        if (t.url) console.log(`Tunnel: ${t.url} (named: ${t.label})`);
+      } else {
+        tunnelTimer = setTimeout(() => {
+          tunnelTimer = null;
+          startTunnel(port);
+          tunnelStarted = true;
+        }, 3000);
+      }
     }
+    const cancelTunnelTimer = () => {
+      if (tunnelTimer) {
+        clearTimeout(tunnelTimer);
+        tunnelTimer = null;
+      }
+    };
 
     // Spawn auto-update guard (detached) — only when launchd is managing
     spawnGuard(child.pid, port);
 
     child.on('error', (err) => {
+      cancelTunnelTimer();
       removePid();
       if (tunnelStarted) stopTunnel();
       stopGuard();
@@ -377,6 +477,7 @@ function startServer() {
     });
 
     child.on('exit', (code, signal) => {
+      cancelTunnelTimer();
       removePid();
       stopTunnel();
       stopGuard();
@@ -389,6 +490,7 @@ function startServer() {
     // Forward signals to the child so graceful shutdown works
     for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
       process.on(sig, () => {
+        cancelTunnelTimer();
         child.kill(sig);
         stopTunnel();
         stopGuard();
@@ -464,11 +566,38 @@ function showStatus() {
     tunnelUrl = fs.readFileSync(tunnelUrlFile, 'utf8').trim();
   } catch {}
 
+  let namedTunnel = null;
+  try {
+    const list = discoverNamedTunnels(parseInt(port, 10));
+    if (list.length) namedTunnel = list[0];
+  } catch (err) {
+    console.warn(`(named-tunnel discovery failed: ${err.message})`);
+  }
+
   if (pid) {
     console.log(`Shooter is running`);
     console.log(`  PID:        ${pid}`);
     console.log(`  URL:        http://localhost:${port}`);
-    if (tunnelUrl) {
+    if (namedTunnel) {
+      const url = namedTunnel.hostname ? `https://${namedTunnel.hostname}` : null;
+      const ls = namedTunnel.launch || {};
+      if (url) {
+        const reach = probeReachability(url, 1500);
+        const reachStr = reach.ok
+          ? `reachable (${reach.status})`
+          : `unreachable${reach.status ? ` (${reach.status})` : ''}`;
+        console.log(`  Tunnel:     ${url}  [${reachStr}]`);
+      }
+      console.log(
+        `  Agent:      ${namedTunnel.label} ` +
+          `(state=${ls.state ?? 'unknown'}, last exit=${ls.lastExitCode ?? 'n/a'})`
+      );
+      if (!namedTunnel.binaryPathHealthy) {
+        console.log(
+          `  WARNING:    cloudflared at ${namedTunnel.binaryPath} not found — will self-heal on next start`
+        );
+      }
+    } else if (tunnelUrl) {
       console.log(`  Tunnel:     ${tunnelUrl}`);
     }
     console.log(`  Autostart:  ${autostartEnabled ? 'enabled' : 'disabled'}`);
@@ -476,6 +605,16 @@ function showStatus() {
     console.log(`  Home:       ${SHOOTER_HOME}`);
   } else {
     console.log('Shooter is not running.');
+    if (namedTunnel) {
+      console.log(
+        `  Tunnel:     named (${namedTunnel.label}) at https://${namedTunnel.hostname || '?'}`
+      );
+      if (!namedTunnel.binaryPathHealthy) {
+        console.log(
+          `  WARNING:    cloudflared at ${namedTunnel.binaryPath} not found — will self-heal on next start`
+        );
+      }
+    }
     console.log(`  Autostart:  ${autostartEnabled ? 'enabled' : 'disabled'}`);
     console.log(`  Home:       ${SHOOTER_HOME}`);
     console.log('\nRun "shooter start" to start the server.');
@@ -543,6 +682,11 @@ function enableLaunchAgent() {
   const shooterBin = resolveShooterBin();
   const nodeBin = process.execPath;
 
+  // All five interpolations below are system-derived paths (no user
+  // input), but XML-escaping them keeps the plist well-formed if any
+  // path ever contains `&`, `<`, or `>` — same hardening as the named-
+  // tunnel rewrite path.
+  const e = xmlEscapeText;
   const plist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -552,18 +696,18 @@ function enableLaunchAgent() {
   <string>${LAUNCHD_LABEL}</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${nodeBin}</string>
-    <string>${shooterBin}</string>
+    <string>${e(nodeBin)}</string>
+    <string>${e(shooterBin)}</string>
     <string>start</string>
   </array>
   <key>WorkingDirectory</key>
-  <string>${PKG_ROOT}</string>
+  <string>${e(PKG_ROOT)}</string>
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>${path.dirname(nodeBin)}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <string>${e(path.dirname(nodeBin))}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>SHOOTER_HOME</key>
-    <string>${SHOOTER_HOME}</string>
+    <string>${e(SHOOTER_HOME)}</string>
   </dict>
   <key>KeepAlive</key>
   <dict>
@@ -573,9 +717,9 @@ function enableLaunchAgent() {
   <key>RunAtLoad</key>
   <true/>
   <key>StandardOutPath</key>
-  <string>${LOG_FILE}</string>
+  <string>${e(LOG_FILE)}</string>
   <key>StandardErrorPath</key>
-  <string>${LOG_FILE}</string>
+  <string>${e(LOG_FILE)}</string>
   <key>ThrottleInterval</key>
   <integer>10</integer>
 </dict>
@@ -588,12 +732,12 @@ function enableLaunchAgent() {
   // Unload existing if present
   if (fs.existsSync(LAUNCHD_PLIST)) {
     try {
-      execSync(`launchctl unload "${LAUNCHD_PLIST}" 2>/dev/null`);
+      execFileSync('launchctl', ['unload', LAUNCHD_PLIST], { stdio: 'ignore' });
     } catch {}
   }
 
   fs.writeFileSync(LAUNCHD_PLIST, plist);
-  execSync(`launchctl load "${LAUNCHD_PLIST}"`);
+  execFileSync('launchctl', ['load', LAUNCHD_PLIST], { stdio: 'ignore' });
 
   console.log('Autostart enabled (macOS LaunchAgent).');
   console.log(`  Plist:  ${LAUNCHD_PLIST}`);
@@ -609,7 +753,7 @@ function disableLaunchAgent() {
   }
 
   try {
-    execSync(`launchctl unload "${LAUNCHD_PLIST}" 2>/dev/null`);
+    execFileSync('launchctl', ['unload', LAUNCHD_PLIST], { stdio: 'ignore' });
   } catch {}
   fs.unlinkSync(LAUNCHD_PLIST);
   console.log('Autostart disabled. LaunchAgent removed.');
@@ -620,15 +764,19 @@ function disableLaunchAgent() {
 function enableSystemdUnit() {
   const shooterBin = resolveShooterBin();
 
+  // Quote interpolated paths so systemd's word-splitter doesn't treat
+  // a space inside e.g. "/Users/John Doe/.local/bin/shooter" as an
+  // argument separator. systemd supports double-quoting per token in
+  // ExecStart= and the whole RHS in Environment=.
   const unit = `[Unit]
 Description=Shooter — Mobile dev notifications & remote terminal
 After=network.target
 
 [Service]
 Type=simple
-ExecStart=${process.execPath} ${shooterBin} start
-WorkingDirectory=${PKG_ROOT}
-Environment=SHOOTER_HOME=${SHOOTER_HOME}
+ExecStart="${process.execPath}" "${shooterBin}" start
+WorkingDirectory="${PKG_ROOT}"
+Environment="SHOOTER_HOME=${SHOOTER_HOME}"
 Restart=on-failure
 RestartSec=10
 
@@ -640,9 +788,9 @@ WantedBy=default.target
   fs.mkdirSync(LOG_DIR, { recursive: true });
   fs.writeFileSync(SYSTEMD_UNIT, unit);
 
-  execSync('systemctl --user daemon-reload');
-  execSync('systemctl --user enable shooter.service');
-  execSync('systemctl --user start shooter.service');
+  execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'inherit' });
+  execFileSync('systemctl', ['--user', 'enable', 'shooter.service'], { stdio: 'inherit' });
+  execFileSync('systemctl', ['--user', 'start', 'shooter.service'], { stdio: 'inherit' });
 
   console.log('Autostart enabled (systemd user unit).');
   console.log(`  Unit:   ${SYSTEMD_UNIT}`);
@@ -657,14 +805,14 @@ function disableSystemdUnit() {
   }
 
   try {
-    execSync('systemctl --user stop shooter.service 2>/dev/null');
+    execFileSync('systemctl', ['--user', 'stop', 'shooter.service'], { stdio: 'ignore' });
   } catch {}
   try {
-    execSync('systemctl --user disable shooter.service 2>/dev/null');
+    execFileSync('systemctl', ['--user', 'disable', 'shooter.service'], { stdio: 'ignore' });
   } catch {}
   fs.unlinkSync(SYSTEMD_UNIT);
   try {
-    execSync('systemctl --user daemon-reload');
+    execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'inherit' });
   } catch {}
   console.log('Autostart disabled. systemd unit removed.');
 }
@@ -745,7 +893,9 @@ function runSetup() {
 
 function runUpdate(subcommand) {
   const { checkForUpdate } = require(path.join(PKG_ROOT, 'scripts', 'update-checker.cjs'));
-  const { recordCheck, isVersionSuppressed } = require(path.join(PKG_ROOT, 'scripts', 'update-state.cjs'));
+  const { recordCheck, isVersionSuppressed } = require(
+    path.join(PKG_ROOT, 'scripts', 'update-state.cjs')
+  );
 
   const result = checkForUpdate(PKG_ROOT);
   if (!result.checkFailed) recordCheck(result.latestVersion);
@@ -760,7 +910,9 @@ function runUpdate(subcommand) {
       console.log(`  Current commit: ${result.currentCommit}`);
       console.log(`  Latest commit:  ${result.latestCommit}`);
       if (isVersionSuppressed(result.latestVersion)) {
-        console.log(`  (version ${result.latestVersion} is temporarily suppressed — will retry in <24h)`);
+        console.log(
+          `  (version ${result.latestVersion} is temporarily suppressed — will retry in <24h)`
+        );
       }
     } else {
       console.log(`Already up to date: v${result.currentVersion} (${result.currentCommit})`);
@@ -783,7 +935,9 @@ function runUpdate(subcommand) {
   const { getCurrentBranch } = require(path.join(PKG_ROOT, 'scripts', 'update-checker.cjs'));
   const branch = getCurrentBranch(PKG_ROOT);
   if (branch !== 'release') {
-    console.log(`Cannot update: currently on branch '${branch || 'unknown'}', updates only apply to 'release'.`);
+    console.log(
+      `Cannot update: currently on branch '${branch || 'unknown'}', updates only apply to 'release'.`
+    );
     console.log('Switch to the release branch and try again.');
     return;
   }
@@ -805,9 +959,9 @@ function runUpdate(subcommand) {
       if (isLaunchdManaging()) {
         const uid = process.getuid ? process.getuid() : 501;
         try {
-          execSync(`launchctl kickstart -k gui/${uid}/${LAUNCHD_LABEL}`, {
+          execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${LAUNCHD_LABEL}`], {
             timeout: 10_000,
-            stdio: 'pipe',
+            stdio: ['ignore', 'pipe', 'ignore'],
           });
           console.log('Signaled launchd to restart the server.');
         } catch {
@@ -828,7 +982,9 @@ function runUpdate(subcommand) {
  * Returns true on success. On failure, rolls back and returns false.
  */
 function performUpdate(result) {
-  const { suppressVersion, recordSuccessfulUpdate } = require(path.join(PKG_ROOT, 'scripts', 'update-state.cjs'));
+  const { suppressVersion, recordSuccessfulUpdate } = require(
+    path.join(PKG_ROOT, 'scripts', 'update-state.cjs')
+  );
 
   // Save current HEAD for rollback
   let savedHead = '';
@@ -987,7 +1143,7 @@ function isLaunchdManaging() {
   if (os.platform() !== 'darwin') return false;
   try {
     const uid = process.getuid ? process.getuid() : 501;
-    execSync(`launchctl print gui/${uid}/${LAUNCHD_LABEL} 2>/dev/null`, {
+    execFileSync('launchctl', ['print', `gui/${uid}/${LAUNCHD_LABEL}`], {
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5_000,
     });
@@ -1016,13 +1172,12 @@ function runGuard() {
     process.exit(1);
   }
 
-  const { checkForUpdate, getCurrentBranch } = require(path.join(PKG_ROOT, 'scripts', 'update-checker.cjs'));
-  const {
-    recordCheck,
-    isVersionSuppressed,
-    suppressVersion,
-    recordSuccessfulUpdate,
-  } = require(path.join(PKG_ROOT, 'scripts', 'update-state.cjs'));
+  const { checkForUpdate, getCurrentBranch } = require(
+    path.join(PKG_ROOT, 'scripts', 'update-checker.cjs')
+  );
+  const { recordCheck, isVersionSuppressed, suppressVersion, recordSuccessfulUpdate } = require(
+    path.join(PKG_ROOT, 'scripts', 'update-state.cjs')
+  );
 
   const log = (msg) => console.log(`[guard] ${new Date().toISOString()} ${msg}`);
 
@@ -1135,9 +1290,9 @@ function runGuard() {
       log('restarting via launchctl...');
       const uid = process.getuid ? process.getuid() : 501;
       try {
-        execSync(`launchctl kickstart -k gui/${uid}/${LAUNCHD_LABEL}`, {
+        execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${LAUNCHD_LABEL}`], {
           timeout: 10_000,
-          stdio: 'pipe',
+          stdio: ['ignore', 'pipe', 'ignore'],
         });
       } catch {
         log('WARNING: launchctl kickstart failed');

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "format:generated": "prettier --write ./src/lib/types/generated/*",
     "quality:all": "pnpm run lint && pnpm run format:check && pnpm run check",
     "gen:types": "npx type-crafter generate typescript-with-decoders ./specs/types/index.yaml ./src/lib/types/generated SingleFile SingleFile && bash scripts/postgen-types.sh && pnpm run format:generated",
-    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs",
+    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs",
     "setup": "node scripts/setup.cjs",
     "prepare": "husky || true",
     "prepublishOnly": "pnpm build"

--- a/tests/tunnel-discovery.test.cjs
+++ b/tests/tunnel-discovery.test.cjs
@@ -1,0 +1,409 @@
+/**
+ * Unit tests for bin/lib/tunnel-discovery.cjs.
+ *
+ * Pure parser tests + a self-heal roundtrip on a temp plist file.
+ * No real launchctl interaction.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  parseCloudflaredConfig,
+  parseLaunchAgentPlist,
+  rewritePlistBinaryPath,
+  ingressMatchesPort,
+  hostnameFromIngress,
+} = require('../bin/lib/tunnel-discovery.cjs');
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`       ${err.message}`);
+    failed++;
+    failures.push({ name, err });
+  }
+}
+
+function assertEqual(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error(`${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertDeepEqual(actual, expected, msg) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) throw new Error(`${msg}: expected ${e}, got ${a}`);
+}
+
+function assertTrue(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+// ── Test 1: parseCloudflaredConfig basic ─────────────────────────────
+
+runTest('parseCloudflaredConfig: extracts tunnel uuid, credentials, and ingress', () => {
+  const yaml = `
+tunnel: ba1f2887-af40-4a5e-acef-d394d344c322
+credentials-file: /Users/foo/.cloudflared/ba1f2887-af40-4a5e-acef-d394d344c322.json
+
+ingress:
+  - hostname: shooter.example.dev
+    service: http://localhost:54006
+  - service: http_status:404
+`;
+  const cfg = parseCloudflaredConfig(yaml);
+  assertEqual(cfg.tunnel, 'ba1f2887-af40-4a5e-acef-d394d344c322', 'tunnel uuid');
+  assertEqual(
+    cfg.credentialsFile,
+    '/Users/foo/.cloudflared/ba1f2887-af40-4a5e-acef-d394d344c322.json',
+    'credentials file'
+  );
+  assertEqual(cfg.ingress.length, 2, 'ingress entry count');
+  assertEqual(cfg.ingress[0].hostname, 'shooter.example.dev', 'first ingress hostname');
+  assertEqual(cfg.ingress[0].service, 'http://localhost:54006', 'first ingress service');
+});
+
+// ── Test 2: parseCloudflaredConfig with comments + quotes ────────────
+
+runTest('parseCloudflaredConfig: handles comments and quoted values', () => {
+  const yaml = `
+# top-level comment
+tunnel: "my-tunnel-uuid"
+ingress:
+  - hostname: 'host.example.dev'  # inline comment
+    service: http://127.0.0.1:54007
+`;
+  const cfg = parseCloudflaredConfig(yaml);
+  assertEqual(cfg.tunnel, 'my-tunnel-uuid', 'quoted tunnel uuid');
+  assertEqual(cfg.ingress[0].hostname, 'host.example.dev', 'quoted hostname');
+  assertEqual(cfg.ingress[0].service, 'http://127.0.0.1:54007', 'service with 127.0.0.1');
+});
+
+// ── Test 3: ingressMatchesPort ──────────────────────────────────────
+
+runTest('ingressMatchesPort: matches localhost and 127.0.0.1 forms', () => {
+  const ingress = [
+    { service: 'http://localhost:54006', hostname: 'a' },
+    { service: 'http_status:404' },
+  ];
+  assertTrue(ingressMatchesPort(ingress, 54006), 'localhost:54006 should match port 54006');
+  assertTrue(!ingressMatchesPort(ingress, 54007), 'port 54007 should not match');
+
+  const ingress2 = [{ service: 'http://127.0.0.1:8080' }];
+  assertTrue(ingressMatchesPort(ingress2, 8080), '127.0.0.1 form should match');
+});
+
+// Regression: substring matching used to false-positive on port prefixes
+// (e.g. port 80 vs localhost:8080).
+runTest('ingressMatchesPort: does not false-positive on port-prefix substring', () => {
+  const ingress = [{ service: 'http://localhost:8080' }];
+  assertTrue(!ingressMatchesPort(ingress, 80), 'port 80 must not match localhost:8080');
+  assertTrue(!ingressMatchesPort(ingress, 8), 'port 8 must not match localhost:8080');
+  assertTrue(ingressMatchesPort(ingress, 8080), 'exact port still matches');
+});
+
+// Ensure non-http schemes and catch-all rules are ignored.
+runTest('ingressMatchesPort: ignores http_status, tcp, ssh schemes', () => {
+  assertTrue(
+    !ingressMatchesPort([{ service: 'http_status:404' }], 404),
+    'http_status catch-all never matches'
+  );
+  assertTrue(
+    !ingressMatchesPort([{ service: 'tcp://localhost:22' }], 22),
+    'tcp:// scheme never matches'
+  );
+  assertTrue(
+    !ingressMatchesPort([{ service: 'http://example.com:54006' }], 54006),
+    'non-localhost host never matches'
+  );
+});
+
+// Service URL with trailing path / query still matches on port.
+runTest('ingressMatchesPort: matches when service URL has a path or trailing slash', () => {
+  assertTrue(
+    ingressMatchesPort([{ service: 'http://localhost:54006/' }], 54006),
+    'trailing slash matches'
+  );
+  assertTrue(
+    ingressMatchesPort([{ service: 'http://localhost:54006/api' }], 54006),
+    'path suffix matches'
+  );
+});
+
+// ── Test 4: hostnameFromIngress ─────────────────────────────────────
+
+runTest('hostnameFromIngress: returns first hostname, skipping catch-all', () => {
+  const ingress = [{ hostname: 'a.example.com', service: 'http://localhost:1' }];
+  assertEqual(hostnameFromIngress(ingress), 'a.example.com', 'first hostname');
+  assertEqual(hostnameFromIngress(null), null, 'null ingress returns null');
+  assertEqual(
+    hostnameFromIngress([{ service: 'http_status:404' }]),
+    null,
+    'no hostname returns null'
+  );
+});
+
+// Regression: a tunnel routing several hostnames to several local ports
+// must return the hostname for the *matched* port.
+runTest('hostnameFromIngress: when port given, picks hostname bound to that port', () => {
+  const ingress = [
+    { hostname: 'other.example.dev', service: 'http://localhost:9999' },
+    { hostname: 'shooter.example.dev', service: 'http://localhost:54006' },
+    { service: 'http_status:404' },
+  ];
+  assertEqual(hostnameFromIngress(ingress, 54006), 'shooter.example.dev', 'matched-port hostname');
+  assertEqual(
+    hostnameFromIngress(ingress, 9999),
+    'other.example.dev',
+    'matched-port hostname (other entry)'
+  );
+  // No matching port — fall back to first hostname for back-compat.
+  assertEqual(
+    hostnameFromIngress(ingress, 1234),
+    'other.example.dev',
+    'no port match falls back to first hostname'
+  );
+});
+
+// ── Test 5: parseLaunchAgentPlist ───────────────────────────────────
+
+runTest('parseLaunchAgentPlist: extracts label and ProgramArguments', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.example.shooter-tunnel</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/cloudflared</string>
+        <string>tunnel</string>
+        <string>--config</string>
+        <string>/Users/foo/.cloudflared/shooter-config.yml</string>
+        <string>run</string>
+        <string>shooter-tunnel</string>
+    </array>
+</dict>
+</plist>`;
+  const p = parseLaunchAgentPlist(xml);
+  assertEqual(p.label, 'dev.example.shooter-tunnel', 'label');
+  assertDeepEqual(
+    p.programArguments,
+    [
+      '/opt/homebrew/bin/cloudflared',
+      'tunnel',
+      '--config',
+      '/Users/foo/.cloudflared/shooter-config.yml',
+      'run',
+      'shooter-tunnel',
+    ],
+    'ProgramArguments'
+  );
+});
+
+// Regression: rewritePlistBinaryPath escapes &/</>, so the parser must
+// unescape them on read — otherwise programArguments.includes(cfg.path)
+// silently fails after a heal cycle on a path containing those chars.
+runTest('parseLaunchAgentPlist: XML-unescapes &amp;, &lt;, &gt;, &quot;, &apos;', () => {
+  const xml = `<?xml version="1.0"?>
+<plist><dict>
+  <key>Label</key><string>dev.example.a&amp;b</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/a&amp;b/&lt;bin&gt;/cloudflared</string>
+    <string>he said &quot;hi&quot;</string>
+    <string>it&apos;s ok</string>
+  </array>
+</dict></plist>`;
+  const p = parseLaunchAgentPlist(xml);
+  assertEqual(p.label, 'dev.example.a&b', 'label entity decoded');
+  assertDeepEqual(
+    p.programArguments,
+    ['/Users/a&b/<bin>/cloudflared', 'he said "hi"', "it's ok"],
+    'all entities decoded in programArguments'
+  );
+});
+
+// ── Test 6: parseLaunchAgentPlist tolerates other arrays ────────────
+
+runTest('parseLaunchAgentPlist: only captures ProgramArguments array, not others', () => {
+  const xml = `<?xml version="1.0"?>
+<plist><dict>
+  <key>Label</key><string>x</string>
+  <key>WatchPaths</key>
+  <array>
+    <string>/var/something</string>
+    <string>/var/another</string>
+  </array>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/real/binary</string>
+    <string>run</string>
+  </array>
+</dict></plist>`;
+  const p = parseLaunchAgentPlist(xml);
+  assertDeepEqual(p.programArguments, ['/real/binary', 'run'], 'only ProgramArguments captured');
+});
+
+// ── Test 7: rewritePlistBinaryPath roundtrip ────────────────────────
+
+runTest('rewritePlistBinaryPath: rewrites binary, leaves rest intact, writes .bak', () => {
+  const tmp = path.join(os.tmpdir(), `shooter-tunnel-test-${process.pid}.plist`);
+  const xml = `<?xml version="1.0"?>
+<plist><dict>
+  <key>Label</key><string>dev.example.tun</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/cloudflared</string>
+    <string>tunnel</string>
+    <string>run</string>
+    <string>shooter-tunnel</string>
+  </array>
+</dict></plist>`;
+  try {
+    fs.writeFileSync(tmp, xml);
+
+    rewritePlistBinaryPath(tmp, '/usr/local/bin/cloudflared', '/opt/homebrew/bin/cloudflared');
+
+    const rewritten = fs.readFileSync(tmp, 'utf8');
+    assertTrue(
+      rewritten.includes('<string>/opt/homebrew/bin/cloudflared</string>'),
+      'new path present'
+    );
+    assertTrue(!rewritten.includes('<string>/usr/local/bin/cloudflared</string>'), 'old path gone');
+    // Subsequent args unchanged.
+    assertTrue(rewritten.includes('<string>tunnel</string>'), 'second arg untouched');
+    assertTrue(rewritten.includes('<string>shooter-tunnel</string>'), 'last arg untouched');
+
+    const bak = fs.readFileSync(tmp + '.bak', 'utf8');
+    assertEqual(bak, xml, '.bak preserves original');
+  } finally {
+    for (const f of [tmp, tmp + '.bak']) {
+      try {
+        if (fs.existsSync(f)) fs.unlinkSync(f);
+      } catch {
+        /* leave for next CI run to notice */
+      }
+    }
+  }
+});
+
+// Regression: parse decodes entities and rewrite encodes them, so the
+// equality check inside rewritePlistBinaryPath must compare in the
+// decoded domain — otherwise healing a path that contains XML special
+// chars throws "refusing to heal".
+runTest('rewritePlistBinaryPath: round-trips a path containing & without throwing', () => {
+  const tmp = path.join(os.tmpdir(), `shooter-tunnel-roundtrip-${process.pid}.plist`);
+  // Plist on disk: path with literal `&` is encoded as `&amp;`
+  const xml = `<?xml version="1.0"?>
+<plist><dict>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/a&amp;b/cloudflared</string>
+  </array>
+</dict></plist>`;
+  try {
+    fs.writeFileSync(tmp, xml);
+    // oldPath is what the parser would have produced — i.e. decoded.
+    rewritePlistBinaryPath(tmp, '/Users/a&b/cloudflared', '/opt/homebrew/bin/cloudflared');
+    const rewritten = fs.readFileSync(tmp, 'utf8');
+    assertTrue(
+      rewritten.includes('<string>/opt/homebrew/bin/cloudflared</string>'),
+      'new path present'
+    );
+    assertTrue(
+      !rewritten.includes('<string>/Users/a&amp;b/cloudflared</string>'),
+      'old encoded path gone'
+    );
+  } finally {
+    for (const f of [tmp, tmp + '.bak']) {
+      try {
+        if (fs.existsSync(f)) fs.unlinkSync(f);
+      } catch {
+        /* leave for next CI run to notice */
+      }
+    }
+  }
+});
+
+// ── XML-escape: paths with &, <, > must be encoded ──────────────────
+
+runTest('rewritePlistBinaryPath: XML-escapes newPath so & < > do not corrupt plist', () => {
+  const tmp = path.join(os.tmpdir(), `shooter-tunnel-xmlescape-${process.pid}.plist`);
+  const xml = `<?xml version="1.0"?>
+<plist><dict>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/cloudflared</string>
+  </array>
+</dict></plist>`;
+  try {
+    fs.writeFileSync(tmp, xml);
+    rewritePlistBinaryPath(tmp, '/usr/local/bin/cloudflared', '/Users/a&b/<bin>/cloudflared');
+    const rewritten = fs.readFileSync(tmp, 'utf8');
+    assertTrue(
+      rewritten.includes('<string>/Users/a&amp;b/&lt;bin&gt;/cloudflared</string>'),
+      'special chars are XML-encoded'
+    );
+    assertTrue(!rewritten.match(/<string>[^<]*<bin>[^<]*<\/string>/), 'no raw < inside <string>');
+  } finally {
+    for (const f of [tmp, tmp + '.bak']) {
+      try {
+        if (fs.existsSync(f)) fs.unlinkSync(f);
+      } catch {
+        /* leave for next CI run to notice */
+      }
+    }
+  }
+});
+
+// ── Test 8: rewritePlistBinaryPath refuses on mismatch ──────────────
+
+runTest('rewritePlistBinaryPath: refuses to rewrite when oldPath does not match', () => {
+  const tmp = path.join(os.tmpdir(), `shooter-tunnel-mismatch-${process.pid}.plist`);
+  const xml = `<?xml version="1.0"?>
+<plist><dict>
+  <key>ProgramArguments</key>
+  <array><string>/some/other/path</string></array>
+</dict></plist>`;
+  try {
+    fs.writeFileSync(tmp, xml);
+
+    let threw = false;
+    try {
+      rewritePlistBinaryPath(tmp, '/usr/local/bin/cloudflared', '/new/path');
+    } catch (err) {
+      threw = true;
+      assertTrue(
+        err.message.includes('expected /usr/local/bin/cloudflared'),
+        'error message mentions expected path'
+      );
+    }
+    assertTrue(threw, 'must throw on mismatch');
+
+    // File should be untouched.
+    assertEqual(fs.readFileSync(tmp, 'utf8'), xml, 'file untouched after refused rewrite');
+  } finally {
+    try {
+      if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
+    } catch {
+      /* leave for next CI run to notice */
+    }
+  }
+});
+
+// ── Summary ─────────────────────────────────────────────────────────
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Shooter's `tunnel` machinery only knew about quick (`--url`) tunnels. Named tunnels with custom hostnames (set up via a hand-written LaunchAgent) were invisible to `shooter status` and silently broke when the cloudflared binary moved (classic example: Intel Homebrew → Apple Silicon migration left `/usr/local/bin/cloudflared` as a dangling symlink, launchd hit `EX_CONFIG (78)`, the tunnel stayed down, the user only noticed because their public URL stopped responding).
- This PR makes both `shooter start` and `shooter status` discover named tunnels automatically (scan `~/.cloudflared/*.yml` + `~/Library/LaunchAgents/*.plist`), self-heal a stale binary path against `which cloudflared` (with a `.bak`), kickstart the agent if it's not running, and report end-to-end reachability of the public hostname in `status`.
- Falls back to the existing quick-tunnel flow when no named tunnel matches the listening port. Linux (systemd user units) is wired for discovery; auto-heal is macOS-only for now.

## What changed
- `bin/lib/tunnel-discovery.cjs` (new) — minimal YAML + plist parsers, discovery, `healAndEnsureRunning`, `probeReachability`.
- `bin/shooter.cjs` — new `ensureNamedTunnelOrFallback(port)` wraps the existing `startTunnel`/`stopTunnel`; called from both daemon and foreground branches of `cmdStart` and from `showStatus`.
- `tests/tunnel-discovery.test.cjs` (new) + `package.json` — 8 unit tests covering YAML parsing, plist parsing, ingress matching, and the `.bak`-preserving rewrite.

## Heal policy
- Detected stale binary → rewrite plist, write `.bak`, `launchctl bootout` + `bootstrap`, emit one `Tunnel plist binary path updated: <old> → <new>` log line. Refuses to touch the plist if the on-disk first-string doesn't match what discovery saw (defensive — prevents races).

## Test plan
- [x] `pnpm test` — 6 + 8 + 8 = 22 unit tests, all green
- [x] `pnpm lint` clean on touched files
- [x] Manual: forced `/usr/local/bin/cloudflared` back into the plist on a real Mac with cloudflared at `/opt/homebrew/bin/cloudflared`; `shooter start`-equivalent driver detected `healthy=false`, healed to `/opt/homebrew/bin/cloudflared`, agent reloaded, `shooter status` reported `Tunnel: https://<hostname> [reachable (200)]`
- [x] Manual: ran `shooter status` twice in a row → idempotent (no spurious heal, no spurious logs)
- [x] Verified `.tunnel_url` is preserved across stop/start when a named tunnel is in use (no quick-tunnel `tunnel.pid` is written, so `stopTunnel()` is a no-op)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discover and manage named Cloudflare tunnels on macOS and Linux; show HTTPS tunnel URL, state, reachability, and binary-health warnings.
  * Prefer named tunnels on start, fallback to quick tunnel; cancellable foreground timers and adjusted daemon startup behavior.
  * Persist discovered tunnel URL for callers.
  * Reachability probing for tunnel URLs.

* **Bug Fixes / Improvements**
  * Hardened autostart plist generation with XML-escaped values and more reliable launchctl operations.
  * Automatic heal/reload for launchd-managed tunnels; Linux units discovered but not auto-healed.

* **Tests**
  * Added tests covering config parsing, plist rewrite behavior, port matching, hostname extraction, and reachability helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/shooter/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->