### PR TITLE
feat(codex): Codex CLI session support

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "format:generated": "prettier --write ./src/lib/types/generated/*",
     "quality:all": "pnpm run lint && pnpm run format:check && pnpm run check",
     "gen:types": "npx type-crafter generate typescript-with-decoders ./specs/types/index.yaml ./src/lib/types/generated SingleFile SingleFile && bash scripts/postgen-types.sh && pnpm run format:generated",
-    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/plan-mode-routing.test.cjs && node tests/dynamic-options-extraction.test.cjs",
+    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/plan-mode-routing.test.cjs && node tests/dynamic-options-extraction.test.cjs && node tests/codex-parser.test.cjs",
     "setup": "node scripts/setup.cjs",
     "prepare": "husky || true",
     "prepublishOnly": "pnpm build"

--- a/server.ts
+++ b/server.ts
@@ -23,6 +23,7 @@ if (!existsSync(handlerPath)) {
 }
 
 const { handler } = await import('./build/handler.js');
+import { codexWatcher } from './src/lib/modules/server/terminal/codex-watcher.js';
 import { openCodeWatcher } from './src/lib/modules/server/terminal/opencode-watcher.js';
 import { ptyManager } from './src/lib/modules/server/terminal/pty-manager.js';
 import { sessionWatcher } from './src/lib/modules/server/terminal/session-watcher.js';
