### PR TITLE
feat(providers): provider registry + Gemini & Qwen readers

### DIFF
--- a/.claude/hooks/codex-hooks.example.json
+++ b/.claude/hooks/codex-hooks.example.json
@@ -1,0 +1,75 @@
+{
+  "_comment": "Copy to ~/.codex/hooks.json (global) or <project>/.codex/hooks.json (per-project).",
+  "_comment2": "Replace /ABSOLUTE/PATH/TO/PROJECT with the real absolute path to this repository.",
+  "_comment3": "Set SHOOTER_USE_LOCAL=true and SHOOTER_LOCAL_PORT=54007 if the server runs locally,",
+  "_comment4": "or set SHOOTER_API_URL=https://<your-tunnel>.trycloudflare.com for remote access.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "SHOOTER_USE_LOCAL=true SHOOTER_LOCAL_PORT=${SHOOTER_LOCAL_PORT:-54007} API_KEY=$API_KEY node /ABSOLUTE/PATH/TO/PROJECT/.claude/hooks/notifier.cjs codex SessionStart"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "SHOOTER_USE_LOCAL=true SHOOTER_LOCAL_PORT=${SHOOTER_LOCAL_PORT:-54007} API_KEY=$API_KEY node /ABSOLUTE/PATH/TO/PROJECT/.claude/hooks/notifier.cjs codex UserPromptSubmit"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "SHOOTER_USE_LOCAL=true SHOOTER_LOCAL_PORT=${SHOOTER_LOCAL_PORT:-54007} API_KEY=$API_KEY node /ABSOLUTE/PATH/TO/PROJECT/.claude/hooks/notifier.cjs codex PreToolUse"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "SHOOTER_USE_LOCAL=true SHOOTER_LOCAL_PORT=${SHOOTER_LOCAL_PORT:-54007} API_KEY=$API_KEY node /ABSOLUTE/PATH/TO/PROJECT/.claude/hooks/notifier.cjs codex PostToolUse"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "SHOOTER_USE_LOCAL=true SHOOTER_LOCAL_PORT=${SHOOTER_LOCAL_PORT:-54007} API_KEY=$API_KEY node /ABSOLUTE/PATH/TO/PROJECT/.claude/hooks/notifier.cjs codex Stop"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "SHOOTER_USE_LOCAL=true SHOOTER_LOCAL_PORT=${SHOOTER_LOCAL_PORT:-54007} API_KEY=$API_KEY node /ABSOLUTE/PATH/TO/PROJECT/.claude/hooks/notifier.cjs codex PermissionRequest",
+            "timeout": 180
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/hooks/notifier.cjs
+++ b/.claude/hooks/notifier.cjs
@@ -24,12 +24,17 @@ const path = require('path');
 // ============================================
 
 // Detect runtime environment
+// Codex mode: invoked as `node notifier.cjs codex <HookEventName>`
+const IS_CODEX =
+  require.main === module &&
+  process.argv[2] === 'codex';
 const IS_OPENCODE =
-  typeof process.env.OPENCODE_VERSION !== 'undefined' ||
-  require.main !== module ||
-  process.argv[1]?.includes('opencode');
-const IS_CLAUDE_CODE = !IS_OPENCODE && require.main === module;
-const RUNTIME = IS_OPENCODE ? 'opencode' : 'claude-code';
+  !IS_CODEX &&
+  (typeof process.env.OPENCODE_VERSION !== 'undefined' ||
+    require.main !== module ||
+    process.argv[1]?.includes('opencode'));
+const IS_CLAUDE_CODE = !IS_OPENCODE && !IS_CODEX && require.main === module;
+const RUNTIME = IS_OPENCODE ? 'opencode' : IS_CODEX ? 'codex' : 'claude-code';
 
 // Environment configuration
 const USE_LOCAL = process.env.SHOOTER_USE_LOCAL === 'true';
@@ -58,8 +63,8 @@ const API_KEY = process.env.API_KEY || process.env.SHOOTER_API_KEY;
 const DEVICE_TOKEN = process.env.SHOOTER_DEVICE_TOKEN || null;
 const AUTH_KEY = API_KEY || '';
 
-// Validate required environment variables ONLY for Claude Code CLI mode
-if (IS_CLAUDE_CODE && !API_KEY) {
+// Validate required environment variables for Claude Code and Codex CLI modes
+if ((IS_CLAUDE_CODE || IS_CODEX) && !API_KEY) {
   console.error('API_KEY environment variable is required');
   process.exit(1);
 }
@@ -419,6 +424,97 @@ function adaptOpenCodeEvent(hookEventType, hookData = {}) {
   };
 
   return createCommonEvent('opencode', eventType, data);
+}
+
+/**
+ * Adapter: Codex CLI hooks.json hook payload -> Common Event Format
+ *
+ * Codex delivers a JSON payload via stdin with at minimum:
+ *   { hook_event_name, session_id, turn_id, transcript_path,
+ *     model, permission_mode, cwd }
+ *
+ * The second CLI arg (`process.argv[3]`) is the HookEventName and
+ * duplicates `hook_event_name` in the payload — either works for routing.
+ *
+ * Event name mapping (Codex → common vocabulary):
+ *   SessionStart      → session.start
+ *   UserPromptSubmit  → user.prompt
+ *   PreToolUse        → tool.before
+ *   PostToolUse       → tool.after
+ *   Stop              → session.idle
+ *   PermissionRequest → permission
+ *   SubagentStart     → subagent.start
+ *   SubagentStop      → subagent.stop
+ *   PreCompact        → context.compact
+ *   (unknown)         → unknown
+ */
+function adaptCodexEvent(stdinData) {
+  // Prefer the payload field; fall back to the CLI arg (argv[3]).
+  const hookEventName =
+    (stdinData && stdinData.hook_event_name) ||
+    process.argv[3] ||
+    'Unknown';
+
+  const data = {};
+  data.sessionId = stdinData?.session_id || '';
+  data.turnId = stdinData?.turn_id || '';
+  data.cwd = stdinData?.cwd || process.cwd();
+  data.model = stdinData?.model || '';
+  data.permissionMode = stdinData?.permission_mode || '';
+  data.transcriptPath = stdinData?.transcript_path || '';
+
+  switch (hookEventName) {
+    case 'SessionStart':
+      data.source = stdinData?.source || '';
+      return createCommonEvent('codex', 'session.start', data);
+
+    case 'UserPromptSubmit':
+      data.message = stdinData?.prompt || '';
+      return createCommonEvent('codex', 'user.prompt', data);
+
+    case 'PreToolUse':
+      data.tool = stdinData?.tool_name || 'Unknown';
+      data.toolInput = stdinData?.tool_input || {};
+      data.command = data.toolInput.command || data.toolInput.cmd || '';
+      data.filePath = data.toolInput.file_path || '';
+      return createCommonEvent('codex', 'tool.before', data);
+
+    case 'PostToolUse':
+      data.tool = stdinData?.tool_name || 'Unknown';
+      data.toolInput = stdinData?.tool_input || {};
+      data.command = data.toolInput.command || data.toolInput.cmd || '';
+      data.filePath = data.toolInput.file_path || '';
+      data.toolResponse = stdinData?.tool_response || '';
+      return createCommonEvent('codex', 'tool.after', data);
+
+    case 'PermissionRequest':
+      data.tool = stdinData?.tool_name || 'Unknown';
+      data.toolInput = stdinData?.tool_input || {};
+      data.command = data.toolInput.command || data.toolInput.cmd || '';
+      data.filePath = data.toolInput.file_path || '';
+      data.description = data.toolInput.description || '';
+      return createCommonEvent('codex', 'permission', data);
+
+    case 'Stop':
+      data.lastAssistantMessage = stdinData?.last_assistant_message || '';
+      return createCommonEvent('codex', 'session.idle', data);
+
+    case 'SubagentStart':
+      data.agentType = stdinData?.agent_type || 'unknown';
+      data.source = stdinData?.source || '';
+      return createCommonEvent('codex', 'subagent.start', data);
+
+    case 'SubagentStop':
+      data.agentType = stdinData?.agent_type || 'unknown';
+      return createCommonEvent('codex', 'subagent.stop', data);
+
+    case 'PreCompact':
+      return createCommonEvent('codex', 'context.compact', data);
+
+    default:
+      data.rawHookEventName = hookEventName;
+      return createCommonEvent('codex', 'unknown', data);
+  }
 }
 
 // ============================================
@@ -1069,7 +1165,16 @@ function toolVerb(toolName) {
  * intentionally omitted — `data.environment` carries it for debug consumers.
  */
 function buildFooter(source) {
-  const runtime = source === 'opencode' ? 'opencode' : 'claude code';
+  let runtime;
+  if (source === 'opencode') {
+    runtime = 'opencode';
+  } else if (source === 'codex') {
+    runtime = 'codex cli';
+  } else if (source === 'gemini') {
+    runtime = 'gemini cli';
+  } else {
+    runtime = 'claude code';
+  }
   return `— ${runtime}`;
 }
 
@@ -1948,6 +2053,36 @@ const OpenCodePlugin = async (ctx) => {
 };
 
 // ============================================
+// 11C: Codex CLI Entry Point
+// ============================================
+
+async function codexMain() {
+  if (!USE_LOCAL && !REMOTE_BASE_URL) {
+    console.error(
+      'SHOOTER_API_URL environment variable is required when SHOOTER_USE_LOCAL is not true'
+    );
+    process.exit(1);
+  }
+
+  const hookEventName = process.argv[3] || 'Unknown';
+
+  debugLog(`Shooter Notifier Codex CLI invoked: ${hookEventName}`);
+  debugLog(`  Runtime: ${RUNTIME}`);
+  debugLog(`  Environment: ${USE_LOCAL ? 'LOCAL' : 'REMOTE'}`);
+
+  const stdinData = await readStdin();
+  if (stdinData) {
+    debugLog(`  Stdin data received: ${JSON.stringify(stdinData).substring(0, 500)}`);
+  } else {
+    debugLog(`  No stdin data`);
+  }
+
+  const event = adaptCodexEvent(stdinData);
+
+  await processEvent(event);
+}
+
+// ============================================
 // Exports and Main Execution
 // ============================================
 
@@ -1971,6 +2106,8 @@ if (typeof module !== 'undefined' && module.exports) {
   module.exports.categoryForOptionCount = categoryForOptionCount;
   module.exports.extractAskUserQuestionOptions = extractAskUserQuestionOptions;
   module.exports.extractElicitationChoices = extractElicitationChoices;
+  // Codex adapter (tests + wiring).
+  module.exports.adaptCodexEvent = adaptCodexEvent;
 }
 
 // Run main() when called directly from CLI (Claude Code)
@@ -1985,4 +2122,17 @@ if (IS_CLAUDE_CODE) {
   });
 
   claudeCodeMain();
+}
+
+// Run Codex main when invoked as `node notifier.cjs codex <HookEventName>`
+if (IS_CODEX) {
+  process.on('SIGINT', () => {
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', () => {
+    process.exit(0);
+  });
+
+  codexMain();
 }

