### PR TITLE
feat(decisions): shared infrastructure for dynamic-option notifications

### DIFF
--- a/ios/Shooter/Shooter/Config.swift
+++ b/ios/Shooter/Shooter/Config.swift
@@ -8,6 +8,8 @@ struct AppConfig {
     struct Endpoints {
         static let health = "/api/health"
         static let response = "/api/response"
+        /// GET /api/decide/<requestId> — full payload for the Decide screen.
+        static let decide = "/api/decide"
     }
 
     // App Information
@@ -21,14 +23,51 @@ struct AppConfig {
     // Notification Configuration
     struct Notifications {
         // Interactive notification action identifiers
+        //
+        // Values match the DecisionKind union on the server
+        // (src/lib/types/decision.ts). Lock-screen buttons POST these
+        // strings to /api/response and the server treats them as
+        // DecisionKind values.
         struct Actions {
+            // ─── PermissionRequest (binary) ─────────────────────────
             static let allow = "ALLOW_ACTION"
             static let deny = "DENY_ACTION"
+
+            // ─── Generic numbered choices (MCP elicitation, AskUserQuestion) ───
+            // The body text tells the user what each option means; the
+            // button label itself is just "Option N". Capped at 4 per
+            // iOS notification action limit.
+            static let option1 = "OPTION_1_ACTION"
+            static let option2 = "OPTION_2_ACTION"
+            static let option3 = "OPTION_3_ACTION"
+            static let option4 = "OPTION_4_ACTION"
+
+            // ─── Plan-mode approval (ExitPlanMode) ─────────────────
+            static let planAuto = "PLAN_AUTO_ACTION"
+            static let planAccept = "PLAN_ACCEPT_ACTION"
+            static let planReview = "PLAN_REVIEW_ACTION"
+            static let planKeep = "PLAN_KEEP_ACTION"
+
+            // ─── Fallback action present on every category ─────────
+            // Opens the app to the Decide screen instead of sending a
+            // decision. Used when the dynamic options don't fit lock-
+            // screen buttons (>4 choices) or the user wants more
+            // context before deciding.
+            static let openInApp = "OPEN_IN_APP_ACTION"
         }
 
         // Interactive notification category identifiers
+        //
+        // Each category is pre-registered at app launch with a fixed
+        // action set. iOS doesn't allow per-notification dynamic action
+        // labels, so the server picks the right category based on the
+        // event kind + option count.
         struct Categories {
             static let permission = "CLAUDE_PERMISSION"
+            static let planApproval = "CLAUDE_PLAN_APPROVAL"
+            static let choice2 = "CLAUDE_CHOICE_2"
+            static let choice3 = "CLAUDE_CHOICE_3"
+            static let choice4 = "CLAUDE_CHOICE_4"
         }
     }
 

--- a/ios/Shooter/Shooter/ContentView.swift
+++ b/ios/Shooter/Shooter/ContentView.swift
@@ -9,12 +9,187 @@ struct ContentView: View {
         WebView(url: serverURL, notificationManager: notificationManager)
             .ignoresSafeArea(edges: .bottom)
             .background(Color(red: 10/255, green: 10/255, blue: 10/255))
+            // @EnvironmentObject doesn't project a Binding via `$`, so
+            // bridge the @Published String? manually for .sheet(item:).
+            .sheet(item: Binding(
+                get: { notificationManager.decideRequestId },
+                set: { notificationManager.decideRequestId = $0 }
+            )) { requestId in
+                DecideView(requestId: requestId.value)
+                    .environmentObject(notificationManager)
+            }
     }
 
     private var serverURL: URL {
         let saved = UserDefaults.standard.string(forKey: "serverUrl") ?? ""
         let urlString = saved.isEmpty ? AppConfig.defaultServerURL : saved
         return URL(string: urlString) ?? URL(string: AppConfig.defaultServerURL)!
+    }
+}
+
+// MARK: - Decide Screen
+//
+// Presented when the user taps the notification body OR the
+// "Open in Shooter" action on a dynamic-options push. Fetches the
+// full options list from /api/decide/<requestId> and renders a
+// proper button per option — works for any option count, any label,
+// and shows the full question text without the lock-screen 4-line
+// truncation.
+
+private struct DecidePayloadDTO: Decodable {
+    let requestId: String
+    let question: String
+    let options: [OptionChoiceDTO]
+    let responseKind: String
+    let toolName: String?
+}
+
+private struct OptionChoiceDTO: Decodable, Identifiable {
+    let id: String
+    let label: String
+    let hint: String?
+}
+
+private enum DecideLoadState {
+    case loading
+    case loaded(DecidePayloadDTO)
+    case error(String)
+}
+
+struct DecideView: View {
+    let requestId: String
+
+    @EnvironmentObject var notificationManager: NotificationManager
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var state: DecideLoadState = .loading
+    @State private var submitting = false
+
+    private var serverUrl: String {
+        UserDefaults.standard.string(forKey: "serverUrl") ?? AppConfig.defaultServerURL
+    }
+
+    private var apiKey: String {
+        KeychainHelper.read(key: "apiKey") ?? ""
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Decide")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Close") { dismiss() }
+                    }
+                }
+        }
+        .task { await load() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .loading:
+            ProgressView("Loading…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .error(let message):
+            VStack(spacing: 16) {
+                Text("Couldn't load")
+                    .font(.headline)
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+                Button("Retry") {
+                    state = .loading
+                    Task { await load() }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
+        case .loaded(let payload):
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    if let toolName = payload.toolName, !toolName.isEmpty {
+                        Text(toolName)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .textCase(.uppercase)
+                    }
+                    Text(payload.question.isEmpty ? "Choose an option" : payload.question)
+                        .font(.title3.weight(.semibold))
+
+                    ForEach(payload.options) { option in
+                        Button { submit(decision: option.id) } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(option.label)
+                                    .font(.body.weight(.medium))
+                                if let hint = option.hint, !hint.isEmpty {
+                                    Text(hint)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .fill(Color(white: 0.15))
+                            )
+                        }
+                        .disabled(submitting)
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        guard let url = URL(string: "\(serverUrl)\(AppConfig.Endpoints.decide)/\(requestId)") else {
+            state = .error("Invalid server URL")
+            return
+        }
+        guard !apiKey.isEmpty else {
+            state = .error("No API key configured. Open Settings and re-scan the QR code.")
+            return
+        }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                state = .error("No HTTP response")
+                return
+            }
+            if http.statusCode == 404 {
+                state = .error("Request not found or already answered.")
+                return
+            }
+            if !(200...299).contains(http.statusCode) {
+                state = .error("Server returned HTTP \(http.statusCode)")
+                return
+            }
+            let payload = try JSONDecoder().decode(DecidePayloadDTO.self, from: data)
+            state = .loaded(payload)
+        } catch {
+            state = .error(error.localizedDescription)
+        }
+    }
+
+    private func submit(decision: String) {
+        submitting = true
+        notificationManager.sendDecisionResponse(requestId: requestId, decision: decision)
+        // Optimistic dismiss — NotificationManager retries with backoff if
+        // the POST fails, so the user shouldn't have to wait for HTTP.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            dismiss()
+        }
     }
 }
 

--- a/ios/Shooter/Shooter/NotificationManager.swift
+++ b/ios/Shooter/Shooter/NotificationManager.swift
@@ -2,10 +2,27 @@ import Foundation
 import UserNotifications
 import UIKit
 