@@ -69,6 +70,10 @@ const sessionWatcherAdapter = {
     if (!sessionFile.includes('/') && !sessionFile.includes('.jsonl')) {
       return openCodeWatcher.getHistory(sessionFile);
     }
+    // Codex rollout files live under ~/.codex/sessions (or archived_sessions).
+    if (sessionFile.includes('/.codex/')) {
+      return codexWatcher.getHistory(sessionFile);
+    }
     return sessionWatcher.getHistory(sessionFile);
   },
   subscribe(sessionFile: string, callback: Parameters<typeof sessionWatcher.watch>[1]) {
@@ -76,6 +81,12 @@ const sessionWatcherAdapter = {
       openCodeWatcher.watch(sessionFile, callback as (messages: ConversationMessage[]) => void);
       return () =>
         openCodeWatcher.stop(sessionFile, callback as (messages: ConversationMessage[]) => void);
+    }
+    if (sessionFile.includes('/.codex/')) {
+      return codexWatcher.subscribe(
+        sessionFile,
+        callback as (messages: ConversationMessage[]) => void
+      );
     }
     // Use subscribe() which returns a ref-counted unsubscribe function.
     // The watcher is only torn down when the last subscriber disconnects.
@@ -209,6 +220,7 @@ function shutdown(signal: string): void {
   ptyManager.disconnectAll();
   sessionWatcher.stopAll();
   openCodeWatcher.stopAll();
+  codexWatcher.stopAll();
 
   // Terminate all remaining WebSocket clients (/ws/session, /ws/events)
   // so wss.close() doesn't hang waiting for them to disconnect.

--- a/specs/types/sessions.yaml
+++ b/specs/types/sessions.yaml
@@ -11,6 +11,8 @@ Sessions:
     enum:
       - claude-code
       - opencode
+      - codex
+      - gemini
     description: Source tool that produced the session
 
   MessageRole:

--- a/src/lib/modules/client/common/index.ts
+++ b/src/lib/modules/client/common/index.ts
@@ -4,5 +4,6 @@ export { getApiKey, isShooterConfig } from './config-guard';
 export { toErrorMessage } from './error';
 export { renderMarkdown } from './markdown';
 export { hasScanner, isNativeBridge, scanQR } from './native-bridge';
+export { sourceLabel, sourceToCommand } from './provider';
 export { formatRelativeTime } from './time';
 export { getToolDescription } from './tool-title';

--- a/src/lib/modules/client/common/provider.ts
+++ b/src/lib/modules/client/common/provider.ts
@@ -1,0 +1,30 @@
+// Shared provider/source mappings used by the session + project UIs so every
+// page agrees on which CLI binary and label corresponds to each SessionSource.
+// Using Record<SessionSource, …> makes these exhaustive: adding a new provider
+// to the SessionSource union forces a compile error here until it is handled.
+
+import type { SessionSource } from '$lib/types';
+
+const SOURCE_COMMAND: Record<SessionSource, string> = {
+  'claude-code': 'claude',
+  codex: 'codex',
+  gemini: 'gemini',
+  opencode: 'opencode',
+};
+
+const SOURCE_LABEL: Record<SessionSource, string> = {
+  'claude-code': 'Claude Code',
+  codex: 'Codex',
+  gemini: 'Gemini',
+  opencode: 'OpenCode',
+};
+
+/** Human-readable label for a session source. */
+export function sourceLabel(source: SessionSource): string {
+  return SOURCE_LABEL[source] ?? 'Claude Code';
+}
+
+/** Map a session source to the CLI binary used to launch/resume it. */
+export function sourceToCommand(source: SessionSource): string {
+  return SOURCE_COMMAND[source] ?? 'claude';
+}

--- a/src/lib/modules/client/terminal/LaunchSheet.svelte
+++ b/src/lib/modules/client/terminal/LaunchSheet.svelte
@@ -9,6 +9,8 @@
 
   const presets: Preset[] = [
     { args: [], command: 'claude', label: 'Claude Code' },
+    { args: [], command: 'codex', label: 'Codex' },
+    { args: [], command: 'gemini', label: 'Gemini' },
     { args: [], command: 'opencode', label: 'OpenCode' },
     { args: [], command: 'zsh', label: 'Shell / zsh' },
     { args: [], command: 'bash', label: 'Bash' },

--- a/src/lib/modules/server/sessions/codex-parser.ts
+++ b/src/lib/modules/server/sessions/codex-parser.ts
@@ -1,0 +1,286 @@
+/**
+ * Codex CLI rollout JSONL parser.
+ *
+ * Codex writes one "rollout" JSONL file per session under
+ * ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl. Each line is a
+ * record `{ timestamp, type, payload }`. The `response_item` records are the
+ * conversation source of truth (event_msg/turn_context/compacted are UI/control
+ * noise). This converts them into the canonical ConversationMessage[] shape,
+ * mirroring jsonl-parser.ts (Claude) and opencode-reader.ts (OpenCode).
+ *
+ * Grouping uses "role runs": consecutive parts of the same category
+ * (user | assistant-content | tool-result) are merged into one message and
+ * flushed when the category changes, producing clean chronological bubbles.
+ */
+
+import type {
+  CodexParseResult,
+  CodexSessionMeta,
+  ConversationMessage,
+  MessagePart,
+} from '$lib/types';
+
+/** Accumulates parts into role-runs, flushing completed messages on category change. */
+class TurnBuilder {
+  private current: null | {
+    category: 'assistant' | 'system' | 'user';
+    parts: MessagePart[];
+    role: ConversationMessage['role'];
+    timestamp: string;
+  } = null;
+  private readonly messages: ConversationMessage[] = [];
+
+  /** Messages flushed so far (excludes the still-open run). */
+  completed(): ConversationMessage[] {
+    return this.messages;
+  }
+
+  flush(): void {
+    if (this.current && this.current.parts.length > 0) {
+      this.messages.push({
+        id: `codex-${this.messages.length}`,
+        parts: this.current.parts,
+        role: this.current.role,
+        timestamp: this.current.timestamp,
+      });
+    }
+    this.current = null;
+  }
+
+  push(role: 'assistant' | 'user', part: MessagePart, timestamp: string): void {
+    const category: 'assistant' | 'system' | 'user' =
+      role === 'user' ? 'user' : part.type === 'tool_result' ? 'system' : 'assistant';
+    const messageRole: ConversationMessage['role'] = category === 'system' ? 'system' : role;
+    if (this.current?.category !== category) {
+      this.flush();
+      this.current = { category, parts: [], role: messageRole, timestamp };
+    }
+    this.current.parts.push(part);
+  }
+
+  result(): ConversationMessage[] {
+    this.flush();
+    return this.messages;
+  }
+}
+
+/**
+ * Incremental Codex parser for live streaming. Feed raw JSONL lines as they are
+ * appended to a rollout file; returns messages that became *complete* on each
+ * call (a run completes when the next run of a different category begins).
+ * Call flushOpen() when the session goes idle to emit the final open run.
+ */
+export class CodexStreamParser {
+  private readonly builder = new TurnBuilder();
+  private emitted = 0;
+
+  /** Emit the final open run when the session goes idle (no more lines are coming). */
+  flushOpen(): ConversationMessage[] {
+    this.builder.flush();
+    return this.drain();
+  }
+
+  /** Feed one raw JSONL line; returns any messages that became complete as a result. */
+  pushLine(rawLine: string): ConversationMessage[] {
+    const trimmed = rawLine.trim();
+    if (trimmed) {
+      try {
+        const entry: unknown = JSON.parse(trimmed);
+        if (isRecord(entry) && entry.type === 'response_item' && isRecord(entry.payload)) {
+          const mapped = responseItemToPart(entry.payload);
+          if (mapped) {
+            this.builder.push(mapped.role, mapped.part, str(entry, 'timestamp'));
+          }
+        }
+      } catch {
+        // skip malformed line
+      }
+    }
+    return this.drain();
+  }
+
+  private drain(): ConversationMessage[] {
+    const all = this.builder.completed();
+    const fresh = all.slice(this.emitted);
+    this.emitted = all.length;
+    return fresh;
+  }
+}
+
+/** Parse the `session_meta` payload (the first line of a rollout file). */
+export function parseCodexMeta(line: string): CodexSessionMeta | null {
+  try {
+    const entry: unknown = JSON.parse(line);
+    if (!isRecord(entry) || entry.type !== 'session_meta' || !isRecord(entry.payload)) {
+      return null;
+    }
+    const p = entry.payload;
+    if (!str(p, 'id') || !str(p, 'cwd')) {
+      return null;
+    }
+    return {
+      cliVersion: str(p, 'cli_version'),
+      cwd: str(p, 'cwd'),
+      id: str(p, 'id'),
+      model: str(p, 'model') || str(p, 'model_provider'),
+      startedAt: str(p, 'timestamp') || str(entry, 'timestamp'),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Parse a full Codex rollout file's text into meta + canonical messages. */
+export function parseCodexRollout(text: string): CodexParseResult {
+  const builder = new TurnBuilder();
+  let meta: CodexSessionMeta | null = null;
+
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    let entry: unknown;
+    try {
+      entry = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!isRecord(entry)) {
+      continue;
+    }
+
+    const ts = str(entry, 'timestamp');
+
+    if (entry.type === 'session_meta') {
+      meta = parseCodexMeta(trimmed);
+      continue;
+    }
+    if (entry.type !== 'response_item' || !isRecord(entry.payload)) {
+      continue; // event_msg, turn_context, compacted — not conversation content
+    }
+
+    const mapped = responseItemToPart(entry.payload);
+    if (mapped) {
+      builder.push(mapped.role, mapped.part, ts);
+    }
+  }
+
+  return { messages: builder.result(), meta };
+}
+
+/** Narrow an unknown value to a plain object with string keys. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Join the text blocks of a Codex `message` content array. */
+function joinMessageText(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return typeof content === 'string' ? content : '';
+  }
+  return content
+    .filter((c): c is Record<string, unknown> => isRecord(c))
+    .filter((c) => c.type === 'input_text' || c.type === 'output_text' || c.type === 'text')
+    .map((c) => str(c, 'text'))
+    .join('\n')
+    .trim();
+}
+
+/** Coerce a tool-call argument (JSON string, raw string, or object) into a record. */
+function parseToolInput(raw: unknown): Record<string, unknown> {
+  if (isRecord(raw)) {
+    return raw;
+  }
+  if (typeof raw === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return isRecord(parsed) ? parsed : { raw };
+    } catch {
+      return { raw };
+    }
+  }
+  return {};
+}
+
+/** Extract the visible reasoning text (Codex reasoning is usually encrypted-only). */
+function reasoningText(payload: Record<string, unknown>): string {
+  const summary = payload.summary;
+  if (Array.isArray(summary) && summary.length > 0) {
+    const text = summary
+      .map((s) => (typeof s === 'string' ? s : isRecord(s) ? str(s, 'text') : ''))
+      .join('\n')
+      .trim();
+    if (text) {
+      return text;
+    }
+  }
+  return typeof payload.content === 'string' ? payload.content.trim() : '';
+}
+
+/** Map one Codex `response_item` payload to a canonical role + MessagePart, or null to skip. */
+function responseItemToPart(
+  p: Record<string, unknown>
+): null | { part: MessagePart; role: 'assistant' | 'user' } {
+  switch (p.type) {
+    case 'custom_tool_call':
+    case 'function_call': {
+      const args = p.type === 'function_call' ? p.arguments : p.input;
+      return {
+        part: {
+          id: str(p, 'call_id'),
+          input: parseToolInput(args),
+          toolName: str(p, 'name') || 'tool',
+          type: 'tool_use',
+        },
+        role: 'assistant',
+      };
+    }
+    case 'custom_tool_call_output':
+    case 'function_call_output':
+    case 'tool_search_output': {
+      const output = typeof p.output === 'string' ? p.output : JSON.stringify(p.output ?? '');
+      return {
+        part: {
+          isError: /exit code:\s*[1-9]/i.test(output),
+          output: output.slice(0, 2000),
+          toolUseId: str(p, 'call_id'),
+          type: 'tool_result',
+        },
+        role: 'assistant',
+      };
+    }
+    case 'message': {
+      if (p.role === 'developer') {
+        return null; // instructions/permissions preamble — skip (like Claude skips system)
+      }
+      const content = joinMessageText(p.content);
+      return content
+        ? { part: { content, type: 'text' }, role: p.role === 'user' ? 'user' : 'assistant' }
+        : null;
+    }
+    case 'reasoning': {
+      const think = reasoningText(p);
+      return think ? { part: { content: think, type: 'thinking' }, role: 'assistant' } : null;
+    }
+    case 'tool_search_call':
+    case 'web_search_call':
+      return {
+        part: {
+          id: str(p, 'call_id'),
+          input: parseToolInput(p.action ?? p.query),
+          toolName: str(p, 'type'),
+          type: 'tool_use',
+        },
+        role: 'assistant',
+      };
+    default:
+      return null;
+  }
+}
+
+/** Safely read a string property from a record (returns '' on miss). */
+function str(obj: Record<string, unknown>, key: string): string {
+  const v = obj[key];
+  return typeof v === 'string' ? v : '';
+}

--- a/src/lib/modules/server/sessions/codex-reader.ts
+++ b/src/lib/modules/server/sessions/codex-reader.ts
@@ -1,0 +1,293 @@
+/**
+ * Codex CLI session reader — listing + conversation retrieval.
+ *
+ * Mirrors jsonl-reader.ts (Claude) and opencode-reader.ts (OpenCode): produces
+ * the same SessionInfo / ProjectGroup / ConversationMessage shapes so the rest
+ * of the app is provider-agnostic.
+ *
+ * Codex sessions live at ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
+ * (and ~/.codex/archived_sessions/). These files can be very large (hundreds of
+ * MB), so listing only reads a bounded prefix of each file for metadata/title
+ * and estimates the message count from file size; the conversation reader bounds
+ * its read for oversized files.
+ */
+
+import type { ConversationMessage, ProjectGroup, SessionInfo } from '$lib/types';
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import { homedir } from 'os';
+import * as path from 'path';
+
+import { parseCodexMeta, parseCodexRollout } from './codex-parser';
+
+/** Bytes read from the head of a rollout file when listing (enough for meta + first prompts). */
+const LIST_PREFIX_BYTES = 256 * 1024;
+/** Above this size, the conversation reader reads only the tail to bound memory. */
+const MAX_FULL_READ_BYTES = 16 * 1024 * 1024;
+/** Rough average bytes per Codex message line, used to estimate message counts cheaply. */
+const APPROX_BYTES_PER_MESSAGE = 3000;
+
+/** User-message wrappers that Codex injects automatically — not real prompts. */
+const SYNTHETIC_PROMPT_PREFIXES = ['<environment_context>', '<user_instructions>', '<permissions'];
+
+/**
+ * Find Codex sessions whose rollout file was written within `thresholdMs` —
+ * i.e. sessions that are currently (or very recently) active. Uses filesystem
+ * mtime rather than ~/.codex/state_5.sqlite, which is WAL-locked while Codex runs.
+ */
+export function detectActiveCodexSessions(
+  thresholdMs: number
+): { cwd: string; id: string; startedAt: number }[] {
+  const cutoff = Date.now() - thresholdMs;
+  const out: { cwd: string; id: string; startedAt: number }[] = [];
+  for (const filePath of collectRolloutFiles()) {
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.mtimeMs < cutoff) {
+        continue;
+      }
+      const meta = parseCodexMeta(readPrefix(filePath).split('\n')[0] ?? '');
+      if (meta) {
+        out.push({ cwd: meta.cwd, id: meta.id, startedAt: stat.birthtimeMs });
+      }
+    } catch {
+      // skip unreadable files
+    }
+  }
+  return out;
+}
+
+/**
+ * Find the rollout file for a Codex session launched in `cwd` after `sinceMs`
+ * (used by pty-manager to link a freshly-launched `codex` terminal to its file).
+ * Picks the newest matching file by creation time.
+ */
+export function findCodexRolloutForCwd(cwd: string, sinceMs: number): null | string {
+  let best: null | { birthtime: number; path: string } = null;
+  for (const filePath of collectRolloutFiles()) {
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.birthtimeMs <= sinceMs) {
+        continue;
+      }
+      const meta = parseCodexMeta(readPrefix(filePath).split('\n')[0] ?? '');
+      if (meta?.cwd === cwd && (!best || stat.birthtimeMs > best.birthtime)) {
+        best = { birthtime: stat.birthtimeMs, path: filePath };
+      }
+    } catch {
+      // skip unreadable files
+    }
+  }
+  return best?.path ?? null;
+}
+
+/**
+ * Return a page of a Codex session's conversation. With `offset` 0 the most
+ * recent `limit` messages are returned, backed up to a user-message boundary so
+ * turns aren't clipped; otherwise the `offset`..`offset + limit` slice is returned.
+ */
+export function getCodexConversation(
+  sessionId: string,
+  offset = 0,
+  limit = 200
+): ConversationMessage[] {
+  const filePath = findRolloutPath(sessionId);
+  if (!filePath || !fs.existsSync(filePath)) {
+    return [];
+  }
+
+  try {
+    const { messages } = parseCodexRollout(readRolloutText(filePath));
+
+    // Match the Claude reader: with no explicit offset, return the most recent
+    // `limit` messages, backing up to a user-message boundary so turns aren't clipped.
+    if (offset === 0 && messages.length > limit) {
+      let startIdx = messages.length - limit;
+      while (startIdx > 0 && messages[startIdx].role !== 'user') {
+        startIdx--;
+      }
+      return messages.slice(startIdx);
+    }
+    return messages.slice(offset, offset + limit);
+  } catch (error) {
+    console.error('[codex] Failed to read conversation:', error);
+    return [];
+  }
+}
+
+/** List all Codex sessions grouped by working directory, most-recently-modified first. */
+export function listCodexProjects(): ProjectGroup[] {
+  const files = collectRolloutFiles();
+  const byCwd = new Map<string, SessionInfo[]>();
+
+  for (const filePath of files) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      continue;
+    }
+    let prefix: string;
+    try {
+      prefix = readPrefix(filePath);
+    } catch {
+      continue;
+    }
+
+    const firstLine = prefix.slice(0, Math.max(0, prefix.indexOf('\n')) || prefix.length);
+    const meta = parseCodexMeta(firstLine);
+    if (!meta) {
+      continue;
+    }
+
+    const session: SessionInfo = {
+      created: meta.startedAt || stat.birthtime.toISOString(),
+      gitBranch: '',
+      id: meta.id,
+      messageCount: Math.max(1, Math.round(stat.size / APPROX_BYTES_PER_MESSAGE)),
+      modified: stat.mtime.toISOString(),
+      projectPath: meta.cwd,
+      source: 'codex' as const,
+      summary: '',
+      title: cleanTitle(firstUserPrompt(prefix)),
+    };
+
+    const bucket = byCwd.get(meta.cwd);
+    if (bucket) {
+      bucket.push(session);
+    } else {
+      byCwd.set(meta.cwd, [session]);
+    }
+  }
+
+  const projects: ProjectGroup[] = [];
+  for (const [cwd, sessions] of byCwd) {
+    sessions.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+    const segments = cwd.split('/').filter(Boolean);
+    projects.push({
+      fullPath: cwd,
+      id: shortHash(cwd),
+      lastModified: sessions[0]?.modified ?? '',
+      name: segments.slice(-2).join('/'),
+      sessionCount: sessions.length,
+      sessions,
+    });
+  }
+
+  return projects.sort(
+    (a, b) => new Date(b.lastModified).getTime() - new Date(a.lastModified).getTime()
+  );
+}
+
+function cleanTitle(prompt: string): string {
+  const firstLine = prompt.replace(/\s+/g, ' ').trim().split('\n')[0]?.trim() ?? '';
+  if (!firstLine) {
+    return 'Untitled Session';
+  }
+  return firstLine.length > 80 ? `${firstLine.slice(0, 77)}...` : firstLine;
+}
+
+function codexSessionsDirs(): string[] {
+  const home = homedir();
+  return [path.join(home, '.codex', 'sessions'), path.join(home, '.codex', 'archived_sessions')];
+}
+
+/** Recursively collect all rollout-*.jsonl file paths under the Codex session roots. */
+function collectRolloutFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name.startsWith('rollout-') && entry.name.endsWith('.jsonl')) {
+        out.push(full);
+      }
+    }
+  };
+  for (const root of codexSessionsDirs()) {
+    walk(root);
+  }
+  return out;
+}
+
+/** Locate a rollout file by its session UUID (embedded in the filename and session_meta.id). */
+function findRolloutPath(sessionId: string): null | string {
+  if (!/^[0-9a-f-]+$/i.test(sessionId)) {
+    return null;
+  }
+  const suffix = `-${sessionId}.jsonl`;
+  return collectRolloutFiles().find((p) => path.basename(p).endsWith(suffix)) ?? null;
+}
+
+/** Pull the first genuine user prompt (skipping Codex's auto-injected wrappers) for a title. */
+function firstUserPrompt(prefixText: string): string {
+  for (const line of prefixText.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || !trimmed.includes('"type":"message"') || !trimmed.includes('"role":"user"')) {
+      continue;
+    }
+    try {
+      const entry = JSON.parse(trimmed) as {
+        payload?: { content?: { text?: string; type?: string }[] };
+      };
+      const text = (entry.payload?.content ?? [])
+        .filter((c) => c.type === 'input_text' && typeof c.text === 'string')
+        .map((c) => c.text ?? '')
+        .join('\n')
+        .trim();
+      if (text && !SYNTHETIC_PROMPT_PREFIXES.some((p) => text.startsWith(p))) {
+        return text;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return '';
+}
+
+/** Read the first `LIST_PREFIX_BYTES` of a file as UTF-8 (complete lines only). */
+function readPrefix(filePath: string): string {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(LIST_PREFIX_BYTES);
+    const bytesRead = fs.readSync(fd, buf, 0, LIST_PREFIX_BYTES, 0);
+    const text = buf.toString('utf-8', 0, bytesRead);
+    const lastNl = text.lastIndexOf('\n');
+    return lastNl === -1 ? text : text.slice(0, lastNl);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/** Read a rollout file's text, bounded to the tail for oversized files. */
+function readRolloutText(filePath: string): string {
+  const stat = fs.statSync(filePath);
+  if (stat.size <= MAX_FULL_READ_BYTES) {
+    return fs.readFileSync(filePath, 'utf-8');
+  }
+  // Oversized: keep session_meta (first line) + the tail (most recent messages).
+  const head = readPrefix(filePath).split('\n')[0] ?? '';
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const start = stat.size - MAX_FULL_READ_BYTES;
+    const buf = Buffer.alloc(MAX_FULL_READ_BYTES);
+    const bytesRead = fs.readSync(fd, buf, 0, MAX_FULL_READ_BYTES, start);
+    const tail = buf.toString('utf-8', 0, bytesRead);
+    // Drop the first (likely partial) line of the tail.
+    return `${head}\n${tail.slice(tail.indexOf('\n') + 1)}`;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function shortHash(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex').slice(0, 8);
+}

--- a/src/lib/modules/server/sessions/process-detector.ts
+++ b/src/lib/modules/server/sessions/process-detector.ts
@@ -1,5 +1,6 @@
 import type { ClaudeSessionFile, DetectedProcess } from '$lib/types';
 
+import { detectActiveCodexSessions } from '$lib/modules/server/sessions/codex-reader';
 import { resolveOpenCodeDbPath } from '$lib/modules/server/sessions/opencode-db-path';
 import Database from 'better-sqlite3';
 import { execSync } from 'child_process';
@@ -44,6 +45,9 @@ const CLAUDE_SESSIONS_DIR = join(homedir(), '.claude', 'sessions');
 
 // OpenCode sessions updated within this window are considered "live"
 const OPENCODE_ACTIVE_THRESHOLD_MS = 3 * 60_000; // 3 minutes
+
+// Codex rollout files written within this window are considered "live"
+const CODEX_ACTIVE_THRESHOLD_MS = 3 * 60_000; // 3 minutes
 
 /**
  * Scan ~/.claude/sessions/*.json to find running Claude Code processes,
@@ -135,6 +139,25 @@ export function detectRunningAISessions(): DetectedProcess[] {
     } catch {
       // OpenCode DB missing or unreadable — skip silently
     }
+  }
+
+  // --- Codex sessions ---
+  // Codex has no PID file; a rollout file written in the last few minutes
+  // indicates an active session. cwd/id come from its session_meta line.
+  try {
+    for (const s of detectActiveCodexSessions(CODEX_ACTIVE_THRESHOLD_MS)) {
+      results.push({
+        command: 'codex',
+        cwd: s.cwd,
+        kind: 'interactive',
+        pid: 0, // Codex doesn't expose a per-session PID
+        projectPath: cwdToProjectPath(s.cwd),
+        sessionId: s.id,
+        startedAt: s.startedAt,
+      });
+    }
+  } catch {
+    // ~/.codex/sessions missing or unreadable — skip silently
   }
 
   // Sort by startedAt descending (most recent first)

--- a/src/lib/modules/server/terminal/codex-watcher.ts
+++ b/src/lib/modules/server/terminal/codex-watcher.ts
@@ -1,0 +1,179 @@
+/**
+ * Codex live session watcher.
+ *
+ * Codex rollout files are append-only JSONL (like Claude's), so this mirrors
+ * SessionWatcher: chokidar detects writes, only the newly-appended bytes are
+ * read, and lines are fed to a CodexStreamParser that emits messages as each
+ * conversation run completes. Because Codex's role-run grouping only flushes a
+ * run when the *next* run begins, an idle timer flushes the final open run when
+ * writing stops, so the last message isn't withheld.
+ */
+
+import type { ConversationMessage, CodexWatchState as WatchState } from '$lib/types';
+
+import { watch as chokidarWatch } from 'chokidar';
+import * as fs from 'fs';
+
+import { CodexStreamParser, parseCodexRollout } from '../sessions/codex-parser';
+
+/** Flush the open run after this many ms without a write. */
+const IDLE_FLUSH_MS = 1500;
+
+class CodexWatcher {
+  private watched = new Map<string, WatchState>();
+
+  /** One-shot full-history read of a rollout file (bypasses the live watch). */
+  getHistory(filePath: string): ConversationMessage[] {
+    if (!fs.existsSync(filePath)) {
+      return [];
+    }
+    try {
+      return parseCodexRollout(fs.readFileSync(filePath, 'utf-8')).messages;
+    } catch (error) {
+      console.error(`[codex-watcher] Failed to read history for ${filePath}:`, error);
+      return [];
+    }
+  }
+
+  /** Detach one `callback` (closing the watcher only when none remain), or stop entirely if no callback is given. */
+  stop(filePath: string, callback?: (messages: ConversationMessage[]) => void): void {
+    const state = this.watched.get(filePath);
+    if (!state) {
+      return;
+    }
+    if (callback) {
+      state.callbacks.delete(callback);
+      if (state.callbacks.size > 0) {
+        return;
+      }
+    }
+    if (state.idleTimer) {
+      clearTimeout(state.idleTimer);
+    }
+    void state.watcher.close();
+    this.watched.delete(filePath);
+    console.log(`[codex-watcher] Stopped watching: ${filePath}`);
+  }
+
+  /** Stop watching every file. */
+  stopAll(): void {
+    for (const [filePath] of this.watched) {
+      this.stop(filePath);
+    }
+  }
+
+  /** Watch a rollout file for appended messages; returns an unsubscribe function. */
+  subscribe(filePath: string, callback: (messages: ConversationMessage[]) => void): () => void {
+    const existing = this.watched.get(filePath);
+    if (existing) {
+      existing.callbacks.add(callback);
+      return () => {
+        this.stop(filePath, callback);
+      };
+    }
+
+    const watcher = chokidarWatch(filePath, {
+      awaitWriteFinish: { pollInterval: 100, stabilityThreshold: 200 },
+      ignoreInitial: true,
+    });
+
+    const state: WatchState = {
+      callbacks: new Set([callback]),
+      idleTimer: null,
+      lineBuffer: '',
+      offset: fs.existsSync(filePath) ? fs.statSync(filePath).size : 0,
+      parser: new CodexStreamParser(),
+      watcher,
+    };
+
+    watcher.on('change', () => {
+      this.readNew(filePath);
+    });
+    watcher.on('add', () => {
+      this.readNew(filePath);
+    });
+    watcher.on('error', (err) => {
+      console.error(`[codex-watcher] watch error ${filePath}:`, err);
+    });
+
+    this.watched.set(filePath, state);
+    console.log(`[codex-watcher] Watching: ${filePath} (offset ${state.offset})`);
+    return () => {
+      this.stop(filePath, callback);
+    };
+  }
+
+  private emit(state: WatchState, messages: ConversationMessage[]): void {
+    if (messages.length === 0) {
+      return;
+    }
+    for (const cb of state.callbacks) {
+      try {
+        cb(messages);
+      } catch (err) {
+        console.error('[codex-watcher] callback error:', err);
+      }
+    }
+  }
+
+  private readNew(filePath: string): void {
+    const state = this.watched.get(filePath);
+    if (!state) {
+      return;
+    }
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      return;
+    }
+    if (stat.size < state.offset) {
+      // Truncated/rotated — reset.
+      state.offset = 0;
+      state.lineBuffer = '';
+      state.parser = new CodexStreamParser();
+    }
+    if (stat.size <= state.offset) {
+      return;
+    }
+
+    const fd = fs.openSync(filePath, 'r');
+    try {
+      const buf = Buffer.alloc(stat.size - state.offset);
+      fs.readSync(fd, buf, 0, buf.length, state.offset);
+      state.offset = stat.size;
+
+      const combined = state.lineBuffer + buf.toString('utf-8');
+      const segments = combined.split('\n');
+      state.lineBuffer = combined.endsWith('\n') ? '' : (segments.pop() ?? '');
+
+      const emitted: ConversationMessage[] = [];
+      for (const line of segments) {
+        if (line.trim()) {
+          emitted.push(...state.parser.pushLine(line));
+        }
+      }
+      this.emit(state, emitted);
+    } finally {
+      fs.closeSync(fd);
+    }
+
+    // Reset the idle timer; flush the final open run once writes stop.
+    if (state.idleTimer) {
+      clearTimeout(state.idleTimer);
+    }
+    state.idleTimer = setTimeout(() => {
+      const current = this.watched.get(filePath);
+      if (current) {
+        this.emit(current, current.parser.flushOpen());
+      }
+    }, IDLE_FLUSH_MS);
+  }
+}
+
+// Single shared instance across module loaders (same pattern as the other watchers).
+const CW_GLOBAL_KEY = '__shooter_codex_watcher';
+export const codexWatcher: CodexWatcher =
+  ((globalThis as Record<string, unknown>)[CW_GLOBAL_KEY] as CodexWatcher) || new CodexWatcher();
+(globalThis as Record<string, unknown>)[CW_GLOBAL_KEY] = codexWatcher;

--- a/src/lib/modules/server/terminal/pty-manager.ts
+++ b/src/lib/modules/server/terminal/pty-manager.ts
@@ -12,6 +12,7 @@ import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from 'fs'
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { findCodexRolloutForCwd } from '../sessions/codex-reader';
 import { broadcastEvent } from '../ws/server.js';
 import { HolderClient } from './holder-client';
 import { openCodeWatcher } from './opencode-watcher';
@@ -960,6 +961,46 @@ class PtyManager {
         () => {
           clearInterval(pollInterval);
           terminal.pollTimer = null;
+        },
+        5 * 60 * 1000
+      );
+    }
+
+    // For Codex: poll ~/.codex/sessions for the rollout file created after
+    // launch whose session_meta.cwd matches. Codex reuses the sessionFile
+    // field (a JSONL path, like Claude); the WS adapter routes it to the
+    // Codex watcher by its /.codex/ path.
+    if (command === 'codex') {
+      const launchTime = terminal.createdAt.getTime();
+      terminal.pollTimer = setInterval(() => {
+        if (terminal.status === 'exited' || terminal.sessionFile) {
+          if (terminal.pollTimer) {
+            clearInterval(terminal.pollTimer);
+            terminal.pollTimer = null;
+          }
+          return;
+        }
+        try {
+          const rollout = findCodexRolloutForCwd(cwd, launchTime);
+          if (rollout) {
+            terminal.sessionFile = rollout;
+            if (terminal.pollTimer) {
+              clearInterval(terminal.pollTimer);
+              terminal.pollTimer = null;
+            }
+            terminalStore.update(id, { sessionFile: rollout });
+          }
+        } catch {
+          // ignore filesystem errors
+        }
+      }, 1500);
+
+      setTimeout(
+        () => {
+          if (terminal.pollTimer) {
+            clearInterval(terminal.pollTimer);
+            terminal.pollTimer = null;
+          }
         },
         5 * 60 * 1000
       );

--- a/src/lib/theme.css
+++ b/src/lib/theme.css
@@ -486,7 +486,7 @@
   --pill-cursor: inherit;
 }
 
-.pill-source-claude {
+.pill-source-claude-code {
   --pill-background: var(--ds-blue-100);
   --pill-color: var(--ds-blue-900);
   --pill-font-size: 10px;
@@ -503,6 +503,26 @@
   --pill-padding: 2px 8px;
   --pill-hover-background: var(--ds-amber-100);
   --pill-hover-color: var(--ds-amber-900);
+  --pill-cursor: inherit;
+}
+
+.pill-source-codex {
+  --pill-background: var(--ds-green-100);
+  --pill-color: var(--ds-green-900);
+  --pill-font-size: 10px;
+  --pill-padding: 2px 8px;
+  --pill-hover-background: var(--ds-green-100);
+  --pill-hover-color: var(--ds-green-900);
+  --pill-cursor: inherit;
+}
+
+.pill-source-gemini {
+  --pill-background: var(--ds-gray-100);
+  --pill-color: var(--ds-gray-900);
+  --pill-font-size: 10px;
+  --pill-padding: 2px 8px;
+  --pill-hover-background: var(--ds-gray-100);
+  --pill-hover-color: var(--ds-gray-900);
   --pill-cursor: inherit;
 }
 

--- a/src/lib/types/codex.ts
+++ b/src/lib/types/codex.ts
@@ -1,0 +1,21 @@
+// Codex CLI session types (hand-written: the rollout record shapes are
+// provider-specific and not worth round-tripping through the YAML codegen).
+// Codex stores sessions as JSONL "rollout" files under
+// ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl.
+
+import type { ConversationMessage } from './sessions';
+
+/** Result of parsing a Codex rollout file into the canonical message model. */
+export interface CodexParseResult {
+  messages: ConversationMessage[];
+  meta: CodexSessionMeta | null;
+}
+
+/** First-line `session_meta` payload of a Codex rollout file. */
+export interface CodexSessionMeta {
+  cliVersion: string;
+  cwd: string;
+  id: string;
+  model: string;
+  startedAt: string;
+}

--- a/src/lib/types/generated/Sessions.ts
+++ b/src/lib/types/generated/Sessions.ts
@@ -14,12 +14,14 @@ import {
  * @type { SessionSource }
  * @description Source tool that produced the session
  */
-export type SessionSource = 'claude-code' | 'opencode';
+export type SessionSource = 'claude-code' | 'opencode' | 'codex' | 'gemini';
 
 export function decodeSessionSource(rawInput: unknown): SessionSource | null {
   switch (rawInput) {
     case 'claude-code':
     case 'opencode':
+    case 'codex':
+    case 'gemini':
       return rawInput;
   }
   return null;
@@ -29,6 +31,8 @@ export function _decodeSessionSource(rawInput: unknown): SessionSource | undefin
   switch (rawInput) {
     case 'claude-code':
     case 'opencode':
+    case 'codex':
+    case 'gemini':
       return rawInput;
   }
   return;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -4,6 +4,7 @@
 export type * from './activity';
 export type * from './apn';
 export type * from './cli';
+export type * from './codex';
 export type * from './common';
 export type * from './dashboard';
 export * from './decision';

--- a/src/lib/types/server.ts
+++ b/src/lib/types/server.ts
@@ -8,10 +8,21 @@
 import type { FSWatcher } from 'chokidar';
 import type WebSocket from 'ws';
 
+import type { CodexStreamParser } from '../modules/server/sessions/codex-parser';
 import type { HolderClient } from '../modules/server/terminal/holder-client';
 import type { ConversationMessage } from './sessions';
 
 // ── holder-client types ─────────────────────────────────────────────
+
+export interface CodexWatchState {
+  callbacks: Set<(messages: ConversationMessage[]) => void>;
+  idleTimer: null | ReturnType<typeof setTimeout>;
+  /** Incomplete trailing line buffered between reads. */
+  lineBuffer: string;
+  offset: number;
+  parser: CodexStreamParser;
+  watcher: FSWatcher;
+}
 
 /** Messages received from the holder process (local ndjson protocol). */
 export type HolderIncomingMessage =
@@ -22,18 +33,20 @@ export type HolderIncomingMessage =
   | { exitCode: null | number; exited: boolean; pid: number; type: 'info' }
   | { path: string; type: 'cwd' };
 
+// ── pty-manager types ───────────────────────────────────────────────
+
 /** Messages sent to the holder process (local ndjson protocol). */
 export type HolderOutgoingMessage =
   | { cols: number; rows: number; type: 'resize' }
   | { data: string; type: 'input' }
   | { signal?: string; type: 'kill' };
 
-// ── pty-manager types ───────────────────────────────────────────────
-
 /**
  * Callback invoked when new JSONL entries are parsed from a watched file.
  */
 export type OnNewEntries = (entries: ConversationMessage[]) => void;
+
+// ── session-watcher types ───────────────────────────────────────────
 
 export interface OpenCodeWatchState {
   callbacks: Set<(messages: ConversationMessage[]) => void>;
@@ -48,8 +61,6 @@ export interface OpenCodeWatchState {
   lastPartTime: number;
   sessionId: string;
 }
-
-// ── session-watcher types ───────────────────────────────────────────
 
 export interface PtyManagedTerminal {
   args: string[];
@@ -78,12 +89,14 @@ export interface PtyManagedTerminal {
   watcherOffset: number;
 }
 
+// ── opencode-watcher types ──────────────────────────────────────────
+
 export interface PtyOutputBuffer {
   data: string[];
   size: number;
 }
 
-// ── opencode-watcher types ──────────────────────────────────────────
+// ── codex-watcher types ─────────────────────────────────────────────
 
 export interface SessionWatchedFile {
   callbacks: Set<OnNewEntries>;

--- a/src/lib/types/sessions.ts
+++ b/src/lib/types/sessions.ts
@@ -23,7 +23,7 @@ export interface ConversationMessage {
 }
 
 export interface DetectedProcess {
-  command: 'claude' | 'opencode';
+  command: 'claude' | 'codex' | 'gemini' | 'opencode';
   cwd: string;
   kind: string;
   pid: number;

--- a/src/routes/api/sessions/+server.ts
+++ b/src/routes/api/sessions/+server.ts
@@ -1,6 +1,7 @@
 import type { ProjectGroup } from '$lib/types';
 
 import { validateAuth } from '$lib/modules/server/auth';
+import { getCodexConversation, listCodexProjects } from '$lib/modules/server/sessions/codex-reader';
 import {
   getSessionConversation,
   listProjectsWithSessions,
@@ -26,27 +27,35 @@ function getMergedProjects(): ProjectGroup[] {
 
   const claudeProjects = listProjectsWithSessions();
   const openCodeProjects = listOpenCodeProjects();
+  const codexProjects = listCodexProjects();
   const projectsByPath = new Map<string, ProjectGroup>();
 
   for (const p of claudeProjects) {
     projectsByPath.set(p.fullPath, { ...p });
   }
 
-  for (const op of openCodeProjects) {
-    const existing = projectsByPath.get(op.fullPath);
-    if (existing) {
-      existing.sessions.push(...op.sessions);
-      existing.sessions.sort(
-        (a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime()
-      );
-      existing.sessionCount = existing.sessions.length;
-      existing.lastModified = existing.sessions[0]?.modified || existing.lastModified;
-      existing.name = existing.name.replace(' (OpenCode)', '');
-    } else {
-      op.name = op.name.replace(' (OpenCode)', '');
-      projectsByPath.set(op.fullPath, { ...op });
+  // Merge a provider's projects into the map, deduplicating by absolute path so
+  // sessions from different agents in the same directory group under one project.
+  const mergeProvider = (incoming: ProjectGroup[], stripSuffix?: string): void => {
+    for (const group of incoming) {
+      const cleanName = stripSuffix ? group.name.replace(stripSuffix, '') : group.name;
+      const existing = projectsByPath.get(group.fullPath);
+      if (existing) {
+        existing.sessions.push(...group.sessions);
+        existing.sessions.sort(
+          (a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime()
+        );
+        existing.sessionCount = existing.sessions.length;
+        existing.lastModified = existing.sessions[0]?.modified || existing.lastModified;
+        existing.name = existing.name.replace(stripSuffix ?? '', '');
+      } else {
+        projectsByPath.set(group.fullPath, { ...group, name: cleanName });
+      }
     }
-  }
+  };
+
+  mergeProvider(openCodeProjects, ' (OpenCode)');
+  mergeProvider(codexProjects);
 
   cachedProjects = [...projectsByPath.values()].sort(
     (a, b) => new Date(b.lastModified).getTime() - new Date(a.lastModified).getTime()
@@ -88,9 +97,12 @@ export const GET: RequestHandler = ({ request, url }) => {
       : undefined;
     let messages = getSessionConversation(sessionId, offset, limit, claudeProjectDir);
 
-    // If Claude Code reader found nothing, try OpenCode
+    // If Claude Code reader found nothing, try OpenCode, then Codex.
     if (messages.length === 0) {
       messages = getOpenCodeConversation(sessionId, offset, limit);
+    }
+    if (messages.length === 0) {
+      messages = getCodexConversation(sessionId, offset, limit);
     }
 
     // Find session info — short-circuit when project is already resolved

--- a/src/routes/api/sessions/connect/+server.ts
+++ b/src/routes/api/sessions/connect/+server.ts
@@ -38,8 +38,9 @@ export const POST: RequestHandler = async ({ request }) => {
     return json({ error: 'cwd is required (string)' }, { status: 400 });
   }
 
-  if (!command || (command !== 'claude' && command !== 'opencode')) {
-    return json({ error: 'command must be "claude" or "opencode"' }, { status: 400 });
+  const VALID_COMMANDS = ['claude', 'opencode', 'codex', 'gemini'];
+  if (!command || !VALID_COMMANDS.includes(command)) {
+    return json({ error: `command must be one of: ${VALID_COMMANDS.join(', ')}` }, { status: 400 });
   }
 
   // --- Validate cwd (same checks as POST /api/terminals) ---
@@ -63,13 +64,14 @@ export const POST: RequestHandler = async ({ request }) => {
 
   // --- Reuse existing terminal if one is already running for this session ---
 
-  const existing = ptyManager
-    .list()
-    .find(
-      (t) =>
-        t.status === 'running' &&
-        (t.sessionFile?.endsWith(`/${sessionId}.jsonl`) || t.openCodeSessionId === sessionId)
-    );
+  const existing = ptyManager.list().find(
+    (t) =>
+      t.status === 'running' &&
+      // Claude: <id>.jsonl ; Codex rollout: rollout-<ts>-<id>.jsonl ; OpenCode: session id
+      (t.sessionFile?.endsWith(`/${sessionId}.jsonl`) ||
+        t.sessionFile?.endsWith(`-${sessionId}.jsonl`) ||
+        t.openCodeSessionId === sessionId)
+  );
 
   if (existing) {
     console.log(
@@ -94,9 +96,15 @@ export const POST: RequestHandler = async ({ request }) => {
     return json({ error: 'No existing terminal for this session' }, { status: 404 });
   }
 
-  // --- Build args based on command ---
+  // --- Build args based on command (resume convention differs per agent CLI) ---
 
-  const args: string[] = command === 'claude' ? ['--resume', sessionId] : ['--session', sessionId];
+  const resumeArgs: Record<string, string[]> = {
+    claude: ['--resume', sessionId],
+    codex: ['resume', sessionId],
+    gemini: [], // Gemini CLI has no session-resume flag; launch fresh in the cwd.
+    opencode: ['--session', sessionId],
+  };
+  const args: string[] = resumeArgs[command] ?? [];
 
   try {
     const terminal = await ptyManager.create(command, args, realCwd, 120, 40);

--- a/src/routes/api/terminals/+server.ts
+++ b/src/routes/api/terminals/+server.ts
@@ -7,7 +7,7 @@ import { basename, isAbsolute, relative } from 'path';
 
 import type { RequestHandler } from './$types';
 
-const ALLOWED_COMMANDS = ['zsh', 'bash', 'sh', 'fish', 'claude', 'opencode'];
+const ALLOWED_COMMANDS = ['zsh', 'bash', 'sh', 'fish', 'claude', 'opencode', 'codex', 'gemini'];
 
 /** Extract the last non-empty line from a scrollback string. */
 function lastScrollbackLine(scrollback: string): null | string {

--- a/src/routes/project/+page.svelte
+++ b/src/routes/project/+page.svelte
@@ -12,6 +12,8 @@
     getCached,
     isShooterConfig,
     setCache,
+    sourceLabel,
+    sourceToCommand,
   } from '$lib/modules/client/common';
   import { Banner, Button, EmptyState, Icon, Pill, Shimmer } from '@juspay/svelte-ui-components';
   import { onDestroy, onMount } from 'svelte';
@@ -246,10 +248,7 @@
         Back to Projects
       </a>
     </div>
-    <EmptyState
-      title="Project Not Found"
-      description="The requested project could not be found."
-    >
+    <EmptyState title="Project Not Found" description="The requested project could not be found.">
       {#snippet icon()}<Icon svg={AlertTriangleSvg} classes="icon-24" />{/snippet}
     </EmptyState>
   {:else}
@@ -269,10 +268,7 @@
     </div>
 
     {#if project.sessions.length === 0}
-      <EmptyState
-        title="No sessions yet"
-        description="Sessions for this project will appear here"
-      >
+      <EmptyState title="No sessions yet" description="Sessions for this project will appear here">
         {#snippet icon()}<Icon svg={BellSvg} classes="icon-24" />{/snippet}
       </EmptyState>
     {:else}
@@ -292,11 +288,7 @@
                   <Button
                     classes="btn-connect btn-xs"
                     onclick={(e: MouseEvent): void =>
-                      void connectToSession(
-                        e,
-                        session.id,
-                        session.source === 'opencode' ? 'opencode' : 'claude'
-                      )}
+                      void connectToSession(e, session.id, sourceToCommand(session.source))}
                     disabled={connectingSessionId === session.id}
                     showLoader={connectingSessionId === session.id}
                   >
@@ -307,11 +299,7 @@
                   <Button
                     classes="btn-resume btn-xs"
                     onclick={(e: MouseEvent): void =>
-                      void connectToSession(
-                        e,
-                        session.id,
-                        session.source === 'opencode' ? 'opencode' : 'claude'
-                      )}
+                      void connectToSession(e, session.id, sourceToCommand(session.source))}
                     disabled={connectingSessionId === session.id}
                     showLoader={connectingSessionId === session.id}
                     text="Resume"
@@ -324,11 +312,7 @@
               {#if session.gitBranch}
                 <Pill text="🌿 {session.gitBranch}" classes="pill-git-branch" />
               {/if}
-              {#if session.source === 'opencode'}
-                <Pill text="OpenCode" classes="pill-source-opencode" />
-              {:else}
-                <Pill text="Claude Code" classes="pill-source-claude" />
-              {/if}
+              <Pill text={sourceLabel(session.source)} classes="pill-source-{session.source}" />
             </div>
             <div class="session-meta-row">
               <span class="session-modified">Last updated {formatDate(session.modified)}</span>

--- a/src/routes/session/[id]/+page.svelte
+++ b/src/routes/session/[id]/+page.svelte
@@ -10,7 +10,7 @@
 
   import { browser } from '$app/environment';
   import { page } from '$app/state';
-  import { getCached, setCache } from '$lib/modules/client/common';
+  import { getCached, setCache, sourceToCommand } from '$lib/modules/client/common';
   import ChatView from '$lib/modules/client/terminal/ChatView.svelte';
   import { Button } from '@juspay/svelte-ui-components';
   import { onMount } from 'svelte';
@@ -315,7 +315,7 @@
     sendStatus = 'connecting';
 
     try {
-      const command = session.source === 'opencode' ? 'opencode' : 'claude';
+      const command = sourceToCommand(session.source);
       const res = await fetch('/api/sessions/connect', {
         body: JSON.stringify({ command, cwd: session.projectPath, sessionId }),
         headers: {
@@ -510,7 +510,7 @@
       }
 
       try {
-        const command = session.source === 'opencode' ? 'opencode' : 'claude';
+        const command = sourceToCommand(session.source);
         const res = await fetch('/api/sessions/connect', {
           body: JSON.stringify({
             command,

--- a/src/routes/terminals/+page.svelte
+++ b/src/routes/terminals/+page.svelte
@@ -21,7 +21,7 @@
 
   const POLL_INTERVAL_MS = 10_000;
   const CACHE_KEY = 'shooter_terminals';
-  const AI_COMMANDS = ['claude', 'opencode'];
+  const AI_COMMANDS = ['claude', 'opencode', 'codex', 'gemini'];
   const SHELL_COMMANDS = ['zsh', 'bash', 'sh', 'fish'];
 
   let terminals = $state<TerminalListItem[]>([]);

--- a/src/routes/terminals/[id]/+page.svelte
+++ b/src/routes/terminals/[id]/+page.svelte
@@ -30,7 +30,7 @@
 
   // ------- Constants -------
 
-  const AI_COMMANDS = ['claude', 'opencode'];
+  const AI_COMMANDS = ['claude', 'opencode', 'codex', 'gemini'];
 
   // ------- Reactive state -------
 

--- a/tests/codex-parser.test.cjs
+++ b/tests/codex-parser.test.cjs
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for the Codex rollout parser (codex-parser.ts).
+ *
+ * Loads the real TypeScript module via the tsx CJS loader (its `$lib/types`
+ * imports are type-only and erased at runtime, so no path-alias resolution is
+ * needed). Validates the canonical-message mapping against a synthetic golden
+ * fixture, then smoke-tests against real ~/.codex sessions when present.
+ */
+
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+require('tsx/cjs');
+const {
+  parseCodexRollout,
+  parseCodexMeta,
+  CodexStreamParser,
+} = require('../src/lib/modules/server/sessions/codex-parser.ts');
+
+let passed = 0;
+function check(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    console.error(`  ✗ ${name}\n    ${err.message}`);
+    process.exitCode = 1;
+  }
+}
+
+const fixturePath = path.join(__dirname, 'fixtures', 'codex', 'sample-rollout.jsonl');
+const fixture = fs.readFileSync(fixturePath, 'utf8');
+const { meta, messages } = parseCodexRollout(fixture);
+
+console.log('codex-parser: golden fixture');
+
+check('extracts session_meta (id, cwd, model, cliVersion)', () => {
+  assert.ok(meta, 'meta should be present');
+  assert.strictEqual(meta.id, 'fixture-uuid-0001');
+  assert.strictEqual(meta.cwd, '/Users/dev/proj');
+  assert.strictEqual(meta.model, 'gpt-5.5');
+  assert.strictEqual(meta.cliVersion, '0.133.0');
+});
+
+check('role-run grouping yields the expected role sequence', () => {
+  const roles = messages.map((m) => m.role);
+  assert.deepStrictEqual(roles, ['user', 'assistant', 'system', 'assistant', 'system', 'assistant', 'user']);
+});
+
+check('skips the developer (permissions) preamble', () => {
+  const hasPreamble = messages.some((m) => m.parts.some((p) => p.type === 'text' && p.content.includes('permissions')));
+  assert.strictEqual(hasPreamble, false);
+});
+
+check('first user message is the prompt text', () => {
+  assert.deepStrictEqual(messages[0].parts, [{ type: 'text', content: 'List the files' }]);
+});
+
+check('assistant turn merges thinking + text + tool_use (encrypted reasoning skipped)', () => {
+  const a = messages[1];
+  const types = a.parts.map((p) => p.type);
+  assert.deepStrictEqual(types, ['thinking', 'text', 'tool_use']);
+  assert.strictEqual(a.parts[0].content, 'Planning to list files');
+  const tool = a.parts[2];
+  assert.strictEqual(tool.toolName, 'shell');
+  assert.deepStrictEqual(tool.input, { command: ['ls'] });
+  assert.strictEqual(tool.id, 'call_1');
+});
+
+check('only one thinking part exists (encrypted-only reasoning produced none)', () => {
+  const thinking = messages.flatMap((m) => m.parts).filter((p) => p.type === 'thinking');
+  assert.strictEqual(thinking.length, 1);
+});
+
+check('function_call_output becomes a system tool_result (not an error)', () => {
+  const sys = messages[2];
+  assert.strictEqual(sys.parts.length, 1);
+  assert.strictEqual(sys.parts[0].type, 'tool_result');
+  assert.strictEqual(sys.parts[0].toolUseId, 'call_1');
+  assert.strictEqual(sys.parts[0].isError, false);
+  assert.ok(sys.parts[0].output.includes('file1.txt'));
+});
+
+check('custom_tool_call (apply_patch) maps to tool_use with raw input', () => {
+  const a = messages[3];
+  assert.strictEqual(a.parts[0].type, 'tool_use');
+  assert.strictEqual(a.parts[0].toolName, 'apply_patch');
+  assert.ok(String(a.parts[0].input.raw).startsWith('*** Begin Patch'));
+});
+
+check('Exit code: 1 output is flagged isError', () => {
+  const sys = messages[4];
+  assert.strictEqual(sys.parts[0].type, 'tool_result');
+  assert.strictEqual(sys.parts[0].isError, true);
+});
+
+check('web_search_call maps to tool_use; trailing assistant text merges', () => {
+  const a = messages[5];
+  const types = a.parts.map((p) => p.type);
+  assert.deepStrictEqual(types, ['tool_use', 'text']);
+  assert.strictEqual(a.parts[0].toolName, 'web_search_call');
+  assert.deepStrictEqual(a.parts[0].input, { type: 'search', query: 'codex notify' });
+  assert.strictEqual(a.parts[1].content, 'Done.');
+});
+
+check('parseCodexMeta reads only the first line', () => {
+  const firstLine = fixture.split('\n')[0];
+  const m = parseCodexMeta(firstLine);
+  assert.strictEqual(m.id, 'fixture-uuid-0001');
+  assert.strictEqual(parseCodexMeta('{"type":"event_msg"}'), null);
+  assert.strictEqual(parseCodexMeta('not json'), null);
+});
+
+// ── Streaming parser (live watcher) ────────────────────────────────────
+console.log('codex-parser: streaming parser');
+
+check('CodexStreamParser fed line-by-line matches the batch parse', () => {
+  const sp = new CodexStreamParser();
+  const streamed = [];
+  for (const line of fixture.split('\n')) {
+    streamed.push(...sp.pushLine(line));
+  }
+  streamed.push(...sp.flushOpen());
+  assert.deepStrictEqual(
+    streamed.map((m) => m.role),
+    messages.map((m) => m.role)
+  );
+  assert.deepStrictEqual(
+    streamed.map((m) => m.parts.map((p) => p.type)),
+    messages.map((m) => m.parts.map((p) => p.type))
+  );
+});
+
+check('CodexStreamParser holds the open run until flushOpen', () => {
+  const sp = new CodexStreamParser();
+  // Two user lines with an assistant line between: the trailing assistant run
+  // stays open until flushOpen().
+  const lines = [
+    '{"type":"response_item","timestamp":"t","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}',
+    '{"type":"response_item","timestamp":"t","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"working"}]}}',
+  ];
+  const a = sp.pushLine(lines[0]); // user run open, nothing completed yet
+  assert.strictEqual(a.length, 0);
+  const b = sp.pushLine(lines[1]); // assistant run starts -> user run completes
+  assert.strictEqual(b.length, 1);
+  assert.strictEqual(b[0].role, 'user');
+  const c = sp.flushOpen(); // assistant run flushes
+  assert.strictEqual(c.length, 1);
+  assert.strictEqual(c[0].role, 'assistant');
+  assert.strictEqual(c[0].parts[0].content, 'working');
+});
+
+// ── Smoke test against real sessions (skipped if none present) ──────────
+console.log('codex-parser: real-session smoke test');
+const sessionsDir = path.join(os.homedir(), '.codex', 'sessions');
+function findRollouts(dir, acc) {
+  if (acc.length >= 3 || !fs.existsSync(dir)) return acc;
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (acc.length >= 3) break;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) findRollouts(p, acc);
+    else if (e.name.startsWith('rollout-') && e.name.endsWith('.jsonl')) acc.push(p);
+  }
+  return acc;
+}
+const real = findRollouts(sessionsDir, []);
+if (real.length === 0) {
+  console.log('  - skipped (no ~/.codex sessions on this machine)');
+} else {
+  for (const f of real) {
+    check(`parses ${path.basename(f)} without throwing and yields a cwd`, () => {
+      const r = parseCodexRollout(fs.readFileSync(f, 'utf8'));
+      assert.ok(r.meta && typeof r.meta.cwd === 'string' && r.meta.cwd.length > 0);
+      assert.ok(Array.isArray(r.messages));
+      for (const m of r.messages) {
+        assert.ok(['user', 'assistant', 'system'].includes(m.role));
+        assert.ok(Array.isArray(m.parts) && m.parts.length > 0);
+      }
+    });
+  }
+}
+
+console.log(`\ncodex-parser: ${passed} checks passed${process.exitCode ? ' (with failures)' : ''}`);

--- a/tests/fixtures/codex/sample-rollout.jsonl
+++ b/tests/fixtures/codex/sample-rollout.jsonl
@@ -1,0 +1,17 @@
+{"timestamp":"2026-05-29T10:00:00.000Z","type":"session_meta","payload":{"id":"fixture-uuid-0001","timestamp":"2026-05-29T10:00:00.000Z","cwd":"/Users/dev/proj","originator":"codex-tui","cli_version":"0.133.0","source":"cli","model":"gpt-5.5","model_provider":"openai"}}
+{"timestamp":"2026-05-29T10:00:01.000Z","type":"turn_context","payload":{"cwd":"/Users/dev/proj","approval_policy":"never"}}
+{"timestamp":"2026-05-29T10:00:01.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"t1"}}
+{"timestamp":"2026-05-29T10:00:02.000Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"<permissions instructions> sandbox ..."}]}}
+{"timestamp":"2026-05-29T10:00:03.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"List the files"}]}}
+{"timestamp":"2026-05-29T10:00:04.000Z","type":"response_item","payload":{"type":"reasoning","summary":[],"content":null,"encrypted_content":"ENCRYPTEDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}
+{"timestamp":"2026-05-29T10:00:05.000Z","type":"response_item","payload":{"type":"reasoning","summary":[{"type":"summary_text","text":"Planning to list files"}],"content":null}}
+{"timestamp":"2026-05-29T10:00:06.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"commentary","content":[{"type":"output_text","text":"I'll list the files now."}]}}
+{"timestamp":"2026-05-29T10:00:07.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":[\"ls\"]}","call_id":"call_1"}}
+{"timestamp":"2026-05-29T10:00:07.000Z","type":"event_msg","payload":{"type":"agent_message","message":"I'll list the files now."}}
+{"timestamp":"2026-05-29T10:00:08.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_1","output":"file1.txt\nfile2.txt"}}
+{"timestamp":"2026-05-29T10:00:09.000Z","type":"response_item","payload":{"type":"custom_tool_call","status":"completed","call_id":"call_2","name":"apply_patch","input":"*** Begin Patch\n*** Update File: a.txt\n@@\n-old\n+new\n*** End Patch"}}
+{"timestamp":"2026-05-29T10:00:10.000Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_2","output":"Exit code: 1\nfailed to apply"}}
+{"timestamp":"2026-05-29T10:00:11.000Z","type":"response_item","payload":{"type":"web_search_call","status":"completed","call_id":"call_3","action":{"type":"search","query":"codex notify"}}}
+{"timestamp":"2026-05-29T10:00:12.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done."}]}}
+{"timestamp":"2026-05-29T10:00:13.000Z","type":"compacted","payload":{"message":"context compacted"}}
+{"timestamp":"2026-05-29T10:00:14.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"thanks"}]}}


### PR DESCRIPTION
Adds **Codex CLI** session support to Shooter: a rollout parser, session list/view across the app, detection of running Codex sessions, and live session mirroring for active Codex terminals. Extends the `SessionSource` provider enum to include Codex.

First of the stack — base `release`.

---

### 📚 Stack — #82 split into 4 single-commit PRs (review & merge 1 → 4)

| # | PR | Scope |
|---|----|-------|
| 1 | #82 | Codex CLI session support |
| 2 | #83 | Provider registry + Gemini & Qwen readers |
| 3 | #84 | Cursor, Copilot & Amp read-only providers |
| 4 | #85 | Session-Over-Sessions coordinator |

Each PR is **one squashed commit**, stacked so each targets the branch below it. Together they reproduce the original #82 branch **byte-for-byte**. GitHub auto-retargets the next PR onto `release` as each one merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Codex and Gemini AI providers across session discovery, terminals, project/session listings, and quick-launch presets.
  * New live parsing and watcher for Codex rollout sessions enabling incremental session streaming and history reads.
  * Shared helpers for provider labels/commands used in UI buttons and pills.

* **Bug Fixes / Improvements**
  * Terminal/resume logic and session detection now recognize Codex/Gemini patterns.
  * Provider pill styles updated and Claude pill renamed for consistency.

* **Tests**
  * Added comprehensive tests and fixtures for Codex rollout parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->