--- a/docs/MULTI-PROVIDER-SUPPORT.md
+++ b/docs/MULTI-PROVIDER-SUPPORT.md
@@ -1,0 +1,85 @@
+# Multi-Provider AI-Agent Support
+
+Shooter mirrors AI coding-agent sessions to your phone, provides remote terminals, and
+sends push notifications. It started Claude-Code-only, then added OpenCode, and now
+**Codex** and **Gemini**. This doc explains how providers plug in and how to add more.
+
+> Sources for the provider formats below were reverse-engineered from real session data
+> on a developer machine and cross-checked against `wesm/agentsview` (a Go tool that
+> parses ~30 agent formats). See `plans/` for the full research corpus.
+
+## The provider seams
+
+Every provider normalizes to the same canonical shapes (`ConversationMessage`,
+`SessionInfo`, `ProjectGroup`, `DetectedProcess`) so the UI and WebSocket layers stay
+provider-agnostic. Adding a provider touches these layers:
+
+| Layer              | File(s)                                                                                                 | What a provider supplies                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Type discriminator | `specs/types/sessions.yaml` (`SessionSource`), `src/lib/types/sessions.ts` (`DetectedProcess.command`)  | a `source` id + CLI command                         |
+| Listing + history  | `src/lib/modules/server/sessions/<p>-reader.ts`                                                         | `list*Projects()`, `get*Conversation()`             |
+| Live mirroring     | `src/lib/modules/server/terminal/<p>-watcher.ts` (or reuse)                                             | `getHistory()`, `subscribe()`                       |
+| Detection          | `src/lib/modules/server/sessions/process-detector.ts`                                                   | "is a session live?"                                |
+| Aggregation        | `src/routes/api/sessions/+server.ts`                                                                    | merge into the project list + conversation fallback |
+| Terminal linking   | `src/lib/modules/server/terminal/pty-manager.ts` (`startSessionDiscovery`)                              | map a launched terminal → its session file          |
+| WS dispatch        | `server.ts` (`sessionWatcherAdapter`), `ws/session-handler.ts`                                          | route a session key to the right watcher            |
+| Launch / resume    | `LaunchSheet.svelte`, `/api/terminals` (allowlist), `/api/sessions/connect` (resume args)               | preset + resume convention                          |
+| UI labels          | `client/common/provider.ts` (`sourceToCommand`/`sourceLabel`), project/session pages, `theme.css` pills | command map + label + pill                          |
+| Notifications      | `.claude/hooks/notifier.cjs` (`adapt*Event`) + the CLI's hook config                                    | event adapter                                       |
+
+`client/common/provider.ts` uses `Record<SessionSource, …>`, so adding a value to the
+`SessionSource` enum forces a compile error until every mapping is handled.
+
+## Codex (full parity)
+
+- **Sessions:** `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` (+ `archived_sessions/`).
+  JSONL records `{timestamp, type, payload}`; `response_item` records are the conversation
+  source of truth (`event_msg`/`turn_context`/`compacted` are control/UI noise).
+- **Parser** (`codex-parser.ts`): maps `message`/`reasoning`/`function_call`/`custom_tool_call`/
+  `web_search_call` (+ `*_output`) to `MessagePart`s using **role-run grouping** (consecutive
+  same-category parts merge into one bubble; flush on category change). `developer` messages and
+  encrypted-only `reasoning` are skipped; injected `<environment_context>` wrappers are stripped
+  from titles. `CodexStreamParser` provides incremental parsing for the live watcher.
+- **Reader** (`codex-reader.ts`): bounded reads (session files can be **hundreds of MB**) — a
+  256 KB prefix for metadata/title, size-estimated message counts, tail-bounded conversation reads.
+- **Watcher** (`codex-watcher.ts`): chokidar tail + `CodexStreamParser`, with an idle-flush so the
+  final turn isn't withheld (role-run grouping only flushes when the _next_ run begins).
+- **Detection:** rollout files written in the last 3 min (robust against the WAL-locked `state_5.sqlite`).
+- **Launch/resume:** `codex` / `codex resume <id>`. Linking finds the rollout file by cwd + birthtime.
+- **Notifications:** Codex has a `~/.codex/hooks.json` system (SessionStart/UserPromptSubmit/
+  PreToolUse/PostToolUse/PermissionRequest/Stop). `notifier.cjs` has a Codex adapter; copy
+  `.claude/hooks/codex-hooks.example.json` to `~/.codex/hooks.json`.
+
+## Gemini (best-effort)
+
+- **Sessions:** `~/.gemini/tmp/<projectHash>/logs.json` (user prompts only, older format) and
+  `~/.gemini/tmp/<projectHash>/chats/session-*.json` (full `ConversationRecord` with tool calls +
+  thoughts, newer format). `projectHash = sha256(cwd)`; reverse-mapped via `~/.gemini/projects.json`.
+- Live transcripts depend on the installed gemini-cli version persisting `chats/`. gemini-cli also
+  has a rich hook system and injects `CLAUDE_PROJECT_DIR`, so `notifier.cjs` is reusable for it.
+- **Wired:** listing + history (`/api/sessions`), detection (`process-detector`), launch (`LaunchSheet`/
+  allowlist), and the source label/pill. Launching `gemini` gives a working raw terminal.
+- **Not yet wired (deferred, best-effort):** a dedicated live _structured_ watcher + `pty-manager`
+  session discovery for Gemini (no `chats/` data was available to verify against on the dev machine);
+  see roadmap item 6. History still renders via the REST reader.
+
+## Roadmap (mined from the knowledge base)
+
+Implemented: Codex full parity; incremental byte-offset live parsing; `task_complete`-aware
+detection signal; Gemini reader.
+
+Recommended next (highest leverage first):
+
+1. **Registry-pattern abstraction** — collapse the per-provider branches across ~14 files into a
+   single `AgentDef` registry entry per provider (pattern proven in `agentsview`). Biggest
+   maintainability win; do it before adding a 5th provider.
+2. **Codex/Gemini bidirectional permissions** — wire the hook `PermissionRequest`/`Notification`
+   events into the existing poll-for-decision flow so Allow/Deny works from the phone.
+3. **Session status badges** (Working / Waiting / Errored / Finished) derived from the transcript
+   (`task_complete`/`Stop`/`AfterAgent`), surfaced on the terminal + project lists.
+4. **Token/cost tracking** — Codex `token_count` + Claude `usage` are already in the transcripts.
+5. **OpenCode dual-backend** — also read the newer `~/.local/share/opencode/storage/` file backend,
+   not just SQLite (correctness fix for upgraded OpenCode installs).
+6. **Gemini live structured mirroring** — a `gemini-watcher.ts` (chokidar on `chats/session-*.json`,
+   atomic-rewrite diffing) + a `pty-manager` discovery branch + a `terminal-store` column, so a
+   launched `gemini` terminal streams into the Chat view like Codex/Claude.

--- a/specs/types/sessions.yaml
+++ b/specs/types/sessions.yaml
@@ -13,6 +13,11 @@ Sessions:
       - opencode
       - codex
       - gemini
+      - qwen
+      - cursor
+      - copilot
+      - amp
+      - iflow
     description: Source tool that produced the session
 
   MessageRole:

--- a/src/lib/modules/client/common/index.ts
+++ b/src/lib/modules/client/common/index.ts
@@ -4,6 +4,6 @@ export { getApiKey, isShooterConfig } from './config-guard';
 export { toErrorMessage } from './error';
 export { renderMarkdown } from './markdown';
 export { hasScanner, isNativeBridge, scanQR } from './native-bridge';
-export { sourceLabel, sourceToCommand } from './provider';
+export { AI_COMMANDS, sourceLabel, sourceToCommand } from './provider';
 export { formatRelativeTime } from './time';
 export { getToolDescription } from './tool-title';

--- a/src/lib/modules/client/common/provider.ts
+++ b/src/lib/modules/client/common/provider.ts
@@ -6,18 +6,31 @@
 import type { SessionSource } from '$lib/types';
 
 const SOURCE_COMMAND: Record<SessionSource, string> = {
+  amp: 'amp',
   'claude-code': 'claude',
   codex: 'codex',
+  copilot: 'copilot',
+  cursor: 'cursor-agent',
   gemini: 'gemini',
+  iflow: 'iflow',
   opencode: 'opencode',
+  qwen: 'qwen',
 };
 
 const SOURCE_LABEL: Record<SessionSource, string> = {
+  amp: 'Amp',
   'claude-code': 'Claude Code',
   codex: 'Codex',
+  copilot: 'Copilot',
+  cursor: 'Cursor',
   gemini: 'Gemini',
+  iflow: 'iFlow',
   opencode: 'OpenCode',
+  qwen: 'Qwen',
 };