+/// Identifiable wrapper around a String requestId so SwiftUI's
+/// .sheet(item:) can drive the Decide screen from
+/// `NotificationManager.decideRequestId`.
+struct DecideRequestId: Identifiable {
+    let value: String
+    var id: String { value }
+}
+
 class NotificationManager: NSObject, ObservableObject {
     @Published var isAuthorized = false
     @Published var deviceToken: String?
     @Published var isConnected = false
+
+    /// Request ID of a pending notification the user tapped (either the
+    /// notification body or the "Open in Shooter" action). The UI
+    /// observes this and presents DecideView for richer interaction
+    /// than the lock-screen quick-tap buttons allow.
+    ///
+    /// Wrapped in DecideRequestId so SwiftUI's .sheet(item:) can use it
+    /// (String isn't Identifiable on its own).
+    @Published var decideRequestId: DecideRequestId?
 
     private var serverUrl: String {
         UserDefaults.standard.string(forKey: "serverUrl") ?? AppConfig.defaultServerURL
@@ -39,30 +56,123 @@ class NotificationManager: NSObject, ObservableObject {
         }
     }
 
-    // MARK: - Notification Categories (Interactive Allow/Deny)
+    // MARK: - Notification Categories
+    //
+    // iOS requires categories to be pre-registered with a fixed action
+    // set; per-notification dynamic labels are not supported. We
+    // register one category per supported event shape (binary
+    // permission, plan-mode 4-way, generic numbered choices 2/3/4) and
+    // the server picks which one to use in each push's aps.category.
+    //
+    // Every category includes an "Open in Shooter" action as a
+    // fallback so the user can always reach the in-app Decide screen
+    // for richer context.
 
     private func setupNotificationCategories() {
+        let openInAppAction = UNNotificationAction(
+            identifier: AppConfig.Notifications.Actions.openInApp,
+            title: "Open in Shooter",
+            options: [.foreground]
+        )
+
+        // ─── CLAUDE_PERMISSION ──────────────────────────────────────
         let allowAction = UNNotificationAction(
             identifier: AppConfig.Notifications.Actions.allow,
             title: "Allow",
             options: [.authenticationRequired]
         )
-
         let denyAction = UNNotificationAction(
             identifier: AppConfig.Notifications.Actions.deny,
             title: "Deny",
             options: [.destructive]
         )
-
         let permissionCategory = UNNotificationCategory(
             identifier: AppConfig.Notifications.Categories.permission,
-            actions: [allowAction, denyAction],
+            actions: [allowAction, denyAction, openInAppAction],
             intentIdentifiers: [],
             options: []
         )
 
-        UNUserNotificationCenter.current().setNotificationCategories([permissionCategory])
-        print("Registered notification categories: CLAUDE_PERMISSION (Allow/Deny)")
+        // ─── CLAUDE_PLAN_APPROVAL ───────────────────────────────────
+        let planAutoAction = UNNotificationAction(
+            identifier: AppConfig.Notifications.Actions.planAuto,
+            title: "Auto Mode",
+            options: [.authenticationRequired]
+        )
+        let planAcceptAction = UNNotificationAction(
+            identifier: AppConfig.Notifications.Actions.planAccept,
+            title: "Accept Edits",
+            options: [.authenticationRequired]
+        )
+        let planReviewAction = UNNotificationAction(
+            identifier: AppConfig.Notifications.Actions.planReview,
+            title: "Review Each",
+            options: [.authenticationRequired]
+        )
+        let planKeepAction = UNNotificationAction(
+            identifier: AppConfig.Notifications.Actions.planKeep,
+            title: "Keep Planning",
+            options: []
+        )
+        let planApprovalCategory = UNNotificationCategory(
+            identifier: AppConfig.Notifications.Categories.planApproval,
+            // iOS caps lock-screen action buttons at 4 — when adding a
+            // 5th the OS hides actions behind the contextual menu. We
+            // chose Auto/Accept/Review + Open-in-app to keep the
+            // common-case taps surfaced; "Keep planning" is reachable
+            // via Open-in-app's Decide screen.
+            actions: [planAutoAction, planAcceptAction, planReviewAction, openInAppAction],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        // ─── CLAUDE_CHOICE_2 / 3 / 4 ────────────────────────────────
+        // Numbered options. The body text tells the user what each
+        // option means (e.g. "1. Use frontend  2. Use backend").
+        let option1 = numberedAction(id: AppConfig.Notifications.Actions.option1, title: "Option 1")
+        let option2 = numberedAction(id: AppConfig.Notifications.Actions.option2, title: "Option 2")
+        let option3 = numberedAction(id: AppConfig.Notifications.Actions.option3, title: "Option 3")
+        let option4 = numberedAction(id: AppConfig.Notifications.Actions.option4, title: "Option 4")
+
+        let choice2Category = UNNotificationCategory(
+            identifier: AppConfig.Notifications.Categories.choice2,
+            actions: [option1, option2, openInAppAction],
+            intentIdentifiers: [],
+            options: []
+        )
+        let choice3Category = UNNotificationCategory(
+            identifier: AppConfig.Notifications.Categories.choice3,
+            actions: [option1, option2, option3, openInAppAction],
+            intentIdentifiers: [],
+            options: []
+        )
+        // For 4 choices we exceed the lock-screen quick-tap limit when
+        // including Open-in-app — iOS will collapse extras into "..."
+        // automatically. Listing all 4 + Open-in-app keeps the in-app
+        // path always reachable.
+        let choice4Category = UNNotificationCategory(
+            identifier: AppConfig.Notifications.Categories.choice4,
+            actions: [option1, option2, option3, option4, openInAppAction],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        UNUserNotificationCenter.current().setNotificationCategories([
+            permissionCategory,
+            planApprovalCategory,
+            choice2Category,
+            choice3Category,
+            choice4Category
+        ])
+        print("Registered notification categories: PERMISSION, PLAN_APPROVAL, CHOICE_2/3/4")
+    }
+
+    private func numberedAction(id: String, title: String) -> UNNotificationAction {
+        UNNotificationAction(
+            identifier: id,
+            title: title,
+            options: [.authenticationRequired]
+        )
     }
 
     // MARK: - Authorization Status
@@ -161,10 +271,11 @@ class NotificationManager: NSObject, ObservableObject {
     /// Maximum retry attempts for permission responses.
     private static let maxRetryAttempts = 3
 
-    /// Send a permission response with exponential backoff retry (H5 fix).
-    private func sendPermissionResponse(requestId: String, decision: String) {
+    /// Send a decision response with exponential backoff retry (H5 fix).
+    /// Used both by lock-screen action taps and the in-app Decide screen.
+    func sendDecisionResponse(requestId: String, decision: String) {
         guard let url = URL(string: "\(serverUrl)\(AppConfig.Endpoints.response)") else {
-            print("Invalid server URL for permission response")
+            print("Invalid server URL for decision response")
             return
         }
 
@@ -181,44 +292,66 @@ class NotificationManager: NSObject, ObservableObject {
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
         } catch {
-            print("Failed to encode permission response: \(error)")
+            print("Failed to encode decision response: \(error)")
             return
         }
 
-        attemptPermissionResponse(request: request, decision: decision, attempt: 1)
+        attemptDecisionResponse(request: request, decision: decision, attempt: 1)
     }
 
-    private func attemptPermissionResponse(request: URLRequest, decision: String, attempt: Int) {
+    private func attemptDecisionResponse(request: URLRequest, decision: String, attempt: Int) {
         URLSession.shared.dataTask(with: request) { [weak self] _, response, error in
             guard let self = self else { return }
 
             if let error = error {
                 if attempt < Self.maxRetryAttempts {
                     let delay = pow(2.0, Double(attempt)) // 2s, 4s, 8s
-                    print("Permission response attempt \(attempt) failed: \(error). Retrying in \(delay)s...")
+                    print("Decision response attempt \(attempt) failed: \(error). Retrying in \(delay)s...")
                     DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
-                        self.attemptPermissionResponse(request: request, decision: decision, attempt: attempt + 1)
+                        self.attemptDecisionResponse(request: request, decision: decision, attempt: attempt + 1)
                     }
                 } else {
-                    print("Permission response FAILED after \(Self.maxRetryAttempts) attempts: \(error)")
+                    print("Decision response FAILED after \(Self.maxRetryAttempts) attempts: \(error)")
                 }
                 return
             }
 
             if let httpResponse = response as? HTTPURLResponse {
                 if (200...299).contains(httpResponse.statusCode) {
-                    print("Permission response sent (\(decision)): HTTP \(httpResponse.statusCode)")
+                    print("Decision response sent (\(decision)): HTTP \(httpResponse.statusCode)")
                 } else if attempt < Self.maxRetryAttempts {
                     let delay = pow(2.0, Double(attempt))
-                    print("Permission response attempt \(attempt) got HTTP \(httpResponse.statusCode). Retrying in \(delay)s...")
+                    print("Decision response attempt \(attempt) got HTTP \(httpResponse.statusCode). Retrying in \(delay)s...")
                     DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
-                        self.attemptPermissionResponse(request: request, decision: decision, attempt: attempt + 1)
+                        self.attemptDecisionResponse(request: request, decision: decision, attempt: attempt + 1)
                     }
                 } else {
-                    print("Permission response FAILED after \(Self.maxRetryAttempts) attempts: HTTP \(httpResponse.statusCode)")
+                    print("Decision response FAILED after \(Self.maxRetryAttempts) attempts: HTTP \(httpResponse.statusCode)")
                 }
             }
         }.resume()
+    }
+}
+
+// MARK: - Action ID → DecisionKind mapping
+
+/// Translate an iOS notification action identifier into the DecisionKind
+/// string the server expects on POST /api/response. Returns nil for
+/// non-decision actions (Open in Shooter, dismiss, default-tap) — those
+/// route to the Decide screen instead of sending a response.
+private func decisionFor(actionIdentifier: String) -> String? {
+    switch actionIdentifier {
+    case AppConfig.Notifications.Actions.allow:       return "allow"
+    case AppConfig.Notifications.Actions.deny:        return "deny"
+    case AppConfig.Notifications.Actions.option1:     return "option_1"
+    case AppConfig.Notifications.Actions.option2:     return "option_2"
+    case AppConfig.Notifications.Actions.option3:     return "option_3"
+    case AppConfig.Notifications.Actions.option4:     return "option_4"
+    case AppConfig.Notifications.Actions.planAuto:    return "plan_auto"
+    case AppConfig.Notifications.Actions.planAccept:  return "plan_accept"
+    case AppConfig.Notifications.Actions.planReview:  return "plan_review"
+    case AppConfig.Notifications.Actions.planKeep:    return "plan_keep"
+    default: return nil
     }
 }
 
@@ -233,29 +366,25 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
     ) {
         let userInfo = response.notification.request.content.userInfo
         let actionIdentifier = response.actionIdentifier
-        let categoryIdentifier = response.notification.request.content.categoryIdentifier
+        let requestId = userInfo["requestId"] as? String
 
-        // Handle interactive permission responses (Allow/Deny from notification)
-        if categoryIdentifier == AppConfig.Notifications.Categories.permission {
-            let requestId = userInfo["requestId"] as? String
-            var decision: String? = nil
-
-            switch actionIdentifier {
-            case AppConfig.Notifications.Actions.allow:
-                decision = "allow"
-            case AppConfig.Notifications.Actions.deny:
-                decision = "deny"
-            case UNNotificationDismissActionIdentifier:
-                // Dismissed -- hook will timeout and fall through to local dialog
-                break
-            default:
-                // Tapped notification body (opened app) -- no decision
-                break
-            }
-
-            if let decision = decision, let requestId = requestId {
-                sendPermissionResponse(requestId: requestId, decision: decision)
-            }
+        if actionIdentifier == AppConfig.Notifications.Actions.openInApp,
+           let requestId = requestId {
+            // User explicitly asked to make the decision in-app — show
+            // the Decide screen for richer context / unlimited options.
+            DispatchQueue.main.async { self.decideRequestId = DecideRequestId(value: requestId) }
+        } else if actionIdentifier == UNNotificationDefaultActionIdentifier,
+                  let requestId = requestId {
+            // User tapped the notification body (not an action button).
+            // Open the Decide screen so they see context before
+            // choosing.
+            DispatchQueue.main.async { self.decideRequestId = DecideRequestId(value: requestId) }
+        } else if actionIdentifier == UNNotificationDismissActionIdentifier {
+            // Dismissed -- hook will timeout and fall through to the
+            // local CC permission dialog. No-op on our side.
+        } else if let decision = decisionFor(actionIdentifier: actionIdentifier),
+                  let requestId = requestId {
+            sendDecisionResponse(requestId: requestId, decision: decision)
         }
 
         completionHandler()

--- a/src/lib/modules/server/apn/pending-requests.ts
+++ b/src/lib/modules/server/apn/pending-requests.ts
@@ -2,15 +2,28 @@
  * Pending Permission Requests Store — SQLite persistence.
  *
  * Persists in-flight permission requests so they survive server
- * restarts. Used by `/api/notify` (creates entries) and `/api/response`
- * (reads/updates decisions). notifier.cjs polls `/api/response` via
- * HTTP, so persisting the row is sufficient — there are no in-process
- * callbacks that need recovery.
+ * restarts. Used by `/api/notify` (creates entries), `/api/response`
+ * (reads/updates decisions), and `/api/decide/[id]` (returns the
+ * question + options for the iOS Decide screen). notifier.cjs polls
+ * `/api/response` via HTTP, so persisting the row is sufficient —
+ * there are no in-process callbacks that need recovery.
  *
  * Database location: `~/.shooter/shooter.db` (shared with terminal-store).
+ *
+ * Schema evolution: the original table had only the binary
+ * permission columns. Newer columns (question, options, response_kind)
+ * support dynamic-options notifications (plan-mode, MCP elicitation,
+ * AskUserQuestion). They are added via ALTER TABLE if missing, so the
+ * store works against both fresh DBs and DBs from older versions.
  */
 
-import type { PendingRequest } from '$lib/types';
+import type {
+  DecisionKind,
+  OptionChoice,
+  PendingRequest,
+  PendingRequestRich,
+  ResponseKind,
+} from '$lib/types';
 
 import Database from 'better-sqlite3';
 import * as fs from 'fs';
@@ -32,15 +45,19 @@ export class PendingRequestsStore {
     this.db.pragma('journal_mode = WAL');
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS pending_requests (
-        request_id  TEXT PRIMARY KEY,
-        session_id  TEXT NOT NULL,
-        tool_name   TEXT NOT NULL,
-        tool_input  TEXT NOT NULL DEFAULT '{}',
-        decision    TEXT,
-        created_at  INTEGER NOT NULL,
-        decided_at  INTEGER
+        request_id    TEXT PRIMARY KEY,
+        session_id    TEXT NOT NULL,
+        tool_name     TEXT NOT NULL,
+        tool_input    TEXT NOT NULL DEFAULT '{}',
+        decision      TEXT,
+        created_at    INTEGER NOT NULL,
+        decided_at    INTEGER,
+        question      TEXT,
+        options       TEXT NOT NULL DEFAULT '[]',
+        response_kind TEXT NOT NULL DEFAULT 'hook'
       )
     `);
+    this.migrate();
   }
 
   cleanup(maxAgeMs: number): number {
@@ -60,9 +77,23 @@ export class PendingRequestsStore {
     return row ? rowToRecord(row) : null;
   }
 
+  getRich(requestId: string): null | PendingRequestRich {
+    const row = this.db
+      .prepare('SELECT * FROM pending_requests WHERE request_id = ?')
+      .get(requestId) as Record<string, unknown> | undefined;
+    return row ? rowToRich(row) : null;
+  }
+
   insert(
     requestId: string,
-    data: { sessionId: string; toolInput: Record<string, unknown>; toolName: string }
+    data: {
+      options?: OptionChoice[];
+      question?: null | string;
+      responseKind?: ResponseKind;
+      sessionId: string;
+      toolInput: Record<string, unknown>;
+      toolName: string;
+    }
   ): void {
     // INSERT OR REPLACE matches the old Map.set semantics: a second
     // create with the same requestId silently overwrites instead of
@@ -70,38 +101,118 @@ export class PendingRequestsStore {
     this.db
       .prepare(
         `INSERT OR REPLACE INTO pending_requests
-         (request_id, session_id, tool_name, tool_input, decision, created_at, decided_at)
-         VALUES (?, ?, ?, ?, NULL, ?, NULL)`
+         (request_id, session_id, tool_name, tool_input, decision, created_at, decided_at, question, options, response_kind)
+         VALUES (?, ?, ?, ?, NULL, ?, NULL, ?, ?, ?)`
       )
-      .run(requestId, data.sessionId, data.toolName, JSON.stringify(data.toolInput), Date.now());
+      .run(
+        requestId,
+        data.sessionId,
+        data.toolName,
+        JSON.stringify(data.toolInput),
+        Date.now(),
+        data.question ?? null,
+        JSON.stringify(data.options ?? []),
+        data.responseKind ?? 'hook'
+      );
   }
 
-  setDecision(requestId: string, decision: 'allow' | 'deny'): boolean {
+  setDecision(requestId: string, decision: DecisionKind): boolean {
     const result = this.db
       .prepare('UPDATE pending_requests SET decision = ?, decided_at = ? WHERE request_id = ?')
       .run(decision, Date.now(), requestId);
     return result.changes > 0;
   }
+
+  /**
+   * Add columns introduced in later versions. Idempotent — uses
+   * PRAGMA table_info to check before each ALTER TABLE so re-running
+   * against a fully-migrated DB is a no-op.
+   */
+  private migrate(): void {
+    const cols = this.db.prepare('PRAGMA table_info(pending_requests)').all() as {
+      name: string;
+    }[];
+    const existing = new Set(cols.map((c) => c.name));
+    const wanted: { name: string; sql: string }[] = [
+      { name: 'question', sql: 'ALTER TABLE pending_requests ADD COLUMN question TEXT' },
+      {
+        name: 'options',
+        sql: "ALTER TABLE pending_requests ADD COLUMN options TEXT NOT NULL DEFAULT '[]'",
+      },
+      {
+        name: 'response_kind',
+        sql: "ALTER TABLE pending_requests ADD COLUMN response_kind TEXT NOT NULL DEFAULT 'hook'",
+      },
+    ];
+    for (const col of wanted) {
+      if (!existing.has(col.name)) {
+        this.db.exec(col.sql);
+      }
+    }
+  }
+}
+
+function parseOptions(raw: unknown): OptionChoice[] {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed as OptionChoice[];
+    }
+  } catch {
+    // corrupt JSON — fall back to empty
+  }
+  return [];
+}
+
+function parseToolInput(raw: unknown): Record<string, unknown> {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // corrupt JSON — fall back to empty
+  }
+  return {};
 }
 
 function rowToRecord(row: Record<string, unknown>): PendingRequest {
-  let toolInput: Record<string, unknown> = {};
-  if (typeof row.tool_input === 'string' && row.tool_input.length > 0) {
-    try {
-      const parsed: unknown = JSON.parse(row.tool_input);
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        toolInput = parsed as Record<string, unknown>;
-      }
-    } catch {
-      // Corrupt JSON — fall back to empty.
-    }
-  }
+  // Legacy adapter — only exposes the binary-decision fields the older
+  // PendingRequest YAML type knows about. New callers should use
+  // rowToRich() / getRich() instead.
+  const decision = row.decision;
   return {
     createdAt: row.created_at as number,
     decidedAt: (row.decided_at as null | number) ?? null,
-    decision: (row.decision as null | PendingRequest['decision']) ?? null,
+    decision: decision === 'allow' || decision === 'deny' ? decision : null,
     sessionId: row.session_id as string,
-    toolInput,
+    toolInput: parseToolInput(row.tool_input),
+    toolName: row.tool_name as string,
+  };
+}
+
+function rowToRich(row: Record<string, unknown>): PendingRequestRich {
+  const responseKindRaw = typeof row.response_kind === 'string' ? row.response_kind : 'hook';
+  const responseKind: ResponseKind =
+    responseKindRaw === 'hook' || responseKindRaw === 'pty' || responseKindRaw === 'info'
+      ? responseKindRaw
+      : 'hook';
+  return {
+    createdAt: row.created_at as number,
+    decidedAt: (row.decided_at as null | number) ?? null,
+    decision: (row.decision as DecisionKind | null) ?? null,
+    options: parseOptions(row.options),
+    question: (row.question as null | string) ?? null,
+    requestId: row.request_id as string,
+    responseKind,
+    sessionId: row.session_id as string,
+    toolInput: parseToolInput(row.tool_input),
     toolName: row.tool_name as string,
   };
 }
