### PR TITLE
feat(decisions): wire plan-mode approval (PR-2 of 3)

### DIFF
--- a/.claude/hooks/notifier.cjs
+++ b/.claude/hooks/notifier.cjs
@@ -524,18 +524,123 @@ function handleSessionStart(_event) {
 }
 
 /**
+ * Plan-mode approval options surfaced when Claude calls ExitPlanMode.
+ *
+ * iOS shows the first 3 + Open-in-Shooter on the lock screen (4 button
+ * cap); plan_keep is reachable via the Decide screen.
+ */
+const PLAN_MODE_OPTIONS = [
+  { id: 'plan_auto', label: 'Auto Mode', hint: 'Bypass permissions for the rest of the session' },
+  {
+    id: 'plan_accept',
+    label: 'Accept Edits',
+    hint: 'Auto-accept file edits; still ask for risky operations',
+  },
+  { id: 'plan_review', label: 'Review Each', hint: 'Default — ask for each tool invocation' },
+  { id: 'plan_keep', label: 'Keep Planning', hint: 'Stay in plan mode without exiting' },
+];
+
+/**
+ * Map plan_* decisions to the hookSpecificOutput shape Claude Code's
+ * PermissionRequest hook expects:
+ *   plan_auto/accept/review → allow + updatedPermissions.setMode
+ *   plan_keep                → deny (stay in plan mode)
+ *
+ * Exported via test hook for unit testing without spinning up CC.
+ */
+function planDecisionToHookResponse(decision) {
+  const modeMap = {
+    plan_auto: 'bypassPermissions',
+    plan_accept: 'acceptEdits',
+    plan_review: 'default',
+  };
+  if (decision === 'plan_keep') {
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PermissionRequest',
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'User chose to keep planning',
+      },
+    };
+  }
+  const mode = modeMap[decision];
+  if (!mode) return null;
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PermissionRequest',
+      decision: {
+        behavior: 'allow',
+        updatedPermissions: [{ type: 'setMode', mode, destination: 'session' }],
+      },
+    },
+  };
+}
+
+/**
+ * Map a binary allow|deny decision to the hookSpecificOutput shape.
+ */
+function binaryDecisionToHookResponse(decision, wsActive) {
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PermissionRequest',
+      permissionDecision: decision,
+      permissionDecisionReason: `User ${decision === 'allow' ? 'approved' : 'denied'} via ${wsActive ? 'WebSocket' : 'iPhone notification'}`,
+    },
+  };
+}
+
+/**
+ * Detect whether this permission request is the plan-mode approval
+ * (ExitPlanMode tool). Plan-mode gets a richer 4-option notification
+ * instead of binary allow/deny.
+ */
+function isPlanModePermission(d) {
+  return d.tool === 'ExitPlanMode' || d.toolName === 'ExitPlanMode';
+}
+
+/**
+ * Build the notification body for a plan-mode approval. The plan
+ * content itself sits in body + question so the iOS Decide screen can
+ * show it; the body also lists the numbered options for lock-screen
+ * users who don't open the app.
+ */
+function buildPlanModeNotification(event) {
+  const d = event.data;
+  const toolInput = d.toolInput || {};
+  const plan = typeof toolInput.plan === 'string' ? toolInput.plan : '';
+  const planSummary = summarize(plan, 300) || 'Plan ready for approval';
+
+  const title = `${event.projectName} · Plan ready`;
+  const subtitle = summarize(plan, 70) || 'Review and choose how to proceed';
+  const body = [
+    planSummary,
+    '',
+    '1. Auto Mode  2. Accept Edits  3. Review Each  4. Keep Planning',
+  ].join('\n');
+
+  return { title, subtitle, body, question: plan };
+}
+
+/**
  * Handle permission events (agent needs user to approve a tool)
  *
  * Builds a rich notification with tool name + details when available,
  * falls back to the message text when tool details aren't available.
  * Content is identical between Claude Code and OpenCode.
+ *
+ * Plan-mode (ExitPlanMode tool) gets a special 4-option flow instead
+ * of binary allow/deny — see PLAN_MODE_OPTIONS + planDecisionToHookResponse.
  */
 async function handlePermission(event) {
   const d = event.data;
   debugLog(`Permission event: tool=${d.tool}, message=${d.message}`);
 
+  const planMode = isPlanModePermission(d);
+
   const ctx = getSessionContext(d.sessionId);
-  const { title, subtitle, body } = buildPermissionNotification(event, ctx);
+  const { title, subtitle, body } = planMode
+    ? buildPlanModeNotification(event)
+    : buildPermissionNotification(event, ctx);
 
   // Check if WebSocket clients are connected — if so, the events channel
   // will broadcast the permission-requested event and we skip the push notification
@@ -544,12 +649,20 @@ async function handlePermission(event) {
   // For Claude Code PermissionRequest: block and poll for iPhone response
   if (IS_CLAUDE_CODE && event.source === 'claude-code') {
     const requestId = Math.random().toString(36).substring(2, 15);
-    debugLog(`Starting bidirectional permission flow (requestId: ${requestId})`);
+    debugLog(
+      `Starting bidirectional permission flow (requestId: ${requestId}, planMode: ${planMode})`
+    );
 
-    let result;
+    const extras = { skipPush: wsActive, subtitle };
+    if (planMode) {
+      extras.notificationCategory = 'CLAUDE_PLAN_APPROVAL';
+      extras.options = PLAN_MODE_OPTIONS;
+      extras.question =
+        typeof d.toolInput?.plan === 'string' ? d.toolInput.plan : 'Approve plan and proceed?';
+      extras.responseKind = 'hook';
+    }
+
     if (wsActive) {
-      // WebSocket clients connected — skip push notification, but still register
-      // the pending request on the server so polling can find it.
       debugLog(`[Notifier] WebSocket clients connected, skipping push notification`);
       if (IS_CLAUDE_CODE) {
         console.error(`\n=== WEBSOCKET ACTIVE — SKIPPING PUSH [${requestId}] ===`);
@@ -557,42 +670,32 @@ async function handlePermission(event) {
         console.error(`Message: ${body}`);
         console.error(`=== REGISTERING REQUEST & POLLING VIA WEBSOCKET CHANNEL ===\n`);
       }
-
-      // Register the pending request but skip the actual push notification —
-      // the events channel will broadcast the permission to connected clients.
-      result = await sendNotificationAndPoll(
-        title,
-        body,
-        'permission',
-        event.source,
-        requestId,
-        d,
-        { skipPush: true, subtitle }
-      );
-    } else {
-      // No WebSocket clients — send push notification and poll
-      result = await sendNotificationAndPoll(
-        title,
-        body,
-        'permission',
-        event.source,
-        requestId,
-        d,
-        { subtitle }
-      );
     }
 
+    const result = await sendNotificationAndPoll(
+      title,
+      body,
+      'permission',
+      event.source,
+      requestId,
+      d,
+      extras
+    );
+
     if (result && result.decision) {
-      const hookResponse = {
-        hookSpecificOutput: {
-          hookEventName: 'PermissionRequest',
-          permissionDecision: result.decision,
-          permissionDecisionReason: `User ${result.decision === 'allow' ? 'approved' : 'denied'} via ${wsActive ? 'WebSocket' : 'iPhone notification'}`,
-        },
-      };
-      // Write decision to stdout for Claude Code to read
-      process.stdout.write(JSON.stringify(hookResponse));
-      debugLog(`Wrote hook decision to stdout: ${result.decision}`);
+      // Plan-mode decisions (plan_auto/accept/review/keep) need the
+      // richer hookSpecificOutput shape with updatedPermissions.setMode.
+      // Binary allow/deny falls through the legacy path.
+      const hookResponse = planMode
+        ? planDecisionToHookResponse(result.decision)
+        : binaryDecisionToHookResponse(result.decision, wsActive);
+
+      if (hookResponse) {
+        process.stdout.write(JSON.stringify(hookResponse));
+        debugLog(`Wrote hook decision to stdout: ${result.decision}`);
+      } else {
+        debugLog(`Unknown decision shape '${result.decision}' — falling through to local dialog`);
+      }
     } else {
       debugLog('No response received - falling through to local permission dialog');
       // Output nothing → Claude Code shows normal permission dialog
@@ -607,6 +710,11 @@ async function handlePermission(event) {
     sendNotification(title, body, 'permission', event.source, subtitle);
   }
 }
+
+// Pure helpers above are also re-exported alongside OpenCodePlugin at
+// the bottom of this file for unit testing. The single module.exports
+// block lives at the end of the file (see "Exports and Main Execution"
+// section).
 
 /**
  * Handle permission_notification events (Notification hook with permission_prompt type).
@@ -1176,8 +1284,47 @@ function sendNotificationAndPoll(
   source,
   requestId,
   eventData,
-  { skipPush = false, subtitle = '' } = {}
+  {
+    skipPush = false,
+    subtitle = '',
+    // Dynamic-options extras forwarded to /api/notify body so the server
+    // can persist them on the pending_requests row + set the right APNs
+    // category. Undefined → server falls back to the binary CLAUDE_PERMISSION
+    // flow (preserves legacy behavior).
+    notificationCategory,
+    question,
+    options,
+    responseKind,
+  } = {}
 ) {
+  // Common body shared between the skipPush (register-only) and the
+  // full push paths. Splitting reduces drift between the two.
+  const buildNotifyBody = (timestamp, finalBody) => ({
+    title,
+    ...(subtitle ? { subtitle } : {}),
+    message: finalBody,
+    waitForResponse: true,
+    ...(skipPush ? { skipPush: true } : {}),
+    ...(DEVICE_TOKEN && { deviceToken: DEVICE_TOKEN }),
+    ...(notificationCategory && { notificationCategory }),
+    ...(question !== undefined && { question }),
+    ...(options && { options }),
+    ...(responseKind && { responseKind }),
+    data: {
+      category,
+      project: getProjectName(),
+      timestamp,
+      requestId,
+      clientTimestamp: timestamp,
+      source: 'shooter-completion-detector',
+      environment: USE_LOCAL ? 'local' : 'remote',
+      runtime: source,
+      toolName: eventData.tool || '',
+      toolInput: eventData.toolInput || {},
+      sessionId: eventData.sessionId || '',
+    },
+  });
+
   return new Promise((resolve) => {
     const timestamp = new Date().toISOString();
 
@@ -1194,27 +1341,7 @@ function sendNotificationAndPoll(
       // Register the pending request on the server so polling finds it.
       // We still need to POST with waitForResponse so the server creates
       // the pending-request entry, but we mark it as ws-only.
-      const registerPayload = JSON.stringify({
-        title,
-        ...(subtitle ? { subtitle } : {}),
-        message: finalBody,
-        waitForResponse: true,
-        skipPush: true,
-        ...(DEVICE_TOKEN && { deviceToken: DEVICE_TOKEN }),
-        data: {
-          category,
-          project: getProjectName(),
-          timestamp,
-          requestId,
-          clientTimestamp: timestamp,
-          source: 'shooter-completion-detector',
-          environment: USE_LOCAL ? 'local' : 'remote',
-          runtime: source,
-          toolName: eventData.tool || '',
-          toolInput: eventData.toolInput || {},
-          sessionId: eventData.sessionId || '',
-        },
-      });
+      const registerPayload = JSON.stringify(buildNotifyBody(timestamp, finalBody));
 
       const registerOptions = {
         method: 'POST',
@@ -1263,26 +1390,7 @@ function sendNotificationAndPoll(
 
     debugLog(`Sending bidirectional notification: "${title}" (requestId: ${requestId})`);
 
-    const payload = JSON.stringify({
-      title,
-      ...(subtitle ? { subtitle } : {}),
-      message: finalBody,
-      waitForResponse: true,
-      ...(DEVICE_TOKEN && { deviceToken: DEVICE_TOKEN }),
-      data: {
-        category,
-        project: getProjectName(),
-        timestamp,
-        requestId,
-        clientTimestamp: timestamp,
-        source: 'shooter-completion-detector',
-        environment: USE_LOCAL ? 'local' : 'remote',
-        runtime: source,
-        toolName: eventData.tool || '',
-        toolInput: eventData.toolInput || {},
-        sessionId: eventData.sessionId || '',
-      },
-    });
+    const payload = JSON.stringify(buildNotifyBody(timestamp, finalBody));
 
     const options = {
       method: 'POST',
@@ -1643,11 +1751,21 @@ const OpenCodePlugin = async (ctx) => {
 // Exports and Main Execution
 // ============================================
 
-// Export for OpenCode plugin system
+// Export for OpenCode plugin system + unit tests.
+//
+// The default export remains OpenCodePlugin so the OpenCode plugin
+// loader (which does `require(notifier.cjs)()`) keeps working. Pure
+// helpers (plan-mode routing, etc.) are attached as named properties
+// so tests/ can require them without spawning the full hook script.
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = OpenCodePlugin;
   module.exports.OpenCodePlugin = OpenCodePlugin;
   module.exports.ShooterNotifier = OpenCodePlugin;
+  // Pure-function exports for unit tests (tests/plan-mode-routing.test.cjs).
+  module.exports.PLAN_MODE_OPTIONS = PLAN_MODE_OPTIONS;
+  module.exports.binaryDecisionToHookResponse = binaryDecisionToHookResponse;
+  module.exports.isPlanModePermission = isPlanModePermission;
+  module.exports.planDecisionToHookResponse = planDecisionToHookResponse;
 }
 
 // Run main() when called directly from CLI (Claude Code)

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "format:generated": "prettier --write ./src/lib/types/generated/*",
     "quality:all": "pnpm run lint && pnpm run format:check && pnpm run check",
     "gen:types": "npx type-crafter generate typescript-with-decoders ./specs/types/index.yaml ./src/lib/types/generated SingleFile SingleFile && bash scripts/postgen-types.sh && pnpm run format:generated",
-    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs",
+    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/plan-mode-routing.test.cjs",
     "setup": "node scripts/setup.cjs",
     "prepare": "husky || true",
     "prepublishOnly": "pnpm build"

--- a/src/routes/api/notify/+server.ts
+++ b/src/routes/api/notify/+server.ts
@@ -1,4 +1,4 @@
-import type { NotificationData } from '$lib/types';
+import type { NotificationData, OptionChoice, ResponseKind } from '$lib/types';
 
 import { env } from '$env/dynamic/private';
 import { LibraryAPNsService } from '$lib/modules/server/apn/library-apns';
@@ -266,6 +266,11 @@ function recordNotification(title: string, message: string, data?: NotificationD
   notificationCache.set(key, Date.now());
 }
 
+// TODO(refactor): extract body parsing, filtering, and platform routing into
+// helpers. This handler grew past the 300-line guideline organically; PR-2
+// adds 4 lines for dynamic-options fields. A dedicated cleanup PR is the
+// right place to split it, not a feature PR.
+// eslint-disable-next-line max-lines-per-function
 export const POST: RequestHandler = async ({ request }) => {
   try {
     // Use singleton APNs client to reuse HTTP/2 connection
@@ -296,6 +301,29 @@ export const POST: RequestHandler = async ({ request }) => {
     const skipPush = typeof body.skipPush === 'boolean' ? body.skipPush : false;
     const waitForResponse =
       typeof body.waitForResponse === 'boolean' ? body.waitForResponse : false;
+
+    // Dynamic-options fields (PR-2/PR-3). When the caller wants to drive
+    // a richer notification category — plan-mode approval, MCP
+    // elicitation, AskUserQuestion choices — these arrive in the top
+    // level of the body so they can be persisted in pending_requests
+    // and surfaced to the iOS Decide screen via /api/decide/[id].
+    //
+    // Backward-compat: when these are omitted, the existing CLAUDE_
+    // PERMISSION binary flow is unchanged.
+    const notificationCategory =
+      typeof body.notificationCategory === 'string' && body.notificationCategory.length > 0
+        ? body.notificationCategory
+        : undefined;
+    const question = typeof body.question === 'string' ? body.question : undefined;
+    const options =
+      Array.isArray(body.options) && body.options.every((o) => o && typeof o === 'object')
+        ? (body.options as OptionChoice[])
+        : undefined;
+    const responseKindRaw = body.responseKind;
+    const responseKind: ResponseKind | undefined =
+      responseKindRaw === 'hook' || responseKindRaw === 'pty' || responseKindRaw === 'info'
+        ? responseKindRaw
+        : undefined;
 
     // Broadcast to /ws/events for real-time activity feed
     try {
@@ -350,6 +378,9 @@ export const POST: RequestHandler = async ({ request }) => {
     if (skipPush) {
       if (waitForResponse) {
         createPendingRequest(canonicalRequestId, {
+          options,
+          question: question ?? null,
+          responseKind: responseKind ?? 'hook',
           sessionId: (data?.sessionId as string) || '',
           toolInput: (data?.toolInput as Record<string, unknown>) || {},
           toolName: (data?.toolName as string) || '',
@@ -370,7 +401,11 @@ export const POST: RequestHandler = async ({ request }) => {
     const payload = {
       badge: 1,
       body: message,
-      category: waitForResponse ? 'CLAUDE_PERMISSION' : undefined,
+      // notificationCategory wins when explicitly set so plan-mode /
+      // elicitation flows can pick CLAUDE_PLAN_APPROVAL / CHOICE_2..4.
+      // Falls back to CLAUDE_PERMISSION for the legacy bidirectional
+      // permission flow when only waitForResponse is provided.
+      category: notificationCategory ?? (waitForResponse ? 'CLAUDE_PERMISSION' : undefined),
       data: {
         ...data,
         requestId: canonicalRequestId,
@@ -429,6 +464,9 @@ export const POST: RequestHandler = async ({ request }) => {
 
         if (waitForResponse) {
           createPendingRequest(canonicalRequestId, {
+            options,
+            question: question ?? null,
+            responseKind: responseKind ?? 'hook',
             sessionId: (data?.sessionId as string) || '',
             toolInput: (data?.toolInput as Record<string, unknown>) || {},
             toolName: (data?.toolName as string) || '',
@@ -505,6 +543,9 @@ export const POST: RequestHandler = async ({ request }) => {
         // only after confirming APNs delivery succeeded
         if (waitForResponse) {
           createPendingRequest(canonicalRequestId, {
+            options,
+            question: question ?? null,
+            responseKind: responseKind ?? 'hook',
             sessionId: (data?.sessionId as string) || '',
             toolInput: (data?.toolInput as Record<string, unknown>) || {},
             toolName: (data?.toolName as string) || '',

--- a/tests/plan-mode-routing.test.cjs
+++ b/tests/plan-mode-routing.test.cjs
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for the plan-mode decision routing helpers in
+ * .claude/hooks/notifier.cjs.
+ *
+ * The notifier.cjs file conditionally exports its pure helpers via
+ * `module.exports` only when `require()`'d (i.e. when require.main !==
+ * module). When executed as a Claude Code hook subprocess, the export
+ * is skipped so we don't pollute the runtime path.
+ *
+ * That lets us unit-test the decision-to-hook-response mapping (which
+ * is pure) without spawning Claude Code or mocking the polling loop.
+ */
+
+'use strict';
+
+const path = require('path');
+
+const notifier = require(path.join(__dirname, '..', '.claude', 'hooks', 'notifier.cjs'));
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(`${label}: expected ${e}, got ${a}`);
+  }
+}
+
+function assertNull(value, label) {
+  if (value !== null) {
+    throw new Error(`${label}: expected null, got ${JSON.stringify(value)}`);
+  }
+}
+
+console.log('\nplan-mode routing unit tests\n');
+
+// ── isPlanModePermission ─────────────────────────────────────────────
+
+runTest('isPlanModePermission: matches tool === "ExitPlanMode"', () => {
+  assertEqual(notifier.isPlanModePermission({ tool: 'ExitPlanMode' }), true, 'tool field');
+});
+
+runTest('isPlanModePermission: matches toolName === "ExitPlanMode"', () => {
+  assertEqual(
+    notifier.isPlanModePermission({ toolName: 'ExitPlanMode' }),
+    true,
+    'toolName field'
+  );
+});
+
+runTest('isPlanModePermission: rejects other tools', () => {
+  assertEqual(notifier.isPlanModePermission({ tool: 'Bash' }), false, 'Bash');
+  assertEqual(notifier.isPlanModePermission({ tool: 'Edit' }), false, 'Edit');
+  assertEqual(notifier.isPlanModePermission({}), false, 'empty');
+});
+
+// ── planDecisionToHookResponse ───────────────────────────────────────
+
+runTest('planDecisionToHookResponse(plan_auto) — allow + bypassPermissions', () => {
+  const out = notifier.planDecisionToHookResponse('plan_auto');
+  assertEqual(out, {
+    hookSpecificOutput: {
+      hookEventName: 'PermissionRequest',
+      decision: {
+        behavior: 'allow',
+        updatedPermissions: [{ type: 'setMode', mode: 'bypassPermissions', destination: 'session' }],
+      },
+    },
+  }, 'plan_auto');
+});
+
+runTest('planDecisionToHookResponse(plan_accept) — allow + acceptEdits', () => {
+  const out = notifier.planDecisionToHookResponse('plan_accept');
+  assertEqual(out.hookSpecificOutput.decision.updatedPermissions[0].mode, 'acceptEdits', 'mode');
+  assertEqual(out.hookSpecificOutput.decision.behavior, 'allow', 'behavior');
+});
+
+runTest('planDecisionToHookResponse(plan_review) — allow + default', () => {
+  const out = notifier.planDecisionToHookResponse('plan_review');
+  assertEqual(out.hookSpecificOutput.decision.updatedPermissions[0].mode, 'default', 'mode');
+  assertEqual(out.hookSpecificOutput.decision.behavior, 'allow', 'behavior');
+});
+
+runTest('planDecisionToHookResponse(plan_keep) — deny with reason', () => {
+  const out = notifier.planDecisionToHookResponse('plan_keep');
+  assertEqual(out, {
+    hookSpecificOutput: {
+      hookEventName: 'PermissionRequest',
+      permissionDecision: 'deny',
+      permissionDecisionReason: 'User chose to keep planning',
+    },
+  }, 'plan_keep');
+});
+
+runTest('planDecisionToHookResponse(unknown decision) — null', () => {
+  assertNull(notifier.planDecisionToHookResponse('option_1'), 'option_1 not a plan mode value');
+  assertNull(notifier.planDecisionToHookResponse('allow'), 'allow not a plan mode value');
+  assertNull(notifier.planDecisionToHookResponse(''), 'empty');
+});
+
+// ── binaryDecisionToHookResponse ─────────────────────────────────────
+
+runTest('binaryDecisionToHookResponse(allow, wsActive=false)', () => {
+  const out = notifier.binaryDecisionToHookResponse('allow', false);
+  assertEqual(out.hookSpecificOutput.permissionDecision, 'allow', 'decision');
+  assertEqual(
+    out.hookSpecificOutput.permissionDecisionReason.includes('approved'),
+    true,
+    'reason mentions approved'
+  );
+  assertEqual(
+    out.hookSpecificOutput.permissionDecisionReason.includes('iPhone notification'),
+    true,
+    'reason mentions iPhone'
+  );
+});
+
+runTest('binaryDecisionToHookResponse(deny, wsActive=true)', () => {
+  const out = notifier.binaryDecisionToHookResponse('deny', true);
+  assertEqual(out.hookSpecificOutput.permissionDecision, 'deny', 'decision');
+  assertEqual(
+    out.hookSpecificOutput.permissionDecisionReason.includes('denied'),
+    true,
+    'reason mentions denied'
+  );
+  assertEqual(
+    out.hookSpecificOutput.permissionDecisionReason.includes('WebSocket'),
+    true,
+    'reason mentions WebSocket'
+  );
+});
+
+// ── PLAN_MODE_OPTIONS shape ──────────────────────────────────────────
+
+runTest('PLAN_MODE_OPTIONS has 4 entries with id+label+hint', () => {
+  const opts = notifier.PLAN_MODE_OPTIONS;
+  assertEqual(opts.length, 4, 'option count');
+  const ids = opts.map((o) => o.id).sort();
+  assertEqual(ids, ['plan_accept', 'plan_auto', 'plan_keep', 'plan_review'], 'ids');
+  for (const o of opts) {
+    if (typeof o.label !== 'string' || o.label.length === 0) {
+      throw new Error(`option ${o.id} missing label`);
+    }
+    if (typeof o.hint !== 'string' || o.hint.length === 0) {
+      throw new Error(`option ${o.id} missing hint`);
+    }
+  }
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

**PR-2 of 3** for the dynamic-options notification feature. Builds on the shared infrastructure landed in #74 (v1.11.0).

When Claude Code calls **ExitPlanMode** (the plan-mode approval prompt), the iPhone now shows a **4-button** push — \"Auto Mode\" / \"Accept Edits\" / \"Review Each\" + \"Open in Shooter\" — backed by the new \`CLAUDE_PLAN_APPROVAL\` category from PR-1. Each option maps back to the correct \`updatedPermissions.setMode\` value on the hook's stdout response, so Claude Code knows which permission mode you picked. The 5th option (\"Keep Planning\") is always reachable via the Decide screen.

Before this PR: ExitPlanMode fell through the binary allow/deny path — you could allow or deny, but couldn't pick which post-plan mode to use.

## Files touched

| File | Change |
| ---- | ------ |
| \`src/routes/api/notify/+server.ts\` | New body fields: \`notificationCategory\`, \`question\`, \`options\`, \`responseKind\`. Forwarded to all 3 createPendingRequest call sites + override APNs aps.category. Backcompat: omitting them keeps the binary CLAUDE_PERMISSION flow. |
| \`.claude/hooks/notifier.cjs\` | New pure helpers (PLAN_MODE_OPTIONS, isPlanModePermission, planDecisionToHookResponse, binaryDecisionToHookResponse). handlePermission branches early on ExitPlanMode and uses the plan-mode flow. sendNotificationAndPoll extras accept the new fields; deduplicated payload construction into a shared helper. Conditional module.exports re-exports helpers for tests. |
| \`tests/plan-mode-routing.test.cjs\` (new) | 11 unit tests for the decision mapping. |
| \`package.json\` | Wire the new test file into \`pnpm test\`. |

## Decision mapping (the heart of PR-2)

| User taps | Hook stdout |
| --------- | ----------- |
| Auto Mode | \`{ behavior: 'allow', updatedPermissions: [{ type: 'setMode', mode: 'bypassPermissions', destination: 'session' }] }\` |
| Accept Edits | \`{ ... mode: 'acceptEdits' ... }\` |
| Review Each | \`{ ... mode: 'default' ... }\` |
| Keep Planning | \`{ permissionDecision: 'deny', permissionDecisionReason: 'User chose to keep planning' }\` |

## What doesn't change

- Existing \`CLAUDE_PERMISSION\` binary Allow/Deny flow — unchanged, still uses the same code path via \`binaryDecisionToHookResponse\`.
- Non-ExitPlanMode permissions — unchanged, plan-mode branch only fires when \`tool === 'ExitPlanMode'\`.
- Notifier polling loop, /api/response, SQLite schema, iOS categories — all done in PR-1.

## Test plan

- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run check\` — 0 errors, 0 warnings
- [x] \`pnpm test\` — **44/44 pass** (6 terminal-store + 12 pending-requests + 15 tunnel-discovery + 11 plan-mode-routing)
- [x] \`pnpm run build\` — success
- [x] Smoke test: piped a synthetic ExitPlanMode PermissionRequest into notifier.cjs against the running daemon; body rendered correctly (\"1. Auto Mode  2. Accept Edits  3. Review Each  4. Keep Planning\") and the daemon accepted it (HTTP 200)
- [ ] CI green
- [ ] After merge: rebuild daemon (\`npm i -g @juspay/shooter@latest\` + restart) AND iOS app, trigger a real plan-mode session, verify the 4-button push appears and tapping each option lands the right \`setMode\` in the next CC tool call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic permission requests with customizable options and response types
  * Enhanced notification system to handle plan-mode permission workflows

* **Tests**
  * Added unit tests for plan-mode and permission routing validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/shooter/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->