+
+/** Every AI-agent CLI binary name (all SessionSources are AI agents, not shells). */
+export const AI_COMMANDS: string[] = Object.values(SOURCE_COMMAND);
 
 /** Human-readable label for a session source. */
 export function sourceLabel(source: SessionSource): string {

--- a/src/lib/modules/client/terminal/LaunchSheet.svelte
+++ b/src/lib/modules/client/terminal/LaunchSheet.svelte
@@ -11,6 +11,7 @@
     { args: [], command: 'claude', label: 'Claude Code' },
     { args: [], command: 'codex', label: 'Codex' },
     { args: [], command: 'gemini', label: 'Gemini' },
+    { args: [], command: 'qwen', label: 'Qwen' },
     { args: [], command: 'opencode', label: 'OpenCode' },
     { args: [], command: 'zsh', label: 'Shell / zsh' },
     { args: [], command: 'bash', label: 'Bash' },

--- a/src/lib/modules/server/sessions/codex-reader.ts
+++ b/src/lib/modules/server/sessions/codex-reader.ts
@@ -58,6 +58,15 @@ export function detectActiveCodexSessions(
   return out;
 }
 
+/** Locate a rollout file by its session UUID (embedded in the filename and session_meta.id). */
+export function findCodexRolloutById(sessionId: string): null | string {
+  if (!/^[0-9a-f-]+$/i.test(sessionId)) {
+    return null;
+  }
+  const suffix = `-${sessionId}.jsonl`;
+  return collectRolloutFiles().find((p) => path.basename(p).endsWith(suffix)) ?? null;
+}
+
 /**
  * Find the rollout file for a Codex session launched in `cwd` after `sinceMs`
  * (used by pty-manager to link a freshly-launched `codex` terminal to its file).
@@ -92,13 +101,13 @@ export function getCodexConversation(
   offset = 0,
   limit = 200
 ): ConversationMessage[] {
-  const filePath = findRolloutPath(sessionId);
+  const filePath = findCodexRolloutById(sessionId);
   if (!filePath || !fs.existsSync(filePath)) {
     return [];
   }
 
   try {
-    const { messages } = parseCodexRollout(readRolloutText(filePath));
+    const { messages } = parseCodexRollout(readBoundedRolloutText(filePath));
 
     // Match the Claude reader: with no explicit offset, return the most recent
     // `limit` messages, backing up to a user-message boundary so turns aren't clipped.
@@ -135,7 +144,8 @@ export function listCodexProjects(): ProjectGroup[] {
       continue;
     }
 
-    const firstLine = prefix.slice(0, Math.max(0, prefix.indexOf('\n')) || prefix.length);
+    const nlIdx = prefix.indexOf('\n');
+    const firstLine = nlIdx === -1 ? prefix : prefix.slice(0, nlIdx);
     const meta = parseCodexMeta(firstLine);
     if (!meta) {
       continue;
@@ -180,6 +190,27 @@ export function listCodexProjects(): ProjectGroup[] {
   );
 }
 
+/** Read a rollout file's text, bounded to the tail for oversized files (Codex files can be 100s of MB). */
+export function readBoundedRolloutText(filePath: string): string {
+  const stat = fs.statSync(filePath);
+  if (stat.size <= MAX_FULL_READ_BYTES) {
+    return fs.readFileSync(filePath, 'utf-8');
+  }
+  // Oversized: keep session_meta (first line) + the tail (most recent messages).
+  const head = readPrefix(filePath).split('\n')[0] ?? '';
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const start = stat.size - MAX_FULL_READ_BYTES;
+    const buf = Buffer.alloc(MAX_FULL_READ_BYTES);
+    const bytesRead = fs.readSync(fd, buf, 0, MAX_FULL_READ_BYTES, start);
+    const tail = buf.toString('utf-8', 0, bytesRead);
+    // Drop the first (likely partial) line of the tail.
+    return `${head}\n${tail.slice(tail.indexOf('\n') + 1)}`;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 function cleanTitle(prompt: string): string {
   const firstLine = prompt.replace(/\s+/g, ' ').trim().split('\n')[0]?.trim() ?? '';
   if (!firstLine) {
@@ -218,15 +249,6 @@ function collectRolloutFiles(): string[] {
   return out;
 }
 
-/** Locate a rollout file by its session UUID (embedded in the filename and session_meta.id). */
-function findRolloutPath(sessionId: string): null | string {
-  if (!/^[0-9a-f-]+$/i.test(sessionId)) {
-    return null;
-  }
-  const suffix = `-${sessionId}.jsonl`;
-  return collectRolloutFiles().find((p) => path.basename(p).endsWith(suffix)) ?? null;
-}
-
 /** Pull the first genuine user prompt (skipping Codex's auto-injected wrappers) for a title. */
 function firstUserPrompt(prefixText: string): string {
   for (const line of prefixText.split('\n')) {
@@ -262,27 +284,6 @@ function readPrefix(filePath: string): string {
     const text = buf.toString('utf-8', 0, bytesRead);
     const lastNl = text.lastIndexOf('\n');
     return lastNl === -1 ? text : text.slice(0, lastNl);
-  } finally {
-    fs.closeSync(fd);
-  }
-}
-
-/** Read a rollout file's text, bounded to the tail for oversized files. */
-function readRolloutText(filePath: string): string {
-  const stat = fs.statSync(filePath);
-  if (stat.size <= MAX_FULL_READ_BYTES) {
-    return fs.readFileSync(filePath, 'utf-8');
-  }
-  // Oversized: keep session_meta (first line) + the tail (most recent messages).
-  const head = readPrefix(filePath).split('\n')[0] ?? '';
-  const fd = fs.openSync(filePath, 'r');
-  try {
-    const start = stat.size - MAX_FULL_READ_BYTES;
-    const buf = Buffer.alloc(MAX_FULL_READ_BYTES);
-    const bytesRead = fs.readSync(fd, buf, 0, MAX_FULL_READ_BYTES, start);
-    const tail = buf.toString('utf-8', 0, bytesRead);
-    // Drop the first (likely partial) line of the tail.
-    return `${head}\n${tail.slice(tail.indexOf('\n') + 1)}`;
   } finally {
     fs.closeSync(fd);
   }

--- a/src/lib/modules/server/sessions/gemini-reader.ts
+++ b/src/lib/modules/server/sessions/gemini-reader.ts
@@ -1,0 +1,571 @@
+/**
+ * Gemini CLI session reader — listing + conversation retrieval.
+ *
+ * Mirrors codex-reader.ts (Codex) for structure/conventions: produces the
+ * same SessionInfo / ProjectGroup / ConversationMessage shapes so the rest of
+ * the app is provider-agnostic.
+ *
+ * Data sources (in preference order per session):
+ *   1. ~/.gemini/tmp/<projectHash>/chats/session-*.json
+ *      Full ConversationRecord (user + model + tool calls + thoughts).
+ *      Present only in newer gemini-cli versions; NOT present on older installs.
+ *   2. ~/.gemini/tmp/<projectHash>/logs.json
+ *      User-messages-only JSON array (LogEntry[]). Always present.
+ *
+ * Project hash → CWD reverse-lookup:
+ *   - Read ~/.gemini/projects.json if present (slug → absolute path, new format).
+ *   - For SHA-256 hash dirs (old format), the hash is irreversible without
+ *     brute-force; we surface the hash itself as the projectPath in that case.
+ */
+
+import type {
+  ConversationMessage,
+  GeminiConversationRecord,
+  GeminiLogEntry,
+  GeminiMessageRecord,
+  GeminiProjectsJson,
+  MessagePart,
+  ProjectGroup,
+  SessionInfo,
+} from '$lib/types';
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import { homedir } from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Files above this size are SKIPPED, not truncated — these are single JSON
+ * documents/arrays, so a partial read would be invalid JSON. Gemini session
+ * files are small in practice; this is only an OOM backstop.
+ */
+const MAX_GEMINI_FILE_BYTES = 64 * 1024 * 1024; // 64 MB
+
+/** Gemini tmp root. */
+const GEMINI_TMP = path.join(homedir(), '.gemini', 'tmp');
+
+/** Gemini projects registry (slug → absolute path). */
+const GEMINI_PROJECTS_JSON = path.join(homedir(), '.gemini', 'projects.json');
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Return sessions whose logs.json or chat file was written within `thresholdMs`
+ * of now — i.e. sessions that are currently (or very recently) active.
+ */
+export function detectActiveGeminiSessions(
+  thresholdMs: number
+): { cwd: string; id: string; startedAt: number }[] {
+  const cutoff = Date.now() - thresholdMs;
+  const projectHashToCwd = buildHashToCwdMap();
+  const projectDirs = collectProjectHashDirs();
+  const out: { cwd: string; id: string; startedAt: number }[] = [];
+
+  for (const hashDir of projectDirs) {
+    const hash = path.basename(hashDir);
+    const cwd = projectHashToCwd.get(hash) ?? hash;
+
+    // Check chats/session-*.json files.
+    const chatFiles = collectChatFiles(hashDir);
+    for (const chatFile of chatFiles) {
+      try {
+        const stat = fs.statSync(chatFile);
+        if (stat.mtimeMs < cutoff) {
+          continue;
+        }
+        const record = readChatFile(chatFile);
+        if (record) {
+          out.push({
+            cwd,
+            id: record.sessionId,
+            startedAt: new Date(record.startTime).getTime(),
+          });
+        }
+      } catch {
+        // skip unreadable files
+      }
+    }
+
+    // Also check logs.json mtime (covers old-format sessions).
+    const logsPath = path.join(hashDir, 'logs.json');
+    try {
+      const stat = fs.statSync(logsPath);
+      if (stat.mtimeMs < cutoff) {
+        continue;
+      }
+      // Surface the most recent session in this logs.json.
+      const entries = readLogsJson(logsPath);
+      if (entries.length > 0) {
+        const last = entries[entries.length - 1];
+        if (last) {
+          // Only add if not already captured from a chat file.
+          const alreadyAdded = out.some((o) => o.id === last.sessionId && o.cwd === cwd);
+          if (!alreadyAdded) {
+            out.push({
+              cwd,
+              id: last.sessionId,
+              startedAt: new Date(entries[0]?.timestamp ?? last.timestamp).getTime(),
+            });
+          }
+        }
+      }
+    } catch {
+      // logs.json missing or unreadable — skip
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Return the conversation messages for a given Gemini session ID.
+ * Prefers chats/session-*.json (full record) over logs.json (user-only).
+ * Mirrors getCodexConversation() pagination behaviour.
+ */
+export function getGeminiConversation(
+  sessionId: string,
+  offset = 0,
+  limit = 200
+): ConversationMessage[] {
+  const projectDirs = collectProjectHashDirs();
+
+  for (const hashDir of projectDirs) {
+    // Try full chat record first.
+    const chatFile = findChatFileForSession(hashDir, sessionId);
+    if (chatFile) {
+      return conversationFromChatFile(chatFile, offset, limit);
+    }
+  }
+
+  // Fall back to logs.json user-only messages.
+  for (const hashDir of projectDirs) {
+    const messages = conversationFromLogsJson(hashDir, sessionId);
+    if (messages.length > 0) {
+      if (offset === 0 && messages.length > limit) {
+        return messages.slice(messages.length - limit);
+      }
+      return messages.slice(offset, offset + limit);
+    }
+  }
+
+  return [];
+}
+
+/**
+ * List all Gemini CLI sessions grouped by project, sorted by most-recently-
+ * modified first.  Mirrors listCodexProjects() from codex-reader.ts.
+ */
+export function listGeminiProjects(): ProjectGroup[] {
+  const projectHashToCwd = buildHashToCwdMap();
+  const projectDirs = collectProjectHashDirs();
+
+  const byCwd = new Map<string, SessionInfo[]>();
+
+  for (const hashDir of projectDirs) {
+    const hash = path.basename(hashDir);
+    const cwd = projectHashToCwd.get(hash) ?? hash;
+
+    // Prefer full chat records if any exist; fall back to logs.json.
+    const chatSessions = collectChatSessions(hashDir, cwd);
+    if (chatSessions.length > 0) {
+      for (const session of chatSessions) {
+        appendToMap(byCwd, cwd, session);
+      }
+      continue;
+    }
+
+    // Fall back: derive sessions from logs.json.
+    const logSessions = sessionsFromLogsJson(hashDir, cwd);
+    for (const session of logSessions) {
+      appendToMap(byCwd, cwd, session);
+    }
+  }
+
+  const projects: ProjectGroup[] = [];
+  for (const [cwd, sessions] of byCwd) {
+    sessions.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+    const segments = cwd.split('/').filter(Boolean);
+    // When the project hash couldn't be reverse-mapped to a real cwd, show a
+    // short friendly label instead of the raw 64-char SHA-256 hash.
+    const isRawHash = /^[0-9a-f]{64}$/i.test(cwd);
+    projects.push({
+      fullPath: cwd,
+      id: shortHash(cwd),
+      lastModified: sessions[0]?.modified ?? '',
+      name: isRawHash ? `Gemini (${cwd.slice(0, 8)})` : segments.slice(-2).join('/'),
+      sessionCount: sessions.length,
+      sessions,
+    });
+  }
+
+  return projects.sort(
+    (a, b) => new Date(b.lastModified).getTime() - new Date(a.lastModified).getTime()
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Session building helpers
+// ---------------------------------------------------------------------------
+
+function appendToMap<V>(map: Map<string, V[]>, key: string, value: V): void {
+  let bucket = map.get(key);
+  if (!bucket) {
+    bucket = [];
+    map.set(key, bucket);
+  }
+  bucket.push(value);
+}
+
+/**
+ * Build a SHA-256 projectHash → cwd map by reading ~/.gemini/projects.json.
+ * Returns an empty map if the file is absent (old gemini-cli installs).
+ */
+function buildHashToCwdMap(): Map<string, string> {
+  const map = new Map<string, string>();
+  try {
+    const raw = fs.readFileSync(GEMINI_PROJECTS_JSON, 'utf-8');
+    const data = JSON.parse(raw) as GeminiProjectsJson;
+    for (const [slugOrHash, absolutePath] of Object.entries(data)) {
+      // projects.json may use either the slug or the full SHA-256 hash as key.
+      map.set(slugOrHash, absolutePath);
+      // Pre-compute SHA-256(absolutePath) → absolutePath as well so that
+      // old hash-named directories match even when projects.json uses slugs.
+      const computed = crypto.createHash('sha256').update(absolutePath).digest('hex');
+      map.set(computed, absolutePath);
+    }
+  } catch {
+    // File absent or malformed — that's fine for old gemini-cli installs.
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Conversation building helpers
+// ---------------------------------------------------------------------------
+
+function cleanTitle(text: string): string {
+  const first = text.replace(/\s+/g, ' ').trim().split('\n')[0]?.trim() ?? '';
+  if (!first) {
+    return 'Untitled Session';
+  }
+  return first.length > 80 ? `${first.slice(0, 77)}...` : first;
+}
+
+/** Enumerate all chats/session-*.json files under a project hash dir. */
+function collectChatFiles(hashDir: string): string[] {
+  const chatsDir = path.join(hashDir, 'chats');
+  try {
+    return fs
+      .readdirSync(chatsDir, { withFileTypes: true })
+      .filter((e) => e.isFile() && e.name.startsWith('session-') && e.name.endsWith('.json'))
+      .map((e) => path.join(chatsDir, e.name));
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ConversationRecord → ConversationMessage mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Build SessionInfo records for each distinct sessionId found in a
+ * chats/session-*.json file under hashDir.
+ */
+function collectChatSessions(hashDir: string, cwd: string): SessionInfo[] {
+  const chatFiles = collectChatFiles(hashDir);
+  const sessions: SessionInfo[] = [];
+
+  for (const chatFile of chatFiles) {
+    try {
+      const stat = fs.statSync(chatFile);
+      const record = readChatFile(chatFile);
+      if (!record) {
+        continue;
+      }
+
+      const userMessages = record.messages.filter((m) => m.type === 'user');
+      const firstUserMsg = userMessages[0];
+      let title = 'Untitled Session';
+      if (firstUserMsg) {
+        title = cleanTitle(extractTextFromContent(firstUserMsg.content));
+      }
+
+      sessions.push({
+        created: record.startTime,
+        gitBranch: '',
+        id: record.sessionId,
+        messageCount: record.messages.length,
+        modified: stat.mtime.toISOString(),
+        projectPath: cwd,
+        source: 'gemini' as const,
+        summary: record.summary ?? '',
+        title,
+      });
+    } catch {
+      // skip unreadable chat files
+    }
+  }
+
+  return sessions;
+}
+
+// ---------------------------------------------------------------------------
+// File I/O helpers
+// ---------------------------------------------------------------------------
+
+/** Enumerate all ~/.gemini/tmp/<hash>/ directories. */
+function collectProjectHashDirs(): string[] {
+  try {
+    return fs
+      .readdirSync(GEMINI_TMP, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => path.join(GEMINI_TMP, e.name));
+  } catch {
+    return [];
+  }
+}
+
+function conversationFromChatFile(
+  chatFile: string,
+  offset: number,
+  limit: number
+): ConversationMessage[] {
+  try {
+    const record = readChatFile(chatFile);
+    if (!record) {
+      return [];
+    }
+
+    const messages = record.messages
+      .filter((m) => m.type === 'user' || m.type === 'gemini')
+      .map(messageRecordToMessage);
+
+    if (offset === 0 && messages.length > limit) {
+      let startIdx = messages.length - limit;
+      while (startIdx > 0 && messages[startIdx]?.role !== 'user') {
+        startIdx--;
+      }
+      return messages.slice(startIdx);
+    }
+    return messages.slice(offset, offset + limit);
+  } catch (err) {
+    console.error('[gemini] Failed to read chat file:', err);
+    return [];
+  }
+}
+
+function conversationFromLogsJson(hashDir: string, sessionId: string): ConversationMessage[] {
+  const logsPath = path.join(hashDir, 'logs.json');
+  const entries = readLogsJson(logsPath);
+  return entries
+    .filter((e) => e.sessionId === sessionId)
+    .map(
+      (entry): ConversationMessage => ({
+        id: `${entry.sessionId}-${String(entry.messageId)}`,
+        parts: [{ content: entry.message, type: 'text' }],
+        role: 'user',
+        timestamp: entry.timestamp,
+      })
+    );
+}
+
+/** Extract plain-text from a GeminiMessageRecord content field. */
+function extractTextFromContent(
+  content: GeminiConversationRecord['messages'][0]['content']
+): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  return content
+    .filter((p): p is { text: string } => 'text' in p)
+    .map((p) => p.text)
+    .join(' ');
+}
+
+/**
+ * Find the chats/session-*.json file for a specific sessionId.
+ * The filename embeds the first 8 chars of the UUID; we fall back to reading
+ * every file in the directory if necessary.
+ */
+function findChatFileForSession(hashDir: string, sessionId: string): null | string {
+  const shortId = sessionId.slice(0, 8);
+  const chatsDir = path.join(hashDir, 'chats');
+  try {
+    const entries = fs.readdirSync(chatsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.startsWith('session-') || !entry.name.endsWith('.json')) {
+        continue;
+      }
+      // Fast path: filename contains shortId.
+      if (entry.name.includes(shortId)) {
+        return path.join(chatsDir, entry.name);
+      }
+    }
+    // Slow path: read each file and check the sessionId field.
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.startsWith('session-') || !entry.name.endsWith('.json')) {
+        continue;
+      }
+      const record = readChatFile(path.join(chatsDir, entry.name));
+      if (record?.sessionId === sessionId) {
+        return path.join(chatsDir, entry.name);
+      }
+    }
+  } catch {
+    // chats dir missing or unreadable
+  }
+  return null;
+}
+
+function isGeminiLogEntry(v: unknown): v is GeminiLogEntry {
+  if (typeof v !== 'object' || v === null) {
+    return false;
+  }
+  const obj = v as Record<string, unknown>;
+  return (
+    typeof obj.sessionId === 'string' &&
+    typeof obj.messageId === 'number' &&
+    typeof obj.message === 'string' &&
+    typeof obj.timestamp === 'string'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+function messageRecordToMessage(record: GeminiMessageRecord): ConversationMessage {
+  const role: 'assistant' | 'user' = record.type === 'user' ? 'user' : 'assistant';
+  const parts: MessagePart[] = [];
+
+  // 1. Thought summaries (only on 'gemini'-type messages).
+  if (record.type === 'gemini' && record.thoughts) {
+    for (const thought of record.thoughts) {
+      parts.push({ content: thought.summary ?? '', type: 'thinking' });
+    }
+  }
+
+  // 2. Content parts.
+  const rawContent = record.content;
+  const contentParts = typeof rawContent === 'string' ? [{ text: rawContent }] : rawContent;
+  for (const part of contentParts) {
+    if ('functionCall' in part) {
+      parts.push({
+        id: part.functionCall.id ?? part.functionCall.name,
+        input: part.functionCall.args,
+        toolName: part.functionCall.name,
+        type: 'tool_use',
+      });
+    } else if ('thought' in part && part.thought === true) {
+      parts.push({ content: part.text, type: 'thinking' });
+    } else if ('text' in part) {
+      parts.push({ content: part.text, type: 'text' });
+    }
+  }
+
+  // 3. Tool calls array (avoid duplicating entries already in content parts).
+  if (record.type === 'gemini' && record.toolCalls) {
+    for (const tc of record.toolCalls) {
+      const alreadyInParts = parts.some((p) => p.type === 'tool_use' && p.id === tc.id);
+      if (!alreadyInParts) {
+        parts.push({
+          id: tc.id,
+          input: tc.args,
+          toolName: tc.name,
+          type: 'tool_use',
+        });
+      }
+    }
+  }
+
+  return {
+    id: record.id,
+    parts,
+    role,
+    timestamp: record.timestamp,
+  };
+}
+
+/** Read and parse a chats/session-*.json file (a single JSON object). */
+function readChatFile(filePath: string): GeminiConversationRecord | null {
+  try {
+    if (fs.statSync(filePath).size > MAX_GEMINI_FILE_BYTES) {
+      return null; // too large to parse safely as one JSON document
+    }
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as GeminiConversationRecord;
+  } catch {
+    return null;
+  }
+}
+
+/** Read and parse ~/.gemini/tmp/<hash>/logs.json (a single JSON array). */
+function readLogsJson(logsPath: string): GeminiLogEntry[] {
+  try {
+    if (fs.statSync(logsPath).size > MAX_GEMINI_FILE_BYTES) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(fs.readFileSync(logsPath, 'utf-8'));
+    return Array.isArray(parsed) ? parsed.filter(isGeminiLogEntry) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Build SessionInfo records for each distinct sessionId found in logs.json.
+ */
+function sessionsFromLogsJson(hashDir: string, cwd: string): SessionInfo[] {
+  const logsPath = path.join(hashDir, 'logs.json');
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(logsPath);
+  } catch {
+    return [];
+  }
+
+  const entries = readLogsJson(logsPath);
+  if (entries.length === 0) {
+    return [];
+  }
+
+  // Group by sessionId; preserve insertion order (chronological).
+  const bySession = new Map<string, GeminiLogEntry[]>();
+  for (const entry of entries) {
+    let bucket = bySession.get(entry.sessionId);
+    if (!bucket) {
+      bucket = [];
+      bySession.set(entry.sessionId, bucket);
+    }
+    bucket.push(entry);
+  }
+
+  const sessions: SessionInfo[] = [];
+  for (const [sessionId, sessionEntries] of bySession) {
+    const first = sessionEntries[0];
+    const last = sessionEntries[sessionEntries.length - 1];
+    sessions.push({
+      created: first?.timestamp ?? stat.birthtime.toISOString(),
+      gitBranch: '',
+      id: sessionId,
+      messageCount: sessionEntries.length,
+      modified: last?.timestamp ?? stat.mtime.toISOString(),
+      projectPath: cwd,
+      source: 'gemini' as const,
+      summary: '',
+      title: cleanTitle(first?.message ?? ''),
+    });
+  }
+
+  return sessions;
+}
+
+function shortHash(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex').slice(0, 8);
+}

--- a/src/lib/modules/server/sessions/opencode-db-path.ts
+++ b/src/lib/modules/server/sessions/opencode-db-path.ts
@@ -1,26 +1,35 @@
+import { existsSync } from 'fs';
 import * as path from 'path';
 
 /**
  * Resolve the path to the OpenCode SQLite database.
  *
- * Checks in this order:
+ * Probes candidate locations and returns the first that EXISTS (the previous
+ * version returned the macOS path unconditionally on darwin, which hid the DB
+ * for installs that use the XDG ~/.local/share path — observed in the wild).
+ * Candidate order:
  * 1. XDG_DATA_HOME/opencode/opencode.db (honours XDG override)
- * 2. ~/Library/Application Support/opencode/opencode.db (legacy macOS path)
- * 3. ~/.local/share/opencode/opencode.db (XDG default)
+ * 2. ~/.local/share/opencode/opencode.db (XDG default — common even on macOS)
+ * 3. ~/Library/Application Support/opencode/opencode.db (legacy macOS path)
  */
 export function resolveOpenCodeDbPath(): string {
   const home = process.env.HOME || '';
+  const candidates: string[] = [];
 
-  // 1. If XDG_DATA_HOME is explicitly set, use it
   if (process.env.XDG_DATA_HOME) {
-    return path.join(process.env.XDG_DATA_HOME, 'opencode', 'opencode.db');
+    candidates.push(path.join(process.env.XDG_DATA_HOME, 'opencode', 'opencode.db'));
   }
-
-  // 2. Legacy macOS path (~/Library/Application Support/opencode/)
+  candidates.push(path.join(home, '.local', 'share', 'opencode', 'opencode.db'));
   if (process.platform === 'darwin') {
-    return path.join(home, 'Library', 'Application Support', 'opencode', 'opencode.db');
+    candidates.push(path.join(home, 'Library', 'Application Support', 'opencode', 'opencode.db'));
   }
 
-  // 3. XDG default (~/.local/share/opencode/)
-  return path.join(home, '.local', 'share', 'opencode', 'opencode.db');
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // None exist yet — return the preferred default; callers tolerate a missing file.
+  return candidates[0] ?? path.join(home, '.local', 'share', 'opencode', 'opencode.db');
 }

--- a/src/lib/modules/server/sessions/process-detector.ts
+++ b/src/lib/modules/server/sessions/process-detector.ts
@@ -1,7 +1,9 @@
 import type { ClaudeSessionFile, DetectedProcess } from '$lib/types';
 
 import { detectActiveCodexSessions } from '$lib/modules/server/sessions/codex-reader';
+import { detectActiveGeminiSessions } from '$lib/modules/server/sessions/gemini-reader';
 import { resolveOpenCodeDbPath } from '$lib/modules/server/sessions/opencode-db-path';
+import { detectActiveQwenSessions } from '$lib/modules/server/sessions/qwen-reader';
 import Database from 'better-sqlite3';
 import { execSync } from 'child_process';
 import { existsSync, readdirSync, readFileSync } from 'fs';
@@ -48,6 +50,12 @@ const OPENCODE_ACTIVE_THRESHOLD_MS = 3 * 60_000; // 3 minutes
 
 // Codex rollout files written within this window are considered "live"
 const CODEX_ACTIVE_THRESHOLD_MS = 3 * 60_000; // 3 minutes
+
+// Gemini session files written within this window are considered "live"
+const GEMINI_ACTIVE_THRESHOLD_MS = 3 * 60_000; // 3 minutes
+
+// Qwen session files written within this window are considered "live"
+const QWEN_ACTIVE_THRESHOLD_MS = 3 * 60_000; // 3 minutes
 
 /**
  * Scan ~/.claude/sessions/*.json to find running Claude Code processes,
@@ -158,6 +166,42 @@ export function detectRunningAISessions(): DetectedProcess[] {
     }
   } catch {
     // ~/.codex/sessions missing or unreadable — skip silently
+  }
+
+  // --- Gemini sessions ---
+  // Gemini has no PID file; a logs.json / chat file written in the last few
+  // minutes indicates an active session. cwd is reverse-mapped where possible.
+  try {
+    for (const s of detectActiveGeminiSessions(GEMINI_ACTIVE_THRESHOLD_MS)) {
+      results.push({
+        command: 'gemini',
+        cwd: s.cwd,
+        kind: 'interactive',
+        pid: 0, // Gemini doesn't expose a per-session PID
+        projectPath: cwdToProjectPath(s.cwd),
+        sessionId: s.id,
+        startedAt: s.startedAt,
+      });
+    }
+  } catch {
+    // ~/.gemini/tmp missing or unreadable — skip silently
+  }
+
+  // --- Qwen sessions ---
+  try {
+    for (const s of detectActiveQwenSessions(QWEN_ACTIVE_THRESHOLD_MS)) {
+      results.push({
+        command: 'qwen',
+        cwd: s.cwd,
+        kind: 'interactive',
+        pid: 0,
+        projectPath: cwdToProjectPath(s.cwd),
+        sessionId: s.id,
+        startedAt: s.startedAt,
+      });
+    }
+  } catch {
+    // ~/.qwen/projects missing or unreadable — skip silently
   }
 
   // Sort by startedAt descending (most recent first)

--- a/src/lib/modules/server/sessions/qwen-reader.ts
+++ b/src/lib/modules/server/sessions/qwen-reader.ts
@@ -1,0 +1,310 @@
+/**
+ * Qwen Code session reader.
+ *
+ * Qwen Code (a Gemini-CLI fork) writes a HYBRID format: a Claude-style JSONL
+ * envelope (uuid/parentUuid/type per line) carrying a Gemini-style message body
+ * (`message: { role, parts: [{text}|{thought}|{functionCall}|{functionResponse}] }`).
+ * Stored at ~/.qwen/projects/<encoded-cwd>/chats/<id>.jsonl. So we parse the
+ * envelope ourselves and map the Gemini-style parts (NOT the Claude parser,
+ * which expects message.content).
+ */
+
+import type { ConversationMessage, MessagePart, ProjectGroup, SessionInfo } from '$lib/types';
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import { homedir } from 'os';
+import * as path from 'path';
+
+const QWEN_PROJECTS = path.join(homedir(), '.qwen', 'projects');
+const PREFIX_BYTES = 64 * 1024;
+/** Cap conversation reads at 16 MB; oversized files are tail-read (matches the Codex reader). */
+const MAX_QWEN_FILE_BYTES = 16 * 1024 * 1024;
+const SYSTEM_TAG_PREFIXES = [
+  '<command-name>',
+  '<local-command',
+  '<system-reminder>',
+  '<task-notification>',
+];
+
+/** Find Qwen sessions whose file changed within `thresholdMs` — i.e. currently or recently active. */
+export function detectActiveQwenSessions(
+  thresholdMs: number
+): { cwd: string; id: string; startedAt: number }[] {
+  const cutoff = Date.now() - thresholdMs;
+  const out: { cwd: string; id: string; startedAt: number }[] = [];
+  for (const filePath of collectQwenFiles()) {
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.mtimeMs < cutoff) {
+        continue;
+      }
+      const meta = readMeta(readPrefix(filePath));
+      if (meta) {
+        out.push({ cwd: meta.cwd, id: meta.id, startedAt: stat.birthtimeMs });
+      }
+    } catch {
+      // skip
+    }
+  }
+  return out;
+}
+
+/**
+ * Return a page of a Qwen session's conversation. With `offset` 0 the most recent
+ * `limit` messages are returned, backed up to a user-message boundary so turns
+ * aren't clipped; otherwise the `offset`..`offset + limit` slice is returned.
+ */
+export function getQwenConversation(
+  sessionId: string,
+  offset = 0,
+  limit = 200
+): ConversationMessage[] {
+  if (!/^[A-Za-z0-9_-]+$/.test(sessionId)) {
+    return [];
+  }
+  const filePath = collectQwenFiles().find((p) => path.basename(p) === `${sessionId}.jsonl`);
+  if (!filePath) {
+    return [];
+  }
+  try {
+    const messages: ConversationMessage[] = [];
+    for (const line of readQwenTextBounded(filePath).split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      try {
+        const msg = qwenLineToMessage(JSON.parse(trimmed) as Record<string, unknown>);
+        if (msg) {
+          messages.push(msg);
+        }
+      } catch {
+        // skip malformed line
+      }
+    }
+    if (offset === 0 && messages.length > limit) {
+      let startIdx = messages.length - limit;
+      while (startIdx > 0 && messages[startIdx].role !== 'user') {
+        startIdx--;
+      }
+      return messages.slice(startIdx);
+    }
+    return messages.slice(offset, offset + limit);
+  } catch (error) {
+    console.error('[qwen] Failed to read conversation:', error);
+    return [];
+  }
+}
+
+/** List all Qwen sessions grouped by working directory, most-recently-modified first. */
+export function listQwenProjects(): ProjectGroup[] {
+  const byCwd = new Map<string, SessionInfo[]>();
+  for (const filePath of collectQwenFiles()) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      continue;
+    }
+    const meta = readMeta(readPrefix(filePath));
+    if (!meta) {
+      continue;
+    }
+    const session: SessionInfo = {
+      created: meta.started || stat.birthtime.toISOString(),
+      gitBranch: meta.gitBranch,
+      id: meta.id,
+      messageCount: 0,
+      modified: stat.mtime.toISOString(),
+      projectPath: meta.cwd,
+      source: 'qwen' as const,
+      summary: '',
+      title: meta.title || 'Untitled Session',
+    };
+    const bucket = byCwd.get(meta.cwd);
+    if (bucket) {
+      bucket.push(session);
+    } else {
+      byCwd.set(meta.cwd, [session]);
+    }
+  }
+
+  const projects: ProjectGroup[] = [];
+  for (const [cwd, sessions] of byCwd) {
+    sessions.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+    const segments = cwd.split('/').filter(Boolean);
+    projects.push({
+      fullPath: cwd,
+      id: shortHash(cwd),
+      lastModified: sessions[0]?.modified ?? '',
+      name: segments.slice(-2).join('/'),
+      sessionCount: sessions.length,
+      sessions,
+    });
+  }
+  return projects.sort(
+    (a, b) => new Date(b.lastModified).getTime() - new Date(a.lastModified).getTime()
+  );
+}
+
+/** All chats/*.jsonl files under ~/.qwen/projects/<encoded-cwd>/chats/. */
+function collectQwenFiles(): string[] {
+  const out: string[] = [];
+  let projectDirs: fs.Dirent[];
+  try {
+    projectDirs = fs.readdirSync(QWEN_PROJECTS, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const dir of projectDirs) {
+    if (!dir.isDirectory()) {
+      continue;
+    }
+    const chatsDir = path.join(QWEN_PROJECTS, dir.name, 'chats');
+    try {
+      for (const f of fs.readdirSync(chatsDir)) {
+        if (f.endsWith('.jsonl')) {
+          out.push(path.join(chatsDir, f));
+        }
+      }
+    } catch {
+      // no chats dir
+    }
+  }
+  return out;
+}
+
+/** Map a Qwen JSONL line (Claude envelope + Gemini message.parts) to a ConversationMessage. */
+function qwenLineToMessage(entry: Record<string, unknown>): ConversationMessage | null {
+  const type = entry.type;
+  if (type !== 'user' && type !== 'assistant') {
+    return null; // skip system/control records
+  }
+  const message = (entry.message ?? {}) as { content?: unknown; parts?: unknown };
+  const rawParts = Array.isArray(message.parts) ? message.parts : [];
+  const parts: MessagePart[] = [];
+  for (const raw of rawParts) {
+    if (typeof raw !== 'object' || raw === null) {
+      continue;
+    }
+    const p = raw as Record<string, unknown>;
+    if (p.functionCall && typeof p.functionCall === 'object') {
+      const fc = p.functionCall as Record<string, unknown>;
+      const toolName = typeof fc.name === 'string' ? fc.name : 'tool';
+      parts.push({
+        id: typeof fc.id === 'string' ? fc.id : toolName,
+        input: (fc.args as Record<string, unknown>) ?? {},
+        toolName,
+        type: 'tool_use',
+      });
+    } else if (p.thought === true && typeof p.text === 'string') {
+      parts.push({ content: p.text, type: 'thinking' });
+    } else if (typeof p.text === 'string') {
+      parts.push({ content: p.text, type: 'text' });
+    }
+  }
+  // Fallback for any Claude-style string content.
+  if (parts.length === 0 && typeof message.content === 'string' && message.content) {
+    parts.push({ content: message.content, type: 'text' });
+  }
+  if (parts.length === 0) {
+    return null;
+  }
+  return {
+    id: typeof entry.uuid === 'string' ? entry.uuid : `qwen-${type}`,
+    parts,
+    role: type === 'user' ? 'user' : 'assistant',
+    timestamp: typeof entry.timestamp === 'string' ? entry.timestamp : '',
+  };
+}
+
+/** Extract {cwd, sessionId, gitBranch, started} + first real user prompt from a Qwen session prefix. */
+function readMeta(
+  prefix: string
+): null | { cwd: string; gitBranch: string; id: string; started: string; title: string } {
+  let cwd = '';
+  let id = '';
+  let gitBranch = '';
+  let started = '';
+  let title = '';
+  for (const line of prefix.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (!cwd && typeof entry.cwd === 'string') {
+      cwd = entry.cwd;
+    }
+    if (!id && typeof entry.sessionId === 'string') {
+      id = entry.sessionId;
+    }
+    if (!gitBranch && typeof entry.gitBranch === 'string') {
+      gitBranch = entry.gitBranch;
+    }
+    if (!started && typeof entry.timestamp === 'string') {
+      started = entry.timestamp;
+    }
+    if (!title && entry.type === 'user') {
+      const msg = entry.message as undefined | { content?: unknown; parts?: unknown };
+      let text = typeof msg?.content === 'string' ? msg.content : '';
+      if (!text && Array.isArray(msg?.parts)) {
+        text = msg.parts
+          .map((p) =>
+            p && typeof p === 'object' && typeof (p as { text?: unknown }).text === 'string'
+              ? (p as { text: string }).text
+              : ''
+          )
+          .join(' ')
+          .trim();
+      }
+      if (text && !SYSTEM_TAG_PREFIXES.some((p) => text.startsWith(p))) {
+        title = text.split('\n')[0]?.slice(0, 80) ?? '';
+      }
+    }
+  }
+  return id && cwd ? { cwd, gitBranch, id, started, title } : null;
+}
+
+/** Read the head of a file (complete lines only). */
+function readPrefix(filePath: string): string {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(PREFIX_BYTES);
+    const n = fs.readSync(fd, buf, 0, PREFIX_BYTES, 0);
+    const text = buf.toString('utf-8', 0, n);
+    const lastNl = text.lastIndexOf('\n');
+    return lastNl === -1 ? text : text.slice(0, lastNl);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/** Read a Qwen session file, bounded to the tail for oversized files to cap memory. */
+function readQwenTextBounded(filePath: string): string {
+  const size = fs.statSync(filePath).size;
+  if (size <= MAX_QWEN_FILE_BYTES) {
+    return fs.readFileSync(filePath, 'utf-8');
+  }
+  // Oversized: read only the trailing window (most recent messages), dropping the
+  // first (likely partial) line so JSON.parse never sees a fragment.
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(MAX_QWEN_FILE_BYTES);
+    const n = fs.readSync(fd, buf, 0, MAX_QWEN_FILE_BYTES, size - MAX_QWEN_FILE_BYTES);
+    const tail = buf.toString('utf-8', 0, n);
+    return tail.slice(tail.indexOf('\n') + 1);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function shortHash(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex').slice(0, 8);
+}

--- a/src/lib/modules/server/sessions/registry.ts
+++ b/src/lib/modules/server/sessions/registry.ts
@@ -1,0 +1,137 @@
+/**
+ * Provider registry — the single place that knows every AI-agent provider.
+ *
+ * Inspired by wesm/agentsview's AgentDef registry: instead of branching on
+ * `command === 'claude'` across ~14 call sites, the session API, the connect
+ * route, and the terminal allowlist all derive from this list. Adding a
+ * provider is one entry here (+ its reader) rather than edits everywhere.
+ *
+ * Detection (process-detector) and live watching (server.ts adapter) stay
+ * provider-specific because their mechanisms differ too much to unify cheaply.
+ */
+
+import type { ConversationMessage, ProjectGroup, ProviderDef } from '$lib/types';
+
+import { getCodexConversation, listCodexProjects } from './codex-reader';
+import { getGeminiConversation, listGeminiProjects } from './gemini-reader';
+import { getSessionConversation, listProjectsWithSessions } from './jsonl-reader';
+import { getOpenCodeConversation, listOpenCodeProjects } from './opencode-reader';
+import { getQwenConversation, listQwenProjects } from './qwen-reader';
+
+/**
+ * Every AI-agent provider, in merge order. `claude-code` MUST stay first: its
+ * projects seed the merge map so the canonical (decoded) project path/name wins
+ * over other providers' guesses.
+ */
+export const PROVIDERS: ProviderDef[] = [
+  {
+    command: 'claude',
+    getConversation: (id, offset, limit) => getSessionConversation(id, offset, limit),
+    isAI: true,
+    label: 'Claude Code',
+    listProjects: listProjectsWithSessions,
+    resumeArgs: (id) => ['--resume', id],
+    source: 'claude-code',
+  },
+  {
+    command: 'opencode',
+    getConversation: getOpenCodeConversation,
+    isAI: true,
+    label: 'OpenCode',
+    listProjects: listOpenCodeProjects,
+    nameSuffix: ' (OpenCode)',
+    resumeArgs: (id) => ['--session', id],
+    source: 'opencode',
+  },
+  {
+    command: 'codex',
+    getConversation: getCodexConversation,
+    isAI: true,
+    label: 'Codex',
+    listProjects: listCodexProjects,
+    resumeArgs: (id) => ['resume', id],
+    source: 'codex',
+  },
+  {
+    command: 'gemini',
+    getConversation: getGeminiConversation,
+    isAI: true,
+    label: 'Gemini',
+    listProjects: listGeminiProjects,
+    resumeArgs: () => [], // Gemini CLI has no session-resume flag
+    source: 'gemini',
+  },
+  {
+    command: 'qwen',
+    getConversation: getQwenConversation,
+    isAI: true,
+    label: 'Qwen',
+    listProjects: listQwenProjects,
+    resumeArgs: () => [],
+    source: 'qwen',
+  },
+];
+
+/** AI-agent binary names (for AI_COMMANDS-style checks). */
+export const AI_COMMANDS: string[] = PROVIDERS.filter((p) => p.isAI).map((p) => p.command);
+
+/** All provider binary names (for the terminal allowlist + connect validation). */
+export const PROVIDER_COMMANDS: string[] = PROVIDERS.map((p) => p.command);
+
+/** Resolve a session's conversation across providers (Claude first, with its project dir). */
+export function getProviderConversation(
+  sessionId: string,
+  offset: number,
+  limit: number,
+  claudeProjectDir?: string
+): ConversationMessage[] {
+  const claude = getSessionConversation(sessionId, offset, limit, claudeProjectDir);
+  if (claude.length > 0) {
+    return claude;
+  }
+  for (const provider of PROVIDERS) {
+    if (provider.source === 'claude-code') {
+      continue;
+    }
+    const messages = provider.getConversation(sessionId, offset, limit);
+    if (messages.length > 0) {
+      return messages;
+    }
+  }
+  return [];
+}
+
+/** Merge every provider's projects, deduplicating by absolute path. */
+export function listAllProviderProjects(): ProjectGroup[] {
+  const byPath = new Map<string, ProjectGroup>();
+  for (const provider of PROVIDERS) {
+    let groups: ProjectGroup[];
+    try {
+      groups = provider.listProjects();
+    } catch {
+      continue; // a broken provider must not take down the whole listing
+    }
+    for (const group of groups) {
+      const name = provider.nameSuffix ? group.name.replace(provider.nameSuffix, '') : group.name;
+      const existing = byPath.get(group.fullPath);
+      if (existing) {
+        existing.sessions.push(...group.sessions);
+        existing.sessions.sort(
+          (a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime()
+        );
+        existing.sessionCount = existing.sessions.length;
+        existing.lastModified = existing.sessions[0]?.modified || existing.lastModified;
+      } else {
+        byPath.set(group.fullPath, { ...group, name });
+      }
+    }
+  }
+  return [...byPath.values()].sort(
+    (a, b) => new Date(b.lastModified).getTime() - new Date(a.lastModified).getTime()
+  );
+}
+
+/** Resume args for a launched command (e.g. `codex resume <id>`). */
+export function resumeArgsForCommand(command: string, sessionId: string): string[] {
+  return PROVIDERS.find((p) => p.command === command)?.resumeArgs(sessionId) ?? [];
+}

--- a/src/lib/modules/server/terminal/codex-watcher.ts
+++ b/src/lib/modules/server/terminal/codex-watcher.ts
@@ -15,6 +15,7 @@ import { watch as chokidarWatch } from 'chokidar';
 import * as fs from 'fs';
 
 import { CodexStreamParser, parseCodexRollout } from '../sessions/codex-parser';
+import { readBoundedRolloutText } from '../sessions/codex-reader';
 
 /** Flush the open run after this many ms without a write. */
 const IDLE_FLUSH_MS = 1500;
@@ -28,7 +29,9 @@ class CodexWatcher {
       return [];
     }
     try {
-      return parseCodexRollout(fs.readFileSync(filePath, 'utf-8')).messages;
+      // Bounded read — rollout files can be hundreds of MB; this is called on
+      // every WS session connection (mirrors getCodexConversation).
+      return parseCodexRollout(readBoundedRolloutText(filePath)).messages;
     } catch (error) {
       console.error(`[codex-watcher] Failed to read history for ${filePath}:`, error);
       return [];

--- a/src/lib/modules/server/ws/session-handler.ts
+++ b/src/lib/modules/server/ws/session-handler.ts
@@ -22,6 +22,8 @@ import type { WebSocket } from 'ws';
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { findCodexRolloutById } from '../sessions/codex-reader';
+
 // ── Module-level references ──────────────────────────────────────────
 
 let _ptyManager: null | PtyManagerLike = null;
@@ -171,34 +173,36 @@ function conversationToLive(msg: ConversationMessage): ServerMessage[] {
  * Returns the absolute path if found, or null.
  */
 function findJsonlFileForSession(sessionId: string): null | string {
-  const claudeProjectsDir = path.join(process.env.HOME || '', '.claude', 'projects');
-
-  if (!fs.existsSync(claudeProjectsDir)) {
+  // Reject anything that could traverse out of the session directories before
+  // it is interpolated into a filesystem path.
+  if (!/^[A-Za-z0-9_-]+$/.test(sessionId)) {
     return null;
   }
 
-  try {
-    const projectDirs = fs.readdirSync(claudeProjectsDir);
-    for (const dir of projectDirs) {
-      const fullDir = path.join(claudeProjectsDir, dir);
-      try {
-        if (!fs.statSync(fullDir).isDirectory()) {
+  const claudeProjectsDir = path.join(process.env.HOME || '', '.claude', 'projects');
+  if (fs.existsSync(claudeProjectsDir)) {
+    try {
+      for (const dir of fs.readdirSync(claudeProjectsDir)) {
+        const fullDir = path.join(claudeProjectsDir, dir);
+        try {
+          if (!fs.statSync(fullDir).isDirectory()) {
+            continue;
+          }
+        } catch {
           continue;
         }
-      } catch {
-        continue;
+        const jsonlPath = path.join(fullDir, `${sessionId}.jsonl`);
+        if (fs.existsSync(jsonlPath)) {
+          return jsonlPath;
+        }
       }
-
-      const jsonlPath = path.join(fullDir, `${sessionId}.jsonl`);
-      if (fs.existsSync(jsonlPath)) {
-        return jsonlPath;
-      }
+    } catch {
+      // Ignore filesystem errors
     }
-  } catch {
-    // Ignore filesystem errors
   }
 
-  return null;
+  // Fall back to an external Codex session: ~/.codex/sessions/**/rollout-*-<id>.jsonl
+  return findCodexRolloutById(sessionId);
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/lib/theme.css
+++ b/src/lib/theme.css
@@ -526,6 +526,39 @@
   --pill-cursor: inherit;
 }
 
+/* Additional providers reuse the existing colour families (cosmetic only). */
+.pill-source-qwen,
+.pill-source-iflow {
+  --pill-background: var(--ds-red-100);
+  --pill-color: var(--ds-red-900);
+  --pill-font-size: 10px;
+  --pill-padding: 2px 8px;
+  --pill-hover-background: var(--ds-red-100);
+  --pill-hover-color: var(--ds-red-900);
+  --pill-cursor: inherit;
+}
+
+.pill-source-cursor {
+  --pill-background: var(--ds-blue-100);
+  --pill-color: var(--ds-blue-900);
+  --pill-font-size: 10px;
+  --pill-padding: 2px 8px;
+  --pill-hover-background: var(--ds-blue-100);
+  --pill-hover-color: var(--ds-blue-900);
+  --pill-cursor: inherit;
+}
+
+.pill-source-copilot,
+.pill-source-amp {
+  --pill-background: var(--ds-amber-100);
+  --pill-color: var(--ds-amber-900);
+  --pill-font-size: 10px;
+  --pill-padding: 2px 8px;
+  --pill-hover-background: var(--ds-amber-100);
+  --pill-hover-color: var(--ds-amber-900);
+  --pill-cursor: inherit;
+}
+
 /* ===== Icon Sizes ===== */
 .icon-14 {
   --icon-width: 14px;

--- a/src/lib/types/gemini.ts
+++ b/src/lib/types/gemini.ts
@@ -1,0 +1,100 @@
+// Gemini CLI session types (hand-written: the on-disk formats are
+// provider-specific and not worth round-tripping through the YAML codegen).
+// Gemini CLI stores user messages in ~/.gemini/tmp/<projectHash>/logs.json
+// and full conversation records in
+// ~/.gemini/tmp/<projectHash>/chats/session-*.json (newer versions only).
+
+// ---------------------------------------------------------------------------
+// logs.json — user-messages-only format (all versions)
+// ---------------------------------------------------------------------------
+
+/** Union of all part shapes that appear in a ConversationRecord message. */
+export type GeminiContentPart = GeminiFunctionCallPart | GeminiTextPart | GeminiThoughtPart;
+
+// ---------------------------------------------------------------------------
+// chats/session-*.json — full ConversationRecord (newer versions)
+// ---------------------------------------------------------------------------
+
+/** Full conversation record stored in chats/session-*.json. */
+export interface GeminiConversationRecord {
+  directories?: string[];
+  kind?: 'main' | 'subagent';
+  lastUpdated: string;
+  messages: GeminiMessageRecord[];
+  projectHash: string;
+  sessionId: string;
+  startTime: string;
+  summary?: string;
+}
+
+/** Inline function-call part from the Google GenAI SDK. */
+export interface GeminiFunctionCallPart {
+  functionCall: {
+    args: Record<string, unknown>;
+    id?: string;
+    name: string;
+  };
+}
+
+/** A single entry in ~/.gemini/tmp/<projectHash>/logs.json. */
+export interface GeminiLogEntry {
+  message: string;
+  messageId: number;
+  sessionId: string;
+  timestamp: string;
+  type: 'user';
+}
+
+/** A single message record in a full ConversationRecord. */
+export type GeminiMessageRecord =
+  | {
+      content: GeminiContentPart[] | string;
+      id: string;
+      thoughts?: GeminiThoughtSummary[];
+      timestamp: string;
+      toolCalls?: GeminiToolCallRecord[];
+      type: 'gemini';
+    }
+  | {
+      content: GeminiContentPart[] | string;
+      id: string;
+      timestamp: string;
+      type: 'error' | 'info' | 'user' | 'warning';
+    };
+
+/** Contents of ~/.gemini/projects.json (present only in newer gemini-cli). */
+export type GeminiProjectsJson = Record<string, string>;
+
+/** Plain-text content part from the Google GenAI SDK. */
+export interface GeminiTextPart {
+  text: string;
+  thought?: false;
+}
+
+/** Inline thinking/reasoning part from the Google GenAI SDK. */
+export interface GeminiThoughtPart {
+  text: string;
+  thought: true;
+}
+
+/** A thought-summary entry attached to a 'gemini'-type message. */
+export interface GeminiThoughtSummary {
+  summary?: string;
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// projects.json — project slug → absolute path registry (newer versions)
+// ---------------------------------------------------------------------------
+
+/** A single tool-call record attached to a 'gemini'-type message. */
+export interface GeminiToolCallRecord {
+  args: Record<string, unknown>;
+  description?: string;
+  displayName?: string;
+  id: string;
+  name: string;
+  result?: unknown;
+  status: 'cancelled' | 'error' | 'pending' | 'success';
+  timestamp: string;
+}

--- a/src/lib/types/generated/Sessions.ts
+++ b/src/lib/types/generated/Sessions.ts
@@ -14,7 +14,16 @@ import {
  * @type { SessionSource }
  * @description Source tool that produced the session
  */
-export type SessionSource = 'claude-code' | 'opencode' | 'codex' | 'gemini';
+export type SessionSource =
+  | 'claude-code'
+  | 'opencode'
+  | 'codex'
+  | 'gemini'
+  | 'qwen'
+  | 'cursor'
+  | 'copilot'
+  | 'amp'
+  | 'iflow';
 
 export function decodeSessionSource(rawInput: unknown): SessionSource | null {
   switch (rawInput) {
@@ -22,6 +31,11 @@ export function decodeSessionSource(rawInput: unknown): SessionSource | null {
     case 'opencode':
     case 'codex':
     case 'gemini':
+    case 'qwen':
+    case 'cursor':
+    case 'copilot':
+    case 'amp':
+    case 'iflow':
       return rawInput;
   }
   return null;
@@ -33,6 +47,11 @@ export function _decodeSessionSource(rawInput: unknown): SessionSource | undefin
     case 'opencode':
     case 'codex':
     case 'gemini':
+    case 'qwen':
+    case 'cursor':
+    case 'copilot':
+    case 'amp':
+    case 'iflow':
       return rawInput;
   }
   return;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -8,6 +8,7 @@ export type * from './codex';
 export type * from './common';
 export type * from './dashboard';
 export * from './decision';
+export type * from './gemini';
 export * from './generated';
 export type * from './neurolink';
 export type * from './server';

--- a/src/lib/types/sessions.ts
+++ b/src/lib/types/sessions.ts
@@ -3,7 +3,7 @@
 // classes and `type: string` instead of the string-literal discriminated unions
 // required at runtime.
 
-import type { MessageRole } from './generated';
+import type { MessageRole, ProjectGroup, SessionSource } from './generated';
 
 /** Internal structure from ~/.claude/sessions/<PID>.json */
 export interface ClaudeSessionFile {
@@ -23,7 +23,16 @@ export interface ConversationMessage {
 }
 
 export interface DetectedProcess {
-  command: 'claude' | 'codex' | 'gemini' | 'opencode';
+  command:
+    | 'amp'
+    | 'claude'
+    | 'codex'
+    | 'copilot'
+    | 'cursor-agent'
+    | 'gemini'
+    | 'iflow'
+    | 'opencode'
+    | 'qwen';
   cwd: string;
   kind: string;
   pid: number;
@@ -33,6 +42,18 @@ export interface DetectedProcess {
 }
 
 export type MessagePart = TextPart | ThinkingPart | ToolResultPart | ToolUsePart;
+
+/** A registered AI-agent provider (see server/sessions/registry.ts). */
+export interface ProviderDef {
+  command: string;
+  getConversation: (sessionId: string, offset: number, limit: number) => ConversationMessage[];
+  isAI: boolean;
+  label: string;
+  listProjects: () => ProjectGroup[];
+  nameSuffix?: string;
+  resumeArgs: (sessionId: string) => string[];
+  source: SessionSource;
+}
 
 export interface TextPart {
   content: string;

--- a/src/routes/api/sessions/+server.ts
+++ b/src/routes/api/sessions/+server.ts
@@ -1,15 +1,10 @@
 import type { ProjectGroup } from '$lib/types';
 
 import { validateAuth } from '$lib/modules/server/auth';
-import { getCodexConversation, listCodexProjects } from '$lib/modules/server/sessions/codex-reader';
 import {
-  getSessionConversation,
-  listProjectsWithSessions,
-} from '$lib/modules/server/sessions/jsonl-reader';
-import {
-  getOpenCodeConversation,
-  listOpenCodeProjects,
-} from '$lib/modules/server/sessions/opencode-reader';
+  getProviderConversation,
+  listAllProviderProjects,
+} from '$lib/modules/server/sessions/registry';
 import { json } from '@sveltejs/kit';
 
 import type { RequestHandler } from './$types';
@@ -25,41 +20,7 @@ function getMergedProjects(): ProjectGroup[] {
     return cachedProjects;
   }
 
-  const claudeProjects = listProjectsWithSessions();
-  const openCodeProjects = listOpenCodeProjects();
-  const codexProjects = listCodexProjects();
-  const projectsByPath = new Map<string, ProjectGroup>();
-
-  for (const p of claudeProjects) {
-    projectsByPath.set(p.fullPath, { ...p });
-  }
-
-  // Merge a provider's projects into the map, deduplicating by absolute path so
-  // sessions from different agents in the same directory group under one project.
-  const mergeProvider = (incoming: ProjectGroup[], stripSuffix?: string): void => {
-    for (const group of incoming) {
-      const cleanName = stripSuffix ? group.name.replace(stripSuffix, '') : group.name;
-      const existing = projectsByPath.get(group.fullPath);
-      if (existing) {
-        existing.sessions.push(...group.sessions);
-        existing.sessions.sort(
-          (a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime()
-        );
-        existing.sessionCount = existing.sessions.length;
-        existing.lastModified = existing.sessions[0]?.modified || existing.lastModified;
-        existing.name = existing.name.replace(stripSuffix ?? '', '');
-      } else {
-        projectsByPath.set(group.fullPath, { ...group, name: cleanName });
-      }
-    }
-  };
-
-  mergeProvider(openCodeProjects, ' (OpenCode)');
-  mergeProvider(codexProjects);
-
-  cachedProjects = [...projectsByPath.values()].sort(
-    (a, b) => new Date(b.lastModified).getTime() - new Date(a.lastModified).getTime()
-  );
+  cachedProjects = listAllProviderProjects();
   cacheTimestamp = now;
   return cachedProjects;
 }
@@ -95,15 +56,7 @@ export const GET: RequestHandler = ({ request, url }) => {
     const claudeProjectDir = matchedProject
       ? matchedProject.fullPath.replace(/\//g, '-')
       : undefined;
-    let messages = getSessionConversation(sessionId, offset, limit, claudeProjectDir);
-
-    // If Claude Code reader found nothing, try OpenCode, then Codex.
-    if (messages.length === 0) {
-      messages = getOpenCodeConversation(sessionId, offset, limit);
-    }
-    if (messages.length === 0) {
-      messages = getCodexConversation(sessionId, offset, limit);
-    }
+    const messages = getProviderConversation(sessionId, offset, limit, claudeProjectDir);
 
     // Find session info — short-circuit when project is already resolved
     let sessionInfo = matchedProject?.sessions.find((s) => s.id === sessionId) ?? null;

--- a/src/routes/api/sessions/connect/+server.ts
+++ b/src/routes/api/sessions/connect/+server.ts
@@ -1,4 +1,5 @@
 import { validateAuth } from '$lib/modules/server/auth';
+import { PROVIDER_COMMANDS, resumeArgsForCommand } from '$lib/modules/server/sessions/registry';
 import { ptyManager } from '$lib/modules/server/terminal/pty-manager';
 import { toErrorMessage } from '$lib/modules/server/utils/error';
 import { json } from '@sveltejs/kit';
@@ -34,13 +35,21 @@ export const POST: RequestHandler = async ({ request }) => {
     return json({ error: 'sessionId is required (string)' }, { status: 400 });
   }
 
+  // sessionId becomes a process argument (e.g. `codex resume <id>`); restrict it
+  // to safe identifier characters to prevent argument/path injection.
+  if (!/^[A-Za-z0-9_-]+$/.test(sessionId)) {
+    return json({ error: 'Invalid sessionId format' }, { status: 400 });
+  }
+
   if (!cwd || typeof cwd !== 'string') {
     return json({ error: 'cwd is required (string)' }, { status: 400 });
   }
 
-  const VALID_COMMANDS = ['claude', 'opencode', 'codex', 'gemini'];
-  if (!command || !VALID_COMMANDS.includes(command)) {
-    return json({ error: `command must be one of: ${VALID_COMMANDS.join(', ')}` }, { status: 400 });
+  if (!command || !PROVIDER_COMMANDS.includes(command)) {
+    return json(
+      { error: `command must be one of: ${PROVIDER_COMMANDS.join(', ')}` },
+      { status: 400 }
+    );
   }
 
   // --- Validate cwd (same checks as POST /api/terminals) ---
@@ -98,13 +107,7 @@ export const POST: RequestHandler = async ({ request }) => {
 
   // --- Build args based on command (resume convention differs per agent CLI) ---
 
-  const resumeArgs: Record<string, string[]> = {
-    claude: ['--resume', sessionId],
-    codex: ['resume', sessionId],
-    gemini: [], // Gemini CLI has no session-resume flag; launch fresh in the cwd.
-    opencode: ['--session', sessionId],
-  };
-  const args: string[] = resumeArgs[command] ?? [];
+  const args: string[] = resumeArgsForCommand(command, sessionId);
 
   try {
     const terminal = await ptyManager.create(command, args, realCwd, 120, 40);

--- a/src/routes/api/terminals/+server.ts
+++ b/src/routes/api/terminals/+server.ts
@@ -1,13 +1,15 @@
 import { validateAuth } from '$lib/modules/server/auth';
+import { PROVIDER_COMMANDS } from '$lib/modules/server/sessions/registry';
 import { ptyManager } from '$lib/modules/server/terminal/pty-manager';
 import { toErrorMessage } from '$lib/modules/server/utils/error';
 import { json } from '@sveltejs/kit';
 import { realpathSync, statSync } from 'fs';
-import { basename, isAbsolute, relative } from 'path';
+import { isAbsolute, relative } from 'path';
 
 import type { RequestHandler } from './$types';
 
-const ALLOWED_COMMANDS = ['zsh', 'bash', 'sh', 'fish', 'claude', 'opencode', 'codex', 'gemini'];
+// Plain shells + every registered AI-agent binary.
+const ALLOWED_COMMANDS = ['zsh', 'bash', 'sh', 'fish', ...PROVIDER_COMMANDS];
 
 /** Extract the last non-empty line from a scrollback string. */
 function lastScrollbackLine(scrollback: string): null | string {
@@ -86,9 +88,9 @@ export const POST: RequestHandler = async ({ request }) => {
       return json({ error: 'command is required' }, { status: 400 });
     }
 
-    // Issue 4: Command allowlist — only allow known safe commands
-    const commandBasename = basename(command);
-    if (!ALLOWED_COMMANDS.includes(commandBasename)) {
+    // Command allowlist — only bare allowlisted binary names. Reject any path
+    // component so an absolute path like "/tmp/bash" (basename "bash") can't slip through.
+    if (command.includes('/') || command.includes('\\') || !ALLOWED_COMMANDS.includes(command)) {
       return json(
         { error: `Command not allowed. Allowed: ${ALLOWED_COMMANDS.join(', ')}` },
         { status: 400 }

--- a/src/routes/terminals/+page.svelte
+++ b/src/routes/terminals/+page.svelte
@@ -5,7 +5,13 @@
   import RefreshSvg from '$lib/assets/icons/refresh.svg?raw';
   import SettingsSvg from '$lib/assets/icons/settings.svg?raw';
   import TerminalSvg from '$lib/assets/icons/terminal.svg?raw';
-  import { clearCache, getCached, isShooterConfig, setCache } from '$lib/modules/client/common';
+  import {
+    AI_COMMANDS,
+    clearCache,
+    getCached,
+    isShooterConfig,
+    setCache,
+  } from '$lib/modules/client/common';
   import LaunchSheet from '$lib/modules/client/terminal/LaunchSheet.svelte';
   import {
     Banner,
@@ -21,7 +27,6 @@
 
   const POLL_INTERVAL_MS = 10_000;
   const CACHE_KEY = 'shooter_terminals';
-  const AI_COMMANDS = ['claude', 'opencode', 'codex', 'gemini'];
   const SHELL_COMMANDS = ['zsh', 'bash', 'sh', 'fish'];
 
   let terminals = $state<TerminalListItem[]>([]);

--- a/src/routes/terminals/[id]/+page.svelte
+++ b/src/routes/terminals/[id]/+page.svelte
@@ -11,6 +11,7 @@
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import AlertTriangleSvg from '$lib/assets/icons/alert-triangle.svg?raw';
+  import { AI_COMMANDS } from '$lib/modules/client/common';
   import ChatView from '$lib/modules/client/terminal/ChatView.svelte';
   import CommandPalette from '$lib/modules/client/terminal/CommandPalette.svelte';
   import ConnectionStatus from '$lib/modules/client/terminal/ConnectionStatus.svelte';
@@ -29,8 +30,6 @@
   import { onDestroy, onMount } from 'svelte';
 
   // ------- Constants -------
-
-  const AI_COMMANDS = ['claude', 'opencode', 'codex', 'gemini'];
 
   // ------- Reactive state -------
 


### PR DESCRIPTION
Introduces a provider **registry** abstraction and adds **Gemini** and **Qwen Code** session readers, plus the Codex notifier hook. Fixes OpenCode DB-path probing to recover sessions on XDG installs.

**Depends on #82** (base branch).

---

### 📚 Stack — #82 split into 4 single-commit PRs (review & merge 1 → 4)

| # | PR | Scope |
|---|----|-------|
| 1 | #82 | Codex CLI session support |
| 2 | #83 | Provider registry + Gemini & Qwen readers |
| 3 | #84 | Cursor, Copilot & Amp read-only providers |
| 4 | #85 | Session-Over-Sessions coordinator |

Each PR is **one squashed commit**, stacked so each targets the branch below it. Together they reproduce the original #82 branch **byte-for-byte**. GitHub auto-retargets the next PR onto `release` as each one merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple AI providers: Gemini, Qwen, Copilot, Cursor, and Amp alongside existing providers.
  * Implemented centralized multi-provider session management for seamless project and conversation retrieval across providers.
  * Added Qwen terminal launch preset for quick access.
  * Improved handling of large session files with bounded reading to prevent memory issues.

* **Chores**
  * Added provider configuration and type definitions for new AI agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->