### PR TITLE
fix(device-token): write to process.env so APNs picks up new tokens

### DIFF
--- a/src/routes/api/device-token/+server.ts
+++ b/src/routes/api/device-token/+server.ts
@@ -1,4 +1,3 @@
-import { env } from '$env/dynamic/private';
 import { validateAuth } from '$lib/modules/server/auth';
 import { json } from '@sveltejs/kit';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
@@ -70,9 +69,14 @@ export const POST: RequestHandler = async ({ request }) => {
   tokens[platform] = token;
   writeTokens(tokens);
 
-  // Update in-memory env so APNs can use it immediately (iOS is the primary APNs target)
+  // Update in-memory env so APNs can use it immediately (iOS is the primary APNs target).
+  // SvelteKit's $env/dynamic/private exposes a Proxy whose getter reads process.env at
+  // access time but whose setter does NOT propagate to process.env. Assigning via the
+  // Proxy is a silent no-op, so subsequent /api/notify calls still read the stale value
+  // from .env. Write straight to process.env so env.DEVICE_TOKEN picks up the new token
+  // on the next read.
   if (platform === 'ios') {
-    (env as Record<string, string>).DEVICE_TOKEN = token;
+    process.env.DEVICE_TOKEN = token;
   }
 
   console.log(`[device-token] Registered ${platform} token (length: ${token.length})`);


### PR DESCRIPTION
## Why

`/api/device-token` tried to update the in-memory device token by assigning through SvelteKit's `\$env/dynamic/private` Proxy:

\`\`\`ts
(env as Record<string, string>).DEVICE_TOKEN = token;
\`\`\`

The Proxy's getter reads `process.env` at access time, but its setter is a silent no-op — assignments don't propagate to `process.env`. So `/api/notify` kept reading the stale value from `.env` on every push. After an iOS app reinstall (which generates a fresh APNs device token), every push silently failed with HTTP 400 `BadDeviceToken` until the user manually edited `.env` and restarted the daemon.

Caught during a real-iPhone E2E test of the dynamic-options decision flow — APNs returned `BadDeviceToken` 5× in a row despite the iOS app having just registered.

## What

- Assign `process.env.DEVICE_TOKEN = token` directly. Same intent, actually works.
- Drop the now-unused `\$env/dynamic/private` import.
- Comment explains the Proxy gotcha so the next person doesn't re-introduce the pattern.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run check` — 0 errors, 0 warnings
- [x] `pnpm test` — 60/60 pass (no test regression from the import drop)