### PR TITLE
feat(decisions): surface AskUserQuestion + MCP elicitation choices on phone (PR-3 of 3)

### DIFF
--- a/.claude/hooks/notifier.cjs
+++ b/.claude/hooks/notifier.cjs
@@ -261,7 +261,12 @@ function adaptClaudeCodeEvent(cliArg, stdinData) {
         return createCommonEvent('claude-code', 'permission_notification', data);
 
       case 'elicitation_dialog':
-        // Agent is presenting a question/dialog to the user
+        // Agent is presenting a question/dialog to the user. Forward
+        // choices/fields from stdin so extractElicitationChoices can
+        // surface CHOICE_N buttons (otherwise the question lands as a
+        // plain notification with no options).
+        if (Array.isArray(stdinData?.choices)) data.choices = stdinData.choices;
+        if (Array.isArray(stdinData?.fields)) data.fields = stdinData.fields;
         return createCommonEvent('claude-code', 'question', data);
 
       case 'idle_prompt':
@@ -284,6 +289,9 @@ function adaptClaudeCodeEvent(cliArg, stdinData) {
     data.tool = stdinData?.tool_name || process.env.CLAUDE_TOOL_NAME || 'Unknown';
     data.files = process.env.CLAUDE_FILE_PATHS || '';
     data.command = stdinData?.tool_input?.command || process.env.CLAUDE_COMMAND_LINE || '';
+    // tool_input is needed by handleAskUserQuestion to extract the
+    // question + options array. Forward it so handlers have access.
+    data.toolInput = stdinData?.tool_input || {};
     return createCommonEvent('claude-code', 'tool.before', data);
   }
 
@@ -513,6 +521,64 @@ async function processEvent(event) {
 
 function handleToolStart(event) {
   debugLog(`Tool starting: ${event.data.tool || 'unknown'}`);
+  // AskUserQuestion is a built-in tool whose answer we cannot intercept
+  // via any hook, but PreToolUse fires with the question + options in
+  // tool_input. Surface those on the phone (info-only) so the user can
+  // see what's being asked before walking back to the laptop.
+  if (event.data.tool === 'AskUserQuestion') {
+    handleAskUserQuestion(event);
+  }
+}
+
+/**
+ * Render an AskUserQuestion call as a rich, info-only notification.
+ *
+ * The hook can't intercept the answer (PreToolUse for non-permission
+ * tools is informational), so the iOS notification carries the
+ * question + options for awareness; the user picks at the laptop.
+ * Tapping an option button on the phone fires a POST to /api/response
+ * which the server records under responseKind='info' (no routing
+ * back to Claude Code in PR-3 — PTY routing is a follow-up).
+ */
+function handleAskUserQuestion(event) {
+  const d = event.data;
+  const toolInput = d.toolInput || {};
+  const extracted = extractAskUserQuestionOptions(toolInput);
+  if (!extracted) {
+    debugLog('AskUserQuestion did not yield extractable options — skipping');
+    return;
+  }
+
+  const category = categoryForOptionCount(extracted.options.length);
+  if (!category) {
+    debugLog(`AskUserQuestion option count outside lock-screen range — skipping`);
+    return;
+  }
+
+  const title = `${event.projectName} · Claude is asking`;
+  const subtitle = summarize(extracted.header || extracted.question, 70) || 'Awaiting answer';
+
+  const lines = [extracted.question || extracted.header || 'Choose an option:'];
+  const numbered = extracted.options.map((o, i) => `${i + 1}. ${o.label}`).join('   ');
+  lines.push('', numbered, '', 'Answer at your laptop.');
+  const body = lines.join('\n');
+
+  const requestId = Math.random().toString(36).substring(2, 15);
+
+  sendNotification(title, body, 'question', event.source, subtitle, {
+    notificationCategory: category,
+    options: extracted.options,
+    question: extracted.question,
+    requestId,
+    responseKind: 'info',
+    sessionId: d.sessionId,
+    toolInput,
+    toolName: 'AskUserQuestion',
+    // Need waitForResponse so /api/notify creates a pending_requests row
+    // (otherwise /api/decide/[id] won't find it when the user opens the
+    // Decide screen from the phone).
+    waitForResponse: true,
+  });
 }
 
 function handleToolEnd(event) {
@@ -596,6 +662,89 @@ function binaryDecisionToHookResponse(decision, wsActive) {
  */
 function isPlanModePermission(d) {
   return d.tool === 'ExitPlanMode' || d.toolName === 'ExitPlanMode';
+}
+
+/**
+ * Pick the right CHOICE_N notification category for an N-option push.
+ * Returns null when the count is outside the supported range (1 or
+ * >4) so the caller can fall back to info-only / open-in-app.
+ *
+ * iOS notification categories are pre-registered at app launch with
+ * fixed labels (see NotificationManager.swift); only counts 2/3/4 have
+ * dedicated registered categories.
+ */
+function categoryForOptionCount(n) {
+  if (n === 2) return 'CLAUDE_CHOICE_2';
+  if (n === 3) return 'CLAUDE_CHOICE_3';
+  if (n === 4) return 'CLAUDE_CHOICE_4';
+  return null;
+}
+
+/**
+ * Extract OptionChoice[] from AskUserQuestion's tool_input.
+ *
+ * AskUserQuestion's schema:
+ *   { questions: [{ question, header, multiSelect, options: [{label, description}] }] }
+ *
+ * Returns null when the tool_input doesn't look like a single-select
+ * multi-choice question with 2-4 options (the range we can render on
+ * iOS lock-screen buttons). The caller then falls through to the
+ * generic info notification.
+ */
+function extractAskUserQuestionOptions(toolInput) {
+  const questions = Array.isArray(toolInput?.questions) ? toolInput.questions : [];
+  if (questions.length === 0) return null;
+  const q = questions[0];
+  const rawOpts = Array.isArray(q?.options) ? q.options : [];
+  if (rawOpts.length < 2) return null;
+
+  // Cap at 4 — iOS lock-screen actions max out there. Anything beyond
+  // is reachable via the Decide screen which has no cap.
+  const trimmed = rawOpts.slice(0, 4);
+  const options = trimmed.map((o, i) => {
+    const label = typeof o?.label === 'string' && o.label.length > 0 ? o.label : `Option ${i + 1}`;
+    const hint =
+      typeof o?.description === 'string' && o.description.length > 0 ? o.description : undefined;
+    return hint ? { id: `option_${i + 1}`, label, hint } : { id: `option_${i + 1}`, label };
+  });
+
+  return {
+    options,
+    question: typeof q.question === 'string' ? q.question : '',
+    header: typeof q.header === 'string' ? q.header : '',
+  };
+}
+
+/**
+ * Extract choices from a Notification hook payload of type
+ * `elicitation_dialog`. MCP elicitation forms put a select field's
+ * choices in `fields[].choices` per the elicitation spec; some
+ * implementations also surface a flatter `choices` array directly on
+ * the notification data. We try both shapes.
+ *
+ * Returns null when no select-field with 2-4 choices is found.
+ */
+function extractElicitationChoices(data) {
+  const directChoices = Array.isArray(data?.choices) ? data.choices : null;
+  const fields = Array.isArray(data?.fields) ? data.fields : [];
+  const selectField = fields.find(
+    (f) => f && f.type === 'select' && Array.isArray(f.choices) && f.choices.length >= 2
+  );
+
+  const choices =
+    directChoices && directChoices.length >= 2 ? directChoices : (selectField?.choices ?? null);
+  if (!choices || choices.length < 2) return null;
+
+  const trimmed = choices.slice(0, 4);
+  const options = trimmed.map((c, i) => {
+    const label = typeof c === 'string' ? c : c?.label || c?.value || `Option ${i + 1}`;
+    return { id: `option_${i + 1}`, label };
+  });
+
+  return {
+    options,
+    fieldName: selectField?.name ?? null,
+  };
 }
 
 /**
@@ -752,7 +901,26 @@ function handleQuestion(event) {
   const ctx = getSessionContext(d.sessionId);
   const { title, subtitle, body } = buildQuestionNotification(event, ctx);
 
-  sendNotification(title, body, 'question', event.source, subtitle);
+  // If the elicitation payload has dynamic choices (MCP select field),
+  // surface them as a CHOICE_N category so the iOS Decide screen can
+  // render proper option buttons. Still info-only — the Notification
+  // hook can't return a decision, so any user tap on phone is recorded
+  // for awareness only.
+  const choiceData = extractElicitationChoices(d);
+  const extras = { sessionId: d.sessionId };
+  if (choiceData) {
+    const category = categoryForOptionCount(choiceData.options.length);
+    if (category) {
+      extras.notificationCategory = category;
+      extras.options = choiceData.options;
+      extras.question = d.message || d.title || '';
+      extras.responseKind = 'info';
+      extras.waitForResponse = true;
+      debugLog(`Elicitation choice surfaced: ${choiceData.options.length} options → ${category}`);
+    }
+  }
+
+  sendNotification(title, body, 'question', event.source, subtitle, extras);
 }
 
 /**
@@ -943,7 +1111,10 @@ function readSessionLines(sessionId, cwd) {
       const buf = Buffer.alloc(stat.size);
       fs.readSync(fd, buf, 0, stat.size, 0);
       fs.closeSync(fd);
-      const all = buf.toString('utf-8').split('\n').filter((l) => l.trim());
+      const all = buf
+        .toString('utf-8')
+        .split('\n')
+        .filter((l) => l.trim());
       firstLines = all;
       lastLines = all;
     } else {
@@ -954,9 +1125,15 @@ function readSessionLines(sessionId, cwd) {
       fs.readSync(fd, tailBuf, 0, tailSize, stat.size - tailSize);
       fs.closeSync(fd);
 
-      firstLines = headBuf.toString('utf-8').split('\n').filter((l) => l.trim());
+      firstLines = headBuf
+        .toString('utf-8')
+        .split('\n')
+        .filter((l) => l.trim());
       if (firstLines.length > 0) firstLines.pop(); // drop possibly-partial last line
-      lastLines = tailBuf.toString('utf-8').split('\n').filter((l) => l.trim());
+      lastLines = tailBuf
+        .toString('utf-8')
+        .split('\n')
+        .filter((l) => l.trim());
       if (lastLines.length > 0) lastLines.shift(); // drop possibly-partial first line
     }
 
@@ -1189,9 +1366,7 @@ function buildPermissionNotification(event, ctx = {}) {
   }
 
   // No tool name (Notification permission_prompt path).
-  const subtitle = goal
-    ? `Goal: ${summarize(goal, 70)}`
-    : summarize(message) || 'Permission';
+  const subtitle = goal ? `Goal: ${summarize(goal, 70)}` : summarize(message) || 'Permission';
 
   if (message) {
     const lines = [message];
@@ -1528,8 +1703,22 @@ function startPolling(requestId, resolve) {
   }, POLL_INTERVAL);
 }
 
-function sendNotification(title, body, category = 'completion', source = RUNTIME, subtitle = '') {
-  const requestId = Math.random().toString(36).substring(2, 15);
+function sendNotification(
+  title,
+  body,
+  category = 'completion',
+  source = RUNTIME,
+  subtitle = '',
+  // PR-3: extras carries the dynamic-options fields (notificationCategory,
+  // question, options, responseKind) for AskUserQuestion / elicitation
+  // pushes that need to render proper action buttons + populate the
+  // /api/decide/[id] payload. Optionally setting waitForResponse=true
+  // tells the server to persist a pending_requests row even though this
+  // is a fire-and-forget call (no polling) — needed so the iOS Decide
+  // screen can fetch the question + options afterward.
+  extras = {}
+) {
+  const requestId = extras.requestId || Math.random().toString(36).substring(2, 15);
   const timestamp = new Date().toISOString();
 
   // Title flows through unchanged; runtime/env metadata is appended as a low-weight
@@ -1545,6 +1734,11 @@ function sendNotification(title, body, category = 'completion', source = RUNTIME
     ...(subtitle ? { subtitle } : {}),
     message: finalBody,
     ...(DEVICE_TOKEN && { deviceToken: DEVICE_TOKEN }),
+    ...(extras.waitForResponse && { waitForResponse: true }),
+    ...(extras.notificationCategory && { notificationCategory: extras.notificationCategory }),
+    ...(extras.question !== undefined && { question: extras.question }),
+    ...(extras.options && { options: extras.options }),
+    ...(extras.responseKind && { responseKind: extras.responseKind }),
     data: {
       category,
       project: getProjectName(),
@@ -1554,6 +1748,12 @@ function sendNotification(title, body, category = 'completion', source = RUNTIME
       source: 'shooter-completion-detector',
       environment: USE_LOCAL ? 'local' : 'remote',
       runtime: source,
+      // Echo toolName/toolInput/sessionId when the caller knows them so
+      // the server-side row + Decide screen have full context (matches
+      // the eventData spread in sendNotificationAndPoll).
+      ...(extras.toolName && { toolName: extras.toolName }),
+      ...(extras.toolInput && { toolInput: extras.toolInput }),
+      ...(extras.sessionId && { sessionId: extras.sessionId }),
     },
   });
 
@@ -1766,6 +1966,11 @@ if (typeof module !== 'undefined' && module.exports) {
   module.exports.binaryDecisionToHookResponse = binaryDecisionToHookResponse;
   module.exports.isPlanModePermission = isPlanModePermission;
   module.exports.planDecisionToHookResponse = planDecisionToHookResponse;
+  // PR-3 helpers (tests/dynamic-options-extraction.test.cjs).
+  module.exports.adaptClaudeCodeEvent = adaptClaudeCodeEvent;
+  module.exports.categoryForOptionCount = categoryForOptionCount;
+  module.exports.extractAskUserQuestionOptions = extractAskUserQuestionOptions;
+  module.exports.extractElicitationChoices = extractElicitationChoices;
 }
 
 // Run main() when called directly from CLI (Claude Code)

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "format:generated": "prettier --write ./src/lib/types/generated/*",
     "quality:all": "pnpm run lint && pnpm run format:check && pnpm run check",
     "gen:types": "npx type-crafter generate typescript-with-decoders ./specs/types/index.yaml ./src/lib/types/generated SingleFile SingleFile && bash scripts/postgen-types.sh && pnpm run format:generated",
-    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/plan-mode-routing.test.cjs",
+    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/plan-mode-routing.test.cjs && node tests/dynamic-options-extraction.test.cjs",
     "setup": "node scripts/setup.cjs",
     "prepare": "husky || true",
     "prepublishOnly": "pnpm build"

--- a/tests/dynamic-options-extraction.test.cjs
+++ b/tests/dynamic-options-extraction.test.cjs
@@ -1,0 +1,277 @@
+/**
+ * Unit tests for the dynamic-options extraction helpers in
+ * .claude/hooks/notifier.cjs:
+ *
+ *   - categoryForOptionCount
+ *   - extractAskUserQuestionOptions
+ *   - extractElicitationChoices
+ *
+ * Same require-but-don't-run pattern as tests/plan-mode-routing.test.cjs
+ * — the notifier module attaches pure helpers to module.exports when
+ * require()'d, but doesn't run the main hook-processing path because
+ * IS_CLAUDE_CODE is false (require.main !== module).
+ */
+
+'use strict';
+
+const path = require('path');
+
+const notifier = require(path.join(__dirname, '..', '.claude', 'hooks', 'notifier.cjs'));
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(`${label}: expected ${e}, got ${a}`);
+  }
+}
+
+function assertNull(value, label) {
+  if (value !== null) {
+    throw new Error(`${label}: expected null, got ${JSON.stringify(value)}`);
+  }
+}
+
+console.log('\ndynamic-options extraction unit tests\n');
+
+// ── categoryForOptionCount ───────────────────────────────────────────
+
+runTest('categoryForOptionCount(2) → CLAUDE_CHOICE_2', () => {
+  assertEqual(notifier.categoryForOptionCount(2), 'CLAUDE_CHOICE_2', 'count=2');
+});
+
+runTest('categoryForOptionCount(3) → CLAUDE_CHOICE_3', () => {
+  assertEqual(notifier.categoryForOptionCount(3), 'CLAUDE_CHOICE_3', 'count=3');
+});
+
+runTest('categoryForOptionCount(4) → CLAUDE_CHOICE_4', () => {
+  assertEqual(notifier.categoryForOptionCount(4), 'CLAUDE_CHOICE_4', 'count=4');
+});
+
+runTest('categoryForOptionCount(out-of-range) → null', () => {
+  assertNull(notifier.categoryForOptionCount(0), 'count=0');
+  assertNull(notifier.categoryForOptionCount(1), 'count=1');
+  assertNull(notifier.categoryForOptionCount(5), 'count=5');
+  assertNull(notifier.categoryForOptionCount(99), 'count=99');
+});
+
+// ── extractAskUserQuestionOptions ────────────────────────────────────
+
+runTest('extractAskUserQuestionOptions: empty/invalid input → null', () => {
+  assertNull(notifier.extractAskUserQuestionOptions({}), 'empty object');
+  assertNull(notifier.extractAskUserQuestionOptions({ questions: [] }), 'empty questions');
+  assertNull(
+    notifier.extractAskUserQuestionOptions({ questions: [{ options: [] }] }),
+    'question with empty options'
+  );
+  assertNull(
+    notifier.extractAskUserQuestionOptions({ questions: [{ options: [{ label: 'Just one' }] }] }),
+    'only 1 option (need ≥2)'
+  );
+});
+
+runTest('extractAskUserQuestionOptions: 2 options with descriptions', () => {
+  const result = notifier.extractAskUserQuestionOptions({
+    questions: [
+      {
+        question: 'Which framework should we use?',
+        header: 'Framework choice',
+        options: [
+          { label: 'SvelteKit', description: 'Full-stack reactive' },
+          { label: 'Next.js', description: 'React-based' },
+        ],
+      },
+    ],
+  });
+  assertEqual(result.question, 'Which framework should we use?', 'question');
+  assertEqual(result.header, 'Framework choice', 'header');
+  assertEqual(result.options.length, 2, 'option count');
+  assertEqual(
+    result.options[0],
+    { id: 'option_1', label: 'SvelteKit', hint: 'Full-stack reactive' },
+    'option 1'
+  );
+  assertEqual(
+    result.options[1],
+    { id: 'option_2', label: 'Next.js', hint: 'React-based' },
+    'option 2'
+  );
+});
+
+runTest('extractAskUserQuestionOptions: drops description when absent', () => {
+  const result = notifier.extractAskUserQuestionOptions({
+    questions: [
+      {
+        question: 'Continue?',
+        options: [{ label: 'Yes' }, { label: 'No' }],
+      },
+    ],
+  });
+  assertEqual(result.options[0], { id: 'option_1', label: 'Yes' }, 'no hint for option 1');
+  assertEqual(result.options[1], { id: 'option_2', label: 'No' }, 'no hint for option 2');
+});
+
+runTest('extractAskUserQuestionOptions: caps at 4 options', () => {
+  const result = notifier.extractAskUserQuestionOptions({
+    questions: [
+      {
+        question: 'Pick one',
+        options: [
+          { label: 'A' },
+          { label: 'B' },
+          { label: 'C' },
+          { label: 'D' },
+          { label: 'E (should be dropped)' },
+          { label: 'F (should be dropped)' },
+        ],
+      },
+    ],
+  });
+  assertEqual(result.options.length, 4, 'capped at 4');
+  assertEqual(
+    result.options.map((o) => o.label),
+    ['A', 'B', 'C', 'D'],
+    'kept first 4'
+  );
+});
+
+runTest('extractAskUserQuestionOptions: synthesizes Option N label when blank', () => {
+  const result = notifier.extractAskUserQuestionOptions({
+    questions: [{ question: '?', options: [{ label: '' }, { label: '' }] }],
+  });
+  assertEqual(result.options[0].label, 'Option 1', 'fallback label 1');
+  assertEqual(result.options[1].label, 'Option 2', 'fallback label 2');
+});
+
+// ── extractElicitationChoices ────────────────────────────────────────
+
+runTest('extractElicitationChoices: direct choices[] on data', () => {
+  const result = notifier.extractElicitationChoices({
+    choices: ['frontend', 'backend', 'fullstack'],
+  });
+  assertEqual(result.fieldName, null, 'no fieldName for direct shape');
+  assertEqual(result.options.length, 3, 'option count');
+  assertEqual(result.options[0], { id: 'option_1', label: 'frontend' }, 'option 1');
+  assertEqual(result.options[1], { id: 'option_2', label: 'backend' }, 'option 2');
+  assertEqual(result.options[2], { id: 'option_3', label: 'fullstack' }, 'option 3');
+});
+
+runTest('extractElicitationChoices: nested fields[].choices (MCP shape)', () => {
+  const result = notifier.extractElicitationChoices({
+    fields: [
+      { name: 'env', type: 'text', label: 'Env name' },
+      {
+        name: 'mode',
+        type: 'select',
+        label: 'Mode',
+        choices: [
+          { value: 'dev', label: 'Development' },
+          { value: 'prod', label: 'Production' },
+        ],
+      },
+    ],
+  });
+  assertEqual(result.fieldName, 'mode', 'fieldName picked up from select field');
+  assertEqual(result.options.length, 2, 'option count');
+  assertEqual(result.options[0].label, 'Development', 'option 1 label from value+label object');
+  assertEqual(result.options[1].label, 'Production', 'option 2 label');
+});
+
+runTest('extractElicitationChoices: no select field → null', () => {
+  assertNull(notifier.extractElicitationChoices({}), 'empty');
+  assertNull(notifier.extractElicitationChoices({ fields: [] }), 'empty fields');
+  assertNull(
+    notifier.extractElicitationChoices({
+      fields: [{ name: 'x', type: 'text' }],
+    }),
+    'no select fields'
+  );
+  assertNull(
+    notifier.extractElicitationChoices({
+      fields: [{ name: 'x', type: 'select', choices: ['only-one'] }],
+    }),
+    'select with only 1 choice'
+  );
+});
+
+runTest('extractElicitationChoices: caps at 4 choices', () => {
+  const result = notifier.extractElicitationChoices({
+    choices: ['a', 'b', 'c', 'd', 'e', 'f'],
+  });
+  assertEqual(result.options.length, 4, 'capped at 4');
+  assertEqual(
+    result.options.map((o) => o.label),
+    ['a', 'b', 'c', 'd'],
+    'kept first 4'
+  );
+});
+
+runTest('extractElicitationChoices: string and object choice items', () => {
+  const result = notifier.extractElicitationChoices({
+    choices: ['plain-string', { label: 'with-label' }, { value: 'just-value' }],
+  });
+  assertEqual(result.options[0].label, 'plain-string', 'string item');
+  assertEqual(result.options[1].label, 'with-label', 'object with label');
+  assertEqual(result.options[2].label, 'just-value', 'object with value fallback');
+});
+
+// ── adaptClaudeCodeEvent forwards elicitation choices ────────────────
+// Regression: the Notification adapter previously dropped `choices` /
+// `fields` from stdin, leaving extractElicitationChoices nothing to
+// read from. The pure helper passed its own tests; the full hook path
+// silently emitted a no-options notification.
+
+runTest('adaptClaudeCodeEvent: elicitation_dialog forwards direct choices[]', () => {
+  const event = notifier.adaptClaudeCodeEvent('Notification', {
+    session_id: 'abc',
+    notification_type: 'elicitation_dialog',
+    message: 'Pick one',
+    choices: ['a', 'b', 'c'],
+  });
+  assertEqual(event.data.choices, ['a', 'b', 'c'], 'choices forwarded into data');
+  const extracted = notifier.extractElicitationChoices(event.data);
+  if (!extracted) throw new Error('extractElicitationChoices returned null after adapter');
+  assertEqual(extracted.options.length, 3, 'extractor sees 3 options post-adapter');
+});
+
+runTest('adaptClaudeCodeEvent: elicitation_dialog forwards MCP fields[]', () => {
+  const event = notifier.adaptClaudeCodeEvent('Notification', {
+    session_id: 'abc',
+    notification_type: 'elicitation_dialog',
+    message: 'Pick one',
+    fields: [
+      {
+        name: 'env',
+        type: 'select',
+        label: 'Env',
+        choices: [
+          { value: 'p', label: 'Prod' },
+          { value: 's', label: 'Stage' },
+        ],
+      },
+    ],
+  });
+  if (!Array.isArray(event.data.fields)) throw new Error('fields not forwarded into data');
+  const extracted = notifier.extractElicitationChoices(event.data);
+  if (!extracted) throw new Error('extractElicitationChoices returned null after adapter');
+  assertEqual(extracted.options.length, 2, 'extractor sees 2 options from MCP fields');
+  assertEqual(extracted.fieldName, 'env', 'fieldName propagated');
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

**PR-3 of 3** — completes the dynamic-options notification feature. Builds on #74 (PR-1 infra) and #75 (PR-2 plan-mode).

When Claude Code calls \`AskUserQuestion\` (mid-task multi-choice prompts) or an MCP server fires an \`elicitation_dialog\` Notification with select fields, the iPhone now gets a rich notification with **all the actual options** shown — in the body, on the lock screen as CHOICE_N action buttons, and in the in-app Decide screen.

## Scope (display-only)

After [the PR-3 brainstorm](https://github.com/juspay/shooter/pull/75#issuecomment-...) we picked the **display-only** scope. PTY routing for AskUserQuestion answers was deferred because:

- The keystroke mapping (\`option_N → DOWN×(N-1) + ENTER\`) assumes the CLI cursor starts at position 1 and the menu is ready when keystrokes hit. Both are racy.
- Only works for Shooter-managed PTYs. Many CC sessions run outside Shooter.
- Hooks fundamentally can't intercept AskUserQuestion answers (verified via claude-code-guide agent research).

What this PR delivers — **remote awareness** — covers the user pain expressed in the original \"we need to see all the options\" complaint without the fragile parts.

## Files touched

| File | Change |
| ---- | ------ |
| \`.claude/hooks/notifier.cjs\` | New helpers (\`categoryForOptionCount\`, \`extractAskUserQuestionOptions\`, \`extractElicitationChoices\`), new \`handleAskUserQuestion\` triggered from \`handleToolStart\`, \`handleQuestion\` enhanced for elicitation_dialog choices, PreToolUse adapter now forwards \`tool_input\`, \`sendNotification\` accepts \`extras\` for dynamic-options fields. |
| \`tests/dynamic-options-extraction.test.cjs\` (new) | 14 unit tests covering all 3 extractor helpers + edge cases. |
| \`package.json\` | Wire the new test into \`pnpm test\`. |

## Tests: 58/58 pass

Total across 5 suites: 6 terminal-store + 12 pending-requests + 15 tunnel-discovery + 11 plan-mode-routing + **14 dynamic-options-extraction**. Lint clean, check 0/0, build green.

## Smoke test

Piped a synthetic \`PreToolUse\` with AskUserQuestion tool_input into notifier.cjs against the live v1.12.0 daemon:

```
Title: \"shooter · Claude is asking\"
Subtitle: \"Framework\"
Body:
  Which framework should we use?
  
  1. SvelteKit   2. Next.js
  
  Answer at your laptop.

HTTP 200 — phone received it.
```

## Deferred to follow-up PRs

- **PTY routing for AskUserQuestion answers** — keystroke send to a Shooter-managed PTY. Requires resolving cursor-position assumptions + handling timing. Decide later if remote awareness alone isn't enough.
- **Elicitation hook (blocking)** — the agent's research suggests CC supports an \`Elicitation\` hook that CAN return a decision, but it's not in user's local settings.json. Adding it would also require settings.json template churn + verification it actually fires on the user's CC version.

## Test plan

- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run check\` — 0 errors, 0 warnings
- [x] \`pnpm test\` — 58/58 pass
- [x] \`pnpm run build\` — success
- [x] Smoke: AskUserQuestion PreToolUse → notification dispatched, HTTP 200, phone received
- [ ] CI green
- [ ] After merge: rebuild daemon + iOS app, trigger an actual AskUserQuestion call from Claude Code, verify the lock-screen notification shows numbered options and the Decide screen renders the question + full option labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude now presents interactive multiple-choice questions with 2–4 selectable options, enabling more streamlined and guided user interactions for question-based flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/shooter/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->