@@ -120,17 +231,24 @@ export function cleanup(maxAgeMs: number = MAX_AGE_MS): void {
 
 export function createPendingRequest(
   requestId: string,
-  data: { sessionId: string; toolInput: Record<string, unknown>; toolName: string }
+  data: {
+    options?: OptionChoice[];
+    question?: null | string;
+    responseKind?: ResponseKind;
+    sessionId: string;
+    toolInput: Record<string, unknown>;
+    toolName: string;
+  }
 ): void {
   cleanup();
   pendingRequestsStore.insert(requestId, data);
 }
 
 export function getDecision(requestId: string): {
-  decision?: 'allow' | 'deny';
+  decision?: DecisionKind;
   status: 'decided' | 'not_found' | 'pending';
 } {
-  const entry = pendingRequestsStore.get(requestId);
+  const entry = pendingRequestsStore.getRich(requestId);
   if (!entry) {
     return { status: 'not_found' };
   }
@@ -143,6 +261,11 @@ export function getDecision(requestId: string): {
   return { status: 'pending' };
 }
 
-export function setDecision(requestId: string, decision: 'allow' | 'deny'): boolean {
+/** Used by /api/decide/[requestId] to render the Decide screen. */
+export function getRichRequest(requestId: string): null | PendingRequestRich {
+  return pendingRequestsStore.getRich(requestId);
+}
+
+export function setDecision(requestId: string, decision: DecisionKind): boolean {
   return pendingRequestsStore.setDecision(requestId, decision);
 }

--- a/src/lib/types/decision.ts
+++ b/src/lib/types/decision.ts
@@ -1,0 +1,114 @@
+// Dynamic-options decision types. Hand-written because the value sets are
+// unions that vary by event kind (permission allow/deny, plan-mode
+// approval modes, generic numbered choices) and YAML can express each
+// enum but not the discriminated union over the response routing kind.
+//
+// These extend the binary PermissionDecision enum generated from
+// specs/types/notification.yaml. PermissionDecision (`allow | deny`)
+// remains the legacy type for callers that only ever needed binary;
+// DecisionKind is the new umbrella accepted by /api/response.
+
+/**
+ * Every decision value /api/response accepts.
+ *
+ * - `allow` / `deny` — binary PermissionRequest answer.
+ * - `plan_auto` / `plan_accept` / `plan_review` / `plan_keep` — ExitPlanMode
+ *   approval modes mirroring Claude Code's plan-mode menu.
+ * - `option_1`..`option_4` — generic numbered choices used by MCP
+ *   elicitation forms and AskUserQuestion. The actual label for each
+ *   option lives in the persisted `options[]` array; the index here is
+ *   1-based to match the body-text rendering.
+ */
+export type DecisionKind =
+  | 'allow'
+  | 'deny'
+  | 'option_1'
+  | 'option_2'
+  | 'option_3'
+  | 'option_4'
+  | 'plan_accept'
+  | 'plan_auto'
+  | 'plan_keep'
+  | 'plan_review';
+
+/**
+ * How the server should route a user's decision back to Claude Code.
+ *
+ * - `hook` — Claude Code's notifier.cjs is blocked in a poll loop on
+ *   /api/response and will read the decision from there, then write it
+ *   to stdout as the hook's response (allow/deny + optional extras).
+ * - `pty`  — the active session lives inside a Shooter-managed PTY;
+ *   server writes the chosen option's keystrokes to the PTY's stdin so
+ *   Claude Code reads it as if the user typed at the laptop.
+ * - `info` — informational only; no answer routes back to Claude Code.
+ *   The push exists to nudge the user to the laptop.
+ */
+export type ResponseKind = 'hook' | 'info' | 'pty';
+
+/** All valid DecisionKind values. Exported so /api/response can validate. */
+export const DECISION_KINDS: readonly DecisionKind[] = [
+  'allow',
+  'deny',
+  'option_1',
+  'option_2',
+  'option_3',
+  'option_4',
+  'plan_accept',
+  'plan_auto',
+  'plan_keep',
+  'plan_review',
+] as const;
+
+/**
+ * Full payload returned by GET /api/decide/[requestId] for the iOS
+ * Decide screen to render. Includes everything the screen needs without
+ * a second round-trip.
+ */
+export interface DecidePayload {
+  options: OptionChoice[];
+  question: string;
+  requestId: string;
+  responseKind: ResponseKind;
+  toolInput?: Record<string, unknown>;
+  /** Snapshot of the tool input that triggered the prompt (for context). */
+  toolName?: string;
+}
+
+/**
+ * One choice rendered to the user. Persisted as JSON in
+ * pending_requests.options and returned from /api/decide/[id] to the
+ * iOS Decide screen.
+ */
+export interface OptionChoice {
+  /** Optional secondary text shown beneath the label in the Decide screen. */
+  hint?: string;
+  /** Decision value the iOS app POSTs to /api/response when this is tapped. */
+  id: DecisionKind;
+  /** Human-readable label ("Use frontend", "Auto mode", etc.). */
+  label: string;
+}
+
+/**
+ * Richer view of a pending_requests row that includes the
+ * dynamic-options columns (question, options, responseKind). The
+ * legacy `PendingRequest` type (binary `decision`, no question/options)
+ * remains the public surface for callers that don't care about dynamic
+ * options. Used by PendingRequestsStore and /api/decide/[id].
+ */
+export interface PendingRequestRich {
+  createdAt: number;
+  decidedAt: null | number;
+  decision: DecisionKind | null;
+  options: OptionChoice[];
+  question: null | string;
+  requestId: string;
+  responseKind: ResponseKind;
+  sessionId: string;
+  toolInput: Record<string, unknown>;
+  toolName: string;
+}
+
+/** Type guard for incoming strings from HTTP requests. */
+export function isDecisionKind(value: unknown): value is DecisionKind {
+  return typeof value === 'string' && (DECISION_KINDS as readonly string[]).includes(value);
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -6,6 +6,7 @@ export type * from './apn';
 export type * from './cli';
 export type * from './common';
 export type * from './dashboard';
+export * from './decision';
 export * from './generated';
 export type * from './neurolink';
 export type * from './server';

--- a/src/routes/api/decide/[requestId]/+server.ts
+++ b/src/routes/api/decide/[requestId]/+server.ts
@@ -1,0 +1,46 @@
+import type { DecidePayload } from '$lib/types';
+
+import { getRichRequest } from '$lib/modules/server/apn/pending-requests';
+import { validateAuth } from '$lib/modules/server/auth';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+// GET /api/decide/[requestId]
+//
+// Returns the full Decide payload (question + options + responseKind +
+// tool context) for the iOS Decide screen to render. Called when the
+// user taps the notification body (or the "Open in Shooter" action)
+// instead of one of the lock-screen quick-tap buttons.
+//
+// Separated from `/api/response` GET (which is the lightweight polling
+// endpoint that returns only the decision) so the rich payload can
+// evolve independently and only fires when the iOS screen actually
+// needs the full context.
+export const GET: RequestHandler = ({ params, request }) => {
+  const authErr = validateAuth(request);
+  if (authErr) {
+    return authErr;
+  }
+
+  const requestId = params.requestId;
+  if (!requestId) {
+    return json({ error: 'requestId path parameter is required' }, { status: 400 });
+  }
+
+  const entry = getRichRequest(requestId);
+  if (!entry) {
+    return json({ error: 'Request not found or expired' }, { status: 404 });
+  }
+
+  const payload: DecidePayload = {
+    options: entry.options,
+    question: entry.question ?? '',
+    requestId: entry.requestId,
+    responseKind: entry.responseKind,
+    toolInput: entry.toolInput,
+    toolName: entry.toolName,
+  };
+
+  return json(payload);
+};

--- a/src/routes/api/response/+server.ts
+++ b/src/routes/api/response/+server.ts
@@ -1,11 +1,31 @@
-import { cleanup, getDecision, setDecision } from '$lib/modules/server/apn/pending-requests';
+import {
+  cleanup,
+  getDecision,
+  getRichRequest,
+  setDecision,
+} from '$lib/modules/server/apn/pending-requests';
 import { validateAuth } from '$lib/modules/server/auth';
 import { toErrorMessage } from '$lib/modules/server/utils/error';
+import { type DecisionKind, isDecisionKind } from '$lib/types';
 import { json } from '@sveltejs/kit';
 
 import type { RequestHandler } from './$types';
 
-// POST /api/response — iOS app sends the user's decision
+// POST /api/response — iOS app sends the user's decision.
+//
+// Accepts the full DecisionKind union (allow/deny/option_1..4/plan_*).
+// Routing of the decision back to Claude Code depends on the stored
+// `response_kind` on the pending request:
+//
+//   - 'hook' (default): notifier.cjs is in a GET poll loop on this
+//     same endpoint; setDecision() flips the row and the next poll
+//     returns 'decided' so the hook can write its stdout response.
+//   - 'pty' : the active Claude Code session is in a Shooter-managed
+//     PTY; the user's choice will be written to that PTY's stdin so
+//     Claude Code sees it as if the user typed at the laptop. Wired up
+//     in PR-3; for PR-1 we accept the decision and stub the routing.
+//   - 'info': no routing back to Claude Code. Decision is recorded for
+//     audit / UI feedback only.
 export const POST: RequestHandler = async ({ request }) => {
   cleanup();
 
@@ -14,9 +34,9 @@ export const POST: RequestHandler = async ({ request }) => {
     return authError;
   }
 
-  let body: { decision?: string; requestId?: string };
+  let body: { decision?: unknown; requestId?: unknown };
   try {
-    body = (await request.json()) as { decision?: string; requestId?: string };
+    body = (await request.json()) as { decision?: unknown; requestId?: unknown };
   } catch {
     return json({ error: 'Invalid JSON in request body' }, { status: 400 });
   }
@@ -24,23 +44,53 @@ export const POST: RequestHandler = async ({ request }) => {
   try {
     const { decision, requestId } = body;
 
-    if (!requestId || !decision) {
-      return json({ error: 'requestId and decision are required' }, { status: 400 });
+    if (typeof requestId !== 'string' || requestId.length === 0) {
+      return json({ error: 'requestId must be a non-empty string' }, { status: 400 });
+    }
+    if (!isDecisionKind(decision)) {
+      return json(
+        {
+          error:
+            'decision must be one of allow, deny, option_1..4, plan_auto, plan_accept, plan_review, plan_keep',
+        },
+        { status: 400 }
+      );
     }
 
-    if (decision !== 'allow' && decision !== 'deny') {
-      return json({ error: 'decision must be "allow" or "deny"' }, { status: 400 });
-    }
-
-    const found = setDecision(requestId, decision);
+    // Persist first so polling notifier.cjs picks it up regardless of
+    // which response_kind we route on. The 'pty' branch is additive —
+    // it ALSO writes to the PTY but the row remains the source of truth.
+    const decisionTyped: DecisionKind = decision;
+    const found = setDecision(requestId, decisionTyped);
     if (!found) {
       return json({ error: 'Request not found or expired' }, { status: 404 });
     }
 
-    console.log(`[response] Decision received: ${decision} for request ${requestId}`);
+    // Routing dispatch. For PR-1 only the 'hook' path is functional;
+    // 'pty' and 'info' are accepted but don't yet forward anywhere
+    // (PR-3 wires PTY; 'info' is intentionally no-op).
+    const entry = getRichRequest(requestId);
+    const responseKind = entry?.responseKind ?? 'hook';
+
+    console.log(
+      `[response] Decision received: ${decisionTyped} for request ${requestId} (responseKind=${responseKind})`
+    );
+
+    if (responseKind === 'pty') {
+      // PR-3 will write the chosen option to the matching PTY's stdin.
+      // For PR-1 we accept and persist so the user gets a "Decision
+      // recorded" confirmation — the laptop just won't act on it yet.
+      return json({
+        message: 'Decision recorded; PTY routing not yet implemented',
+        responseKind,
+        success: true,
+        timestamp: new Date().toISOString(),
+      });
+    }
 
     return json({
       message: 'Decision recorded',
+      responseKind,
       success: true,
       timestamp: new Date().toISOString(),
     });

--- a/tests/pending-requests.test.cjs
+++ b/tests/pending-requests.test.cjs
@@ -15,24 +15,54 @@ const DB_PATH = '/tmp/shooter-test-pending.db';
 
 const MAX_AGE_MS = 5 * 60 * 1000;
 
-function rowToRecord(row) {
-  let toolInput = {};
-  if (typeof row.tool_input === 'string' && row.tool_input.length > 0) {
-    try {
-      const parsed = JSON.parse(row.tool_input);
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        toolInput = parsed;
-      }
-    } catch (_) {
-      /* corrupt JSON — fall back */
-    }
+function parseOptions(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (_) {
+    return [];
   }
+}
+
+function parseToolInput(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function rowToRich(row) {
+  const responseKindRaw = typeof row.response_kind === 'string' ? row.response_kind : 'hook';
+  const responseKind =
+    responseKindRaw === 'hook' || responseKindRaw === 'pty' || responseKindRaw === 'info'
+      ? responseKindRaw
+      : 'hook';
+  return {
+    requestId: row.request_id,
+    sessionId: row.session_id,
+    toolName: row.tool_name,
+    toolInput: parseToolInput(row.tool_input),
+    decision: row.decision ?? null,
+    createdAt: row.created_at,
+    decidedAt: row.decided_at ?? null,
+    question: row.question ?? null,
+    options: parseOptions(row.options),
+    responseKind,
+  };
+}
+
+function rowToRecord(row) {
+  const decision = row.decision;
   return {
     createdAt: row.created_at,
     decidedAt: row.decided_at ?? null,
-    decision: row.decision ?? null,
+    decision: decision === 'allow' || decision === 'deny' ? decision : null,
     sessionId: row.session_id,
-    toolInput,
+    toolInput: parseToolInput(row.tool_input),
     toolName: row.tool_name,
   };
 }
@@ -43,30 +73,56 @@ class PendingRequestsStore {
     this.db.pragma('journal_mode = WAL');
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS pending_requests (
-        request_id  TEXT PRIMARY KEY,
-        session_id  TEXT NOT NULL,
-        tool_name   TEXT NOT NULL,
-        tool_input  TEXT NOT NULL DEFAULT '{}',
-        decision    TEXT,
-        created_at  INTEGER NOT NULL,
-        decided_at  INTEGER
+        request_id    TEXT PRIMARY KEY,
+        session_id    TEXT NOT NULL,
+        tool_name     TEXT NOT NULL,
+        tool_input    TEXT NOT NULL DEFAULT '{}',
+        decision      TEXT,
+        created_at    INTEGER NOT NULL,
+        decided_at    INTEGER,
+        question      TEXT,
+        options       TEXT NOT NULL DEFAULT '[]',
+        response_kind TEXT NOT NULL DEFAULT 'hook'
       )
     `);
+    this.migrate();
+  }
+
+  migrate() {
+    const cols = this.db.prepare('PRAGMA table_info(pending_requests)').all();
+    const existing = new Set(cols.map((c) => c.name));
+    const wanted = [
+      { name: 'question', sql: 'ALTER TABLE pending_requests ADD COLUMN question TEXT' },
+      {
+        name: 'options',
+        sql: "ALTER TABLE pending_requests ADD COLUMN options TEXT NOT NULL DEFAULT '[]'",
+      },
+      {
+        name: 'response_kind',
+        sql: "ALTER TABLE pending_requests ADD COLUMN response_kind TEXT NOT NULL DEFAULT 'hook'",
+      },
+    ];
+    for (const col of wanted) {
+      if (!existing.has(col.name)) this.db.exec(col.sql);
+    }
   }
 
   insert(requestId, data) {
     this.db
       .prepare(
         `INSERT OR REPLACE INTO pending_requests
-         (request_id, session_id, tool_name, tool_input, decision, created_at, decided_at)
-         VALUES (?, ?, ?, ?, NULL, ?, NULL)`
+         (request_id, session_id, tool_name, tool_input, decision, created_at, decided_at, question, options, response_kind)
+         VALUES (?, ?, ?, ?, NULL, ?, NULL, ?, ?, ?)`
       )
       .run(
         requestId,
         data.sessionId,
         data.toolName,
         JSON.stringify(data.toolInput),
-        data.createdAt ?? Date.now()
+        data.createdAt ?? Date.now(),
+        data.question ?? null,
+        JSON.stringify(data.options ?? []),
+        data.responseKind ?? 'hook'
       );
   }
 
@@ -77,15 +133,20 @@ class PendingRequestsStore {
     return row ? rowToRecord(row) : null;
   }
 
+  getRich(requestId) {
+    const row = this.db
+      .prepare('SELECT * FROM pending_requests WHERE request_id = ?')
+      .get(requestId);
+    return row ? rowToRich(row) : null;
+  }
+
   delete(requestId) {
     this.db.prepare('DELETE FROM pending_requests WHERE request_id = ?').run(requestId);
   }
 
   setDecision(requestId, decision) {
     const result = this.db
-      .prepare(
-        'UPDATE pending_requests SET decision = ?, decided_at = ? WHERE request_id = ?'
-      )
+      .prepare('UPDATE pending_requests SET decision = ?, decided_at = ? WHERE request_id = ?')
       .run(decision, Date.now(), requestId);
     return result.changes > 0;
   }
@@ -151,7 +212,7 @@ function runTest(name, fn) {
 
 console.log('\nPendingRequestsStore unit tests\n');
 
-// ── Test 1: Insert and Get ───────────────────────────────────────────
+// ── Test 1: Insert and Get (legacy fields only) ──────────────────────
 
 runTest('Test 1: Insert and Get', (store) => {
   store.insert('req-1', {
@@ -167,20 +228,12 @@ runTest('Test 1: Insert and Get', (store) => {
   assertEqual(got.toolInput, { command: 'ls -la', timeout: 5000 }, 'toolInput round-trip');
   assertEqual(got.decision, null, 'initial decision is null');
   assertEqual(got.decidedAt, null, 'initial decidedAt is null');
-
-  if (typeof got.createdAt !== 'number' || got.createdAt <= 0) {
-    throw new Error(`createdAt should be a positive epoch ms, got ${got.createdAt}`);
-  }
 });
 
 // ── Test 2: setDecision flips decision + decidedAt ───────────────────
 
 runTest('Test 2: setDecision flips decision + decidedAt', (store) => {
-  store.insert('req-2', {
-    sessionId: 'sess-2',
-    toolName: 'Edit',
-    toolInput: { file_path: '/tmp/foo' },
-  });
+  store.insert('req-2', { sessionId: 's', toolName: 'Edit', toolInput: { file_path: '/tmp/foo' } });
 
   const before = Date.now();
   const ok = store.setDecision('req-2', 'allow');
@@ -193,12 +246,7 @@ runTest('Test 2: setDecision flips decision + decidedAt', (store) => {
     throw new Error(`decidedAt should be a number >= ${before}, got ${got.decidedAt}`);
   }
 
-  // 'deny' should also work
-  store.insert('req-2b', {
-    sessionId: 'sess-2',
-    toolName: 'Bash',
-    toolInput: {},
-  });
+  store.insert('req-2b', { sessionId: 's', toolName: 'Bash', toolInput: {} });
   store.setDecision('req-2b', 'deny');
   assertEqual(store.get('req-2b').decision, 'deny', 'decision is deny');
 });
@@ -206,18 +254,13 @@ runTest('Test 2: setDecision flips decision + decidedAt', (store) => {
 // ── Test 3: setDecision on missing requestId returns false ───────────
 
 runTest('Test 3: setDecision on missing requestId returns false', (store) => {
-  const ok = store.setDecision('does-not-exist', 'allow');
-  assertEqual(ok, false, 'setDecision returns false when row absent');
+  assertEqual(store.setDecision('does-not-exist', 'allow'), false, 'setDecision returns false');
 });
 
 // ── Test 4: delete + get after delete ────────────────────────────────
 
 runTest('Test 4: delete + get after delete', (store) => {
-  store.insert('req-del', {
-    sessionId: 's',
-    toolName: 'Bash',
-    toolInput: {},
-  });
+  store.insert('req-del', { sessionId: 's', toolName: 'Bash', toolInput: {} });
   assertNotNull(store.get('req-del'), 'row exists before delete');
   store.delete('req-del');
   assertEqual(store.get('req-del'), null, 'row gone after delete');
@@ -231,7 +274,6 @@ runTest('Test 5: INSERT OR REPLACE on duplicate requestId', (store) => {
     toolName: 'Bash',
     toolInput: { command: 'echo hi' },
   });
-  // Second insert with same id should not throw and should overwrite
   store.insert('dup', {
     sessionId: 'second',
     toolName: 'Edit',
@@ -249,20 +291,15 @@ runTest('Test 5: INSERT OR REPLACE on duplicate requestId', (store) => {
 
 runTest('Test 6: cleanup removes only expired rows', (store) => {
   const now = Date.now();
-  // Insert an "old" row by passing an explicit createdAt 10 min ago.
   store.insert('old', {
     sessionId: 's',
     toolName: 'Bash',
     toolInput: {},
     createdAt: now - 10 * 60 * 1000,
   });
-  store.insert('recent', {
-    sessionId: 's',
-    toolName: 'Bash',
-    toolInput: {},
-  });
+  store.insert('recent', { sessionId: 's', toolName: 'Bash', toolInput: {} });
 
-  const removed = store.cleanup(MAX_AGE_MS); // 5 minute window
+  const removed = store.cleanup(MAX_AGE_MS);
   assertEqual(removed, 1, 'cleanup removed 1 stale row');
   assertEqual(store.get('old'), null, 'old row gone');
   assertNotNull(store.get('recent'), 'recent row survives');
@@ -276,28 +313,132 @@ runTest('Test 7: Tool input round-trip preserves nested values', (store) => {
     flags: ['-sS', '--http2'],
     nested: { headers: { 'Content-Type': 'application/json' }, retries: 3 },
   };
-  store.insert('nested', {
-    sessionId: 's',
-    toolName: 'Bash',
-    toolInput: input,
-  });
-
-  const got = store.get('nested');
-  assertEqual(got.toolInput, input, 'nested toolInput round-trip');
+  store.insert('nested', { sessionId: 's', toolName: 'Bash', toolInput: input });
+  assertEqual(store.get('nested').toolInput, input, 'nested toolInput round-trip');
 });
 
 // ── Test 8: Corrupt JSON in tool_input column falls back to {} ───────
 
 runTest('Test 8: Corrupt tool_input JSON falls back to empty object', (store) => {
-  // Directly insert a row with malformed JSON to verify rowToRecord doesn't throw.
   store.db
     .prepare(
-      `INSERT INTO pending_requests (request_id, session_id, tool_name, tool_input, created_at) VALUES (?, ?, ?, ?, ?)`
+      `INSERT INTO pending_requests
+       (request_id, session_id, tool_name, tool_input, created_at, options, response_kind)
+       VALUES (?, ?, ?, ?, ?, '[]', 'hook')`
     )
     .run('bad', 's', 'Bash', '{this is not valid JSON', Date.now());
   const got = store.get('bad');
   assertNotNull(got, 'row still readable');
   assertEqual(got.toolInput, {}, 'toolInput defaults to {} on parse failure');
+});
+
+// ── Test 9: insert with new fields (question, options, responseKind) ─
+
+runTest('Test 9: insert with question + options + responseKind', (store) => {
+  store.insert('rich-1', {
+    sessionId: 's',
+    toolName: 'AskUserQuestion',
+    toolInput: {},
+    question: 'Which framework should we use?',
+    options: [
+      { id: 'option_1', label: 'Frontend (SvelteKit)' },
+      { id: 'option_2', label: 'Backend (Fastify)', hint: 'Node.js / TypeScript' },
+    ],
+    responseKind: 'pty',
+  });
+
+  const rich = store.getRich('rich-1');
+  assertNotNull(rich, 'getRich returns row');
+  assertEqual(rich.question, 'Which framework should we use?', 'question round-trip');
+  assertEqual(rich.options.length, 2, 'options count');
+  assertEqual(rich.options[0].id, 'option_1', 'option[0].id');
+  assertEqual(rich.options[1].hint, 'Node.js / TypeScript', 'option[1].hint');
+  assertEqual(rich.responseKind, 'pty', 'responseKind round-trip');
+});
+
+// ── Test 10: insert defaults — question null, options [], responseKind hook ─
+
+runTest('Test 10: defaults for new fields when not provided', (store) => {
+  store.insert('default-fields', {
+    sessionId: 's',
+    toolName: 'Bash',
+    toolInput: { command: 'ls' },
+  });
+  const rich = store.getRich('default-fields');
+  assertEqual(rich.question, null, 'question defaults to null');
+  assertEqual(rich.options, [], 'options defaults to []');
+  assertEqual(rich.responseKind, 'hook', 'responseKind defaults to hook');
+});
+
+// ── Test 11: migration adds missing columns to old-schema DB ─────────
+
+runTest('Test 11: migrate() adds new columns to old schema', () => {
+  // Wipe DB completely then create the OLD schema (no new columns) manually
+  for (const suffix of ['', '-wal', '-shm']) {
+    try {
+      fs.unlinkSync(DB_PATH + suffix);
+    } catch (_) {
+      /* ignore */
+    }
+  }
+  const old = new Database(DB_PATH);
+  old.pragma('journal_mode = WAL');
+  old.exec(`
+    CREATE TABLE pending_requests (
+      request_id  TEXT PRIMARY KEY,
+      session_id  TEXT NOT NULL,
+      tool_name   TEXT NOT NULL,
+      tool_input  TEXT NOT NULL DEFAULT '{}',
+      decision    TEXT,
+      created_at  INTEGER NOT NULL,
+      decided_at  INTEGER
+    )
+  `);
+  // Insert a row in the OLD schema (pre-migration)
+  old
+    .prepare(
+      `INSERT INTO pending_requests
+       (request_id, session_id, tool_name, tool_input, created_at)
+       VALUES (?, ?, ?, ?, ?)`
+    )
+    .run('legacy-row', 'sess', 'Bash', '{}', Date.now());
+  old.close();
+
+  // Re-open via the store — constructor's migrate() should add columns
+  const store = new PendingRequestsStore(DB_PATH);
+  try {
+    const cols = store.db.prepare('PRAGMA table_info(pending_requests)').all();
+    const names = new Set(cols.map((c) => c.name));
+    if (!names.has('question')) throw new Error('migrate() did not add `question` column');
+    if (!names.has('options')) throw new Error('migrate() did not add `options` column');
+    if (!names.has('response_kind')) throw new Error('migrate() did not add `response_kind`');
+
+    // The legacy row should still be readable and have default values
+    // for the new columns
+    const rich = store.getRich('legacy-row');
+    assertNotNull(rich, 'legacy row still readable after migration');
+    assertEqual(rich.question, null, 'legacy row has null question');
+    assertEqual(rich.options, [], 'legacy row has [] options');
+    assertEqual(rich.responseKind, 'hook', 'legacy row has hook responseKind');
+  } finally {
+    store.close();
+  }
+});
+
+// ── Test 12: migrate() is idempotent (re-running is a no-op) ─────────
+
+runTest('Test 12: migrate() is idempotent', (store) => {
+  // Constructor already ran migrate(). Run it again explicitly.
+  store.migrate();
+  store.migrate();
+  // Inserting should still work
+  store.insert('post-migrate', {
+    sessionId: 's',
+    toolName: 'Bash',
+    toolInput: {},
+    question: 'still works?',
+  });
+  assertEqual(store.getRich('post-migrate').question, 'still works?', 'works after re-migrate');
 });
 
 // ── Summary ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**PR-1 of 3** for surfacing all of Claude Code's interactive options (not just allow/deny) on the iPhone.

This PR is pure infrastructure — no new event triggers fire yet, the existing CLAUDE_PERMISSION binary flow is unchanged. PR-2 will wire plan-mode (ExitPlanMode) and PR-3 will wire MCP elicitation + AskUserQuestion+PTY.

## What lands

### Server

| Change | What |
| ------ | ---- |
| `src/lib/types/decision.ts` (new) | Hand-written types: \`DecisionKind\`, \`ResponseKind\`, \`OptionChoice\`, \`DecidePayload\`, \`PendingRequestRich\`, \`isDecisionKind\` guard. |
| \`pending_requests\` schema migration | Idempotent ALTER TABLE adds \`question\`, \`options\` (JSON), \`response_kind\` columns. Legacy DBs upgrade in place. |
| \`PendingRequestsStore.insert\` / \`getRich\` | Round-trip the new fields. Legacy \`get\` / PendingRequest type stay binary so old callers don't break. |
| \`/api/response\` POST | Accepts any \`DecisionKind\` value (allow/deny/option_1..4/plan_*). Routes by stored \`response_kind\`. The 'pty' branch is stubbed for PR-3. |
| \`/api/decide/[requestId]\` GET (new) | Returns the full payload (question + options + responseKind + tool context) for the iOS Decide screen. |

### iOS

| Change | What |
| ------ | ---- |
| \`Config.swift\` | New action IDs (OPTION_1..4, PLAN_*, OPEN_IN_APP) and category IDs (PLAN_APPROVAL, CHOICE_2/3/4). |
| \`NotificationManager.swift\` | Registers all new categories with fixed action sets (iOS bars per-notification dynamic labels). Every category includes "Open in Shooter" so the in-app Decide screen is always reachable. Renamed \`sendPermissionResponse\` → \`sendDecisionResponse\` and added \`decisionFor(actionIdentifier:)\` mapping for the full DecisionKind union. |
| \`ContentView.swift\` (+ DecideView struct) | New SwiftUI screen that fetches \`/api/decide/[id]\` on appear and renders one button per option — any label, any count. Presented via \`.sheet(item:)\` driven by NotificationManager's new \`@Published decideRequestId\`. |

## Why this UX

iOS \`UNNotificationCategory\` actions are registered at app launch with fixed labels — you cannot change \`"Allow"\` / \`"Deny"\` to \`"Option A"\` / \`"Option B"\` per push. So the lock-screen buttons are numbered (\"Option 1\", \"Option 2\", ...) and the notification BODY carries the actual labels. For richer UI (>4 options, longer labels, full context), the user taps "Open in Shooter" or the notification body itself — which triggers DecideView with proper buttons.

## What doesn't change

- Existing CLAUDE_PERMISSION Allow/Deny flow — same behavior, same code path.
- \`PendingRequest\` legacy type stays binary-decision so the YAML-generated type matches what older callers expect.
- No new commits to notifier.cjs (PR-2/PR-3 will add hooks).

## Test plan

- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run check\` — 0 errors, 0 warnings
- [x] \`pnpm run build\` — success
- [x] \`pnpm test\` — **33/33 pass** (6 terminal-store + 12 pending-requests + 15 tunnel-discovery)
  - 4 new pending-requests cases: insert with new fields, defaults when not provided, migration from legacy schema, idempotent re-migration
- [ ] CI green on this PR
- [ ] iOS rebuild in Xcode + verify existing Allow/Deny flow still works
- [ ] iOS rebuild + verify DecideView renders when notification body is tapped (PR-2 will provide a notification that actually exercises this path; for PR-1 the Decide screen is reachable but won't have data unless an option-bearing pending row is in the DB)