### PR TITLE
feat(sos): Session-Over-Sessions multi-agent coordinator

### DIFF
--- a/docs/SESSION-OVER-SESSIONS-CONCEPT.md
+++ b/docs/SESSION-OVER-SESSIONS-CONCEPT.md
@@ -1,0 +1,365 @@
+# Session Over Sessions (SoS) — Synthesis Concept Document
+
+**Synthesized from:** 6 multi-lens mining passes, 375 + 92 knowledge-base entries  
+**Date:** 2026-05-29  
+**Author:** Synthesis agent, cross-referencing sos-agent-to-agent.md, sos-orchestration.md, sos-shared-context.md, sos-message-relay.md, sos-concurrent-sessions.md, sos-protocols-hitl.md
+
+---
+
+## 1. Crisp Definition
+
+> **Session Over Sessions** is a meta-layer that (a) subscribes to N concurrently-running agent sessions (Claude Code, Codex, OpenCode, etc.), (b) reads each session's live event stream, and (c) routes, relays, and injects messages between sessions and into new sessions — presenting a single unified "super-session" to the human operator.
+
+The user's verbatim intent: _"if one [agent session] is running, another is running; they both talk to each other in one session — a concept of session over sessions, which reads from both of these and passes to other ones."_
+
+The coordinator is not passive. It is an active broker: it (1) observes child sessions' state machines, (2) decides which information crosses session boundaries, (3) injects that information into target sessions, and (4) escalates decisions to the human when policy requires it.
+
+**What it is not**: a monolithic agent that replaces parallel sessions. SoS is the coordination membrane between autonomous agents, not a replacement for them.
+
+**Grounding in the corpus**: The clearest name for this pattern already exists — Gas Town calls it "The Mayor AI Coordinator" (`githubprojects_3899619286326340159`); Octogent calls it "Octoboss" (`parasmadan.in_3877305782659851702`); Rob Hallam describes it as the Claude session that "has full context … writing prompts for Codex … managing like all these ten agents" (`robhallam__3851764032377748268`).
+
+---
+
+## 2. Technique Catalog
+
+Each technique is labeled with the lens it came from and the source video(s).
+
+---
+
+### T1 — Beads Ledger / Named Mailboxes (Append-Only Shared State)
+
+**Source videos**: Gas Town (`githubprojects_3899619286326340159`)  
+**Lens**: agent-to-agent, orchestration, shared-context, message-relay, concurrent-sessions, protocols-HITL
+
+**Mechanism**: Every work event (task assignment, tool result, context checkpoint) is appended as a "bead" to a git-backed or SQLite-backed append-only log. Each agent has a named identity and a mailbox. The coordinator writes to mailboxes; agents poll them. No IPC required — disk is the bus.
+
+> "Built-in mailboxes, identities, and handoffs" / "Work state stored in Beads ledger" / "Scale comfortably to 20-30 agents"
+
+**Maps to SoS**: The coordinator (meta-session) is "The Mayor." Worker sessions (Claude, Codex, OpenCode terminals) are "Polecats." The Beads ledger maps to a `sos_relay_log` SQLite table in `~/.shooter/shooter.db`. Each bead row: `(id, from_session, to_session, message_type, payload, ts, consumed_at)`.
+
+**Architecture tier**: Persistence / message bus
+
+---
+
+### T2 — ACP Injection (`cband continue`) / HTTP Daemon
+
+**Source videos**: Claudraband (`githubsignals_3874535135337291122`), VibeAround (`githubsignals_3890103852199156424`)  
+**Lens**: agent-to-agent, message-relay, concurrent-sessions, protocols-HITL
+
+**Mechanism**: Claudraband wraps Claude Code TUI in a controlled tmux pane and exposes a three-layer injection API: `cband continue <session-id> '<prompt>'` → HTTP POST → daemon → `tmux send-keys`. VibeAround adds `/handover`, `/pickup`, and `/switch <agent>` commands using the ACP Rust SDK to serialise and migrate session context across surfaces or across agent processes.
+
+> "cband continue <session-id> 'what was the result of the research?'" / "Move a live coding session between terminal and IM with /handover / /pickup — full context preserved." / "Run /switch claude, /switch codex, or /switch cursor from any channel to switch agents on the fly"
+
+**Maps to SoS**: Shooter's `pty-manager.ts` already owns PTYs via Unix-socket holder processes. The ACP injection layer sits on top: `POST /api/sessions/:id/inject` is the Claudraband equivalent. `/handover`+`/pickup` becomes two WebSocket events (`relay_handover`, `relay_pickup`) in `ws-protocol.yaml`. `/switch` becomes a `pty-manager.ts` attach/detach + context prefix injection.
+
+**Architecture tier**: Write-side relay / control plane
+
+---
+
+### T3 — Coordinator + Worker Topology (Hub-and-Spoke)
+
+**Source videos**: Octogent (`parasmadan.in_3877305782659851702`), Rob Hallam (`robhallam__3851764032377748268`), Ruflo (`aiadventureryt_3869407061121786825`)  
+**Lens**: orchestration, concurrent-sessions, agent-to-agent
+
+**Mechanism**: One coordinator session holds the plan and context map; N worker sessions execute specialized subtasks. Octogent's Octoboss dispatches to domain-specialist swarms (Frontend UI / API Backend / Docs & Knowledge). Rob Hallam's Claude acts as "taste guy" — reads all Codex outputs, synthesizes decisions, and generates the next Codex prompts. Octogent names the coordinator's terminal ID pattern: `docs-knowledge-swarm-1`.
+
+> "Claude has full context of my code base and everything and it's writing prompts for Codex. Codex outputs something, I give it to Claude." / "Your terminal ID is `docs-knowledge-swarm-1`"
+
+**Maps to SoS**: Shooter's SoS meta-session IS the Octoboss. Its `sos_sessions` SQLite table stores `(session_id, capability, status, coordinator_id)`. Routing rule: capability-first (route auth tasks to the "backend" Claude session, UI tasks to the "frontend" Codex session). A `PERMISSION` node in the graph routes all PermissionRequests through a single APNs notification queue.
+
+**Architecture tier**: Routing / dispatch
+
+---
+
+### T4 — Process-Table Auto-Discovery + Hook Event PID Mapping
+
+**Source videos**: Claude Control (`githubsignals_3877154328675116231`), agtop (`githubsignals_3876376987761906329`)  
+**Lens**: concurrent-sessions, message-relay, protocols-HITL
+
+**Mechanism**: Claude Control scans the OS process table for `claude` PIDs. Hook events (`SubagentStart`, `PreToolUse`, etc.) carry the authoritative PID-to-JSONL-path mapping. mtime on `~/.claude/` JSONL files is the fallback for sessions started before the monitor. This gives zero-config discovery of all running sessions. agtop adds `context_pressure` as a real-time metric — the trigger for compaction-triggered relay.
+
+> "Detects all running claude CLI processes via the process table, uses hook events for authoritative PID-to-JSONL mapping with mtime-based fallback." / "Classifies each session as Working, Idle, Waiting (needs input), Errored, or Finished"
+
+**Maps to SoS**: Shooter's `session-watcher.ts` already tails JSONL via chokidar. Add: (1) `pgrep -la claude` on a 5-second poll, (2) a 5-state session status machine (`Working | Idle | Waiting | Compacting | Finished`) in `terminal-store.ts`. Context pressure >70% triggers the PreCompact snapshot relay.
+
+**Architecture tier**: Discovery / observation
+
+---
+
+### T5 — PreCompact Hook Interception (Context Boundary Survival)
+
+**Source videos**: Claude Harness (`githubsignals_3888917703615132104`)  
+**Lens**: shared-context, orchestration, message-relay, concurrent-sessions
+
+**Mechanism**: Claude Code v2.1.105+ fires a `PreCompact` lifecycle hook before silently compacting a long context window. The harness intercepts this, writes the full pre-compaction state to `Plans.md` (a git-tracked, session-surviving artifact), and optionally blocks compaction until state is saved. `harness-mem` re-injects this summary into the next session's initial context.
+
+> "Long-running tasks no longer get cut off mid-flight by automatic compaction." / "harness-mem integration: sessions remember what you worked on last time."
+
+**Maps to SoS**: Register a `PreCompact` hook in `.claude/settings.json` → `notifier.cjs`. On fire: (1) serialize last-N JSONL events to `sos_relay_log` with `message_type='precompact_snapshot'`, (2) send a push notification "session compacting", (3) return `{"action":"continue"}`. On next session start, the coordinator reads the snapshot and injects it as a context prefix. This closes the restart-context-loss gap.
+
+**Architecture tier**: Context lifecycle / persistence
+
+---
+
+### T6 — Structured Trace Capture + Skill Propagation (Knowledge Plane)
+
+**Source videos**: Hivemind (`githubsignals_3896549067676034823`)  
+**Lens**: shared-context, orchestration, agent-to-agent
+
+**Mechanism**: Hivemind intercepts file operations on `~/.deeplake/memory/` via a virtual filesystem backed by SQL. Every agent session's prompts, tool calls, and results are captured as structured traces. Patterns are codified into reusable skills and propagated in real-time to all connected agents via the shared mount point. A background worker at session-end generates AI-produced wiki summaries.
+
+> "One engineer's agent figures out a tricky migration on Monday. Tuesday, every agent on the team can execute the pattern." / "Intercepts file operations on ~/.deeplake/memory/ through a virtual filesystem backed by SQL" / "Summarizes sessions into AI-generated wiki pages via a background worker at session end"
+
+**Maps to SoS**: Shooter's `session-watcher.ts` already reads JSONL — this is the trace capture. Add: (1) a `sos_memory` SQLite table `(session_id, summary_text, relevance_score, created_at)`, (2) a background summarizer that runs at `Stop` hook time, (3) a context injector that reads the top-3 relevant summaries and prepends them to a new session's initial prompt. No Deeplake needed; SQLite FTS5 replaces the vector store for keyword retrieval.
+
+**Architecture tier**: Knowledge plane / ambient memory
+
+---
+
+### T7 — Ambient Memory Gardener Daemon
+
+**Source videos**: jcode (`wassimyounes__3886731891801439107`), Mercury (`githubprojects_3883123658403563467`)  
+**Lens**: shared-context, orchestration, concurrent-sessions
+
+**Mechanism**: jcode ships an "Ambient agent" — a background process with no user interaction that continuously reads all session outputs, prunes stale memory entries, consolidates related items, and updates a shared store. It runs during idle windows of the primary agents, never blocking their forward progress.
+
+> "Ambient agent that gardens your memory while you sleep."
+
+**Maps to SoS**: A `SosMemoryGardener` background coroutine in `server.ts` runs every 30 seconds when all sessions are Idle simultaneously. It reads from `sos_memory`, calls a lightweight LLM (Neurolink / Claude Haiku) to consolidate, and writes a single `context_summary` row. On session start, this summary is the injection payload.
+
+**Architecture tier**: Background maintenance
+
+---
+
+### T8 — Two-Tier Policy Gate + Audit Log
+
+**Source videos**: CrabTrap (`githubsignals_3881292748473284075`)  
+**Lens**: protocols-HITL
+
+**Mechanism**: HTTP proxy sits between agent and the outside world. Tier 1: static URL/pattern rules (deterministic, O(1)). Tier 2 on no-match: LLM policy judge. Outcome: ALLOW, DENY (403), or (extended) ESCALATE-TO-HUMAN. Every decision logged to a PostgreSQL audit table.
+
+> "AI Agent (HTTP_PROXY set) → TLS Decrypt → Static Rules → LLM Judge → DENY-403 / ALLOW → External API. AUDIT LOG — every request and decision logged."
+
+**Maps to SoS**: The SoS coordinator's inter-session message router implements the same two tiers: (1) allowlist check (trusted session pairs + allowed message types), (2) LLM classify for ambiguous relay decisions. ESCALATE → APNs push. A `relay_decisions` SQLite table audits every routing choice. Set `HTTP_PROXY` in `pty-holder.cjs` environment to route outbound agent calls through a local CrabTrap instance.
+
+**Architecture tier**: Policy / guardrails
+
+---
+
+### T9 — HITL Permission Relay (Centralized Approval Queue)
+
+**Source videos**: Claude Control, Paseo (`github.awesome_3874757184274547172`), Claudraband  
+**Lens**: protocols-HITL, concurrent-sessions, message-relay
+
+**Mechanism**: All PermissionRequest hook events from all running sessions are routed to a single centralized approval interface (dashboard or mobile app) rather than each session handling its own. Claudraband's HTTP daemon answers pending prompts via `POST /sessions/<id>/answer`. Paseo routes terminal-command approvals to the phone with real-time streaming.
+
+> "Approve or reject tool-use permission prompts directly from the dashboard without switching to the terminal." / "Approve terminal commands [from phone]." / "answer pending prompts, expose them through a daemon, or drive them through ACP"
+
+**Maps to SoS**: Shooter already implements this for its own Claude sessions (`notifier.cjs` → APNs → `/api/response`). Generalize: any session registered with the SoS coordinator has its `PermissionRequest` routed through Shooter's mobile notification flow, not independently. Batch multiple simultaneous requests within a 2-second window and send a single grouped notification.
+
+**Architecture tier**: HITL / approval loop
+
+---
+
+### T10 — Round-Robin CLI Proxy (Capacity-Aware Routing)
+
+**Source videos**: Rob Hallam (`robhallam__3851764032377748268`), CodexBar (`githubsignals_3901965695855070705`)  
+**Lens**: concurrent-sessions, message-relay
+
+**Mechanism**: `github.com/liltspater/CLIProxyAPI` replaces Claude Code's `base_url` via an environment variable, routing API calls to a local proxy that round-robins across multiple accounts/tokens. CodexBar polls provider rate-limit endpoints to expose per-provider capacity, enabling capacity-aware routing.
+
+> "you can essentially like go beneath Claude code and you just like change the URL that it's making API calls to and everything gets uh routed through this proxy, so it automatically does like a Round Robin"
+
+**Maps to SoS**: Set `ANTHROPIC_BASE_URL` in each child session's `pty-holder.cjs` environment to point at a local CLIProxyAPI instance. The coordinator uses CodexBar-style capacity metrics to route new tasks to the session with the most available quota.
+
+**Architecture tier**: Resource management / rate-limit avoidance
+
+---
+
+### T11 — Git Worktree Isolation per Agent
+
+**Source videos**: 1Code (`github.awesome_3813895435787141916`), Gas Town, Capy (`olaconleyy_3855946079321848360`)  
+**Lens**: concurrent-sessions, orchestration
+
+**Mechanism**: Each parallel agent session works in its own isolated Git worktree (separate branch + working directory). This eliminates merge conflicts between concurrent writers. The coordinator merges outputs via PR/diff review after each session completes. 1Code calls this "Branch Safety — Never accidentally commit to main branch."
+
+> "1Code fixes this by wrapping the agent in a visual dashboard that lets you run multiple tasks at once. You can have one agent fixing a bug and another writing docs simultaneously, each running in its own isolated Git."
+
+**Maps to SoS**: WorkForge (Sachin's own worktree management tool) already provides the primitive. When the coordinator dispatches a task to a worker session, it calls WorkForge to create a worktree, sets it as the session's working directory in `pty-holder.cjs`, and later surfaces a diff-review notification when the session reaches `Finished` state.
+
+**Architecture tier**: Isolation / conflict prevention
+
+---
+
+## 3. Reference Patterns and Trade-offs
+
+### Pattern A — Blackboard (Shared Persistent Store)
+
+**What it is**: All sessions read from and write to a single shared store (SQLite `sos_relay_log` + `sos_memory` + `sos_sessions`). The coordinator mediates reads/writes. No direct session-to-session IPC.
+
+**Fits**: Gas Town (Beads ledger), Hivemind (virtual-fs + SQL), agentsview (SQLite + SSE), Mercury (SQLite Second Brain), harness-mem (Plans.md).
+
+**Trade-offs**:
+
+- Pro: survives process restarts; no coupling between sessions; append-only = trivially auditable; matches Shooter's existing `terminal-store.ts` design
+- Pro: SQLite handles concurrent reads with WAL mode at zero operational cost
+- Con: eventual consistency — a session reading the blackboard sees a state that is slightly stale; not suitable for sub-100ms synchronous coordination
+- Con: requires the coordinator to poll or watch the store; adds a polling loop
+
+**Best fit for SoS**: Yes. This is the primary persistence and relay mechanism for Shooter.
+
+---
+
+### Pattern B — Message Bus / SSE Fan-Out
+
+**What it is**: The coordinator exposes an SSE endpoint (`GET /api/sos/events`). All sessions subscribe. The coordinator writes events; subscribers filter by `session_id`. Agentsview implements this pattern exactly.
+
+**Fits**: agentsview (SQLite + SSE), Capy (Slack as message bus), Claude Control (native notifications as push events).
+
+**Trade-offs**:
+
+- Pro: real-time delivery without polling; fits Shooter's existing WebSocket architecture (add a `channel: 'sos'` type to the WS multiplexer)
+- Pro: clients can subscribe/unsubscribe without coordinator changes
+- Con: stateless — a session that reconnects misses events not replayed from the SQLite store
+- Con: relies on an open connection; sessions that restart lose their subscription
+
+**Best fit for SoS**: Yes, for the delivery layer on top of the blackboard. SSE/WebSocket delivers; SQLite stores.
+
+---
+
+### Pattern C — Supervisor-Orchestrator (Plan + Dispatch Loop)
+
+**What it is**: The coordinator generates a structured plan (like Harness's `Plans.md`) before dispatching. Each step is assigned to a worker session by capability. The coordinator blocks on the current step until it completes, then dispatches the next. Ruflo and Octogent implement this.
+
+**Fits**: Claude Harness (Plan→Work→Review→Commit lifecycle), Octogent (Octoboss step-by-step instructions), Ruflo (graph-structured specialization), Verdant AI (write/debug/test parallelization).
+
+**Trade-offs**:
+
+- Pro: deterministic execution order; coordinator knows when to relay (step N output → step N+1 input)
+- Pro: each step is a discrete artifact reviewable by the human
+- Con: sequential steps cannot be parallelized; coordination overhead for each step
+- Con: requires the coordinator to be an LLM agent itself, adding latency and cost per dispatch cycle
+
+**Best fit for SoS**: For planned, multi-step tasks (e.g., "design + implement + test an API endpoint"). Not suitable for reactive/event-driven relay.
+
+---
+
+### Pattern D — Direct Agent-to-Agent (ACP / tmux injection)
+
+**What it is**: Session A sends a message directly to Session B via ACP or PTY stdin injection, without routing through the coordinator. VibeAround's `/handover`+`/pickup` and Claudraband's `cband continue` both fit here.
+
+**Fits**: VibeAround (ACP Rust SDK, `/switch`), Claudraband (cband continue, ACP server), jcode (swarm bridge node).
+
+**Trade-offs**:
+
+- Pro: lowest latency; no coordinator overhead per message
+- Pro: VibeAround + Claudraband are off-the-shelf solutions usable today
+- Con: no central audit trail unless the coordinator is copied on each relay
+- Con: tight coupling between sessions — Session A must know Session B's address
+- Con: ACP is an emerging standard with evolving spec; may require updates as protocol matures
+
+**Best fit for SoS**: For real-time interactive relays (user typing `/switch codex` from the phone) and for the HITL relay path (coordinator receives approval → `cband continue` → session unblocks).
+
+---
+
+### Pattern E — Round-Robin / Capacity-Aware Router
+
+**What it is**: The coordinator dispatches tasks not by capability but by available capacity, selecting the session with the most remaining token/rate quota. CLIProxyAPI and CodexBar implement the primitives.
+
+**Fits**: Rob Hallam (CLI proxy round-robin), CodexBar (capacity monitoring for 40+ providers).
+
+**Trade-offs**:
+
+- Pro: maximizes throughput; prevents stalls from rate limits
+- Pro: zero changes to agent code (env-var base_url override)
+- Con: ignores specialization — a frontend task may be routed to a backend-capable session purely because it has more quota
+- Con: CLIProxyAPI is a community tool with no SLA; needs validation
+
+**Best fit for SoS**: As a secondary routing layer after capability-based dispatch. Route within a capability-matched set using round-robin.
+
+---
+
+## 4. Implementation Mapping to Shooter (Existing Infrastructure)
+
+| SoS concern       | Existing Shooter primitive                               | Gap to close                                                            |
+| ----------------- | -------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Session discovery | `session-watcher.ts` (chokidar on JSONL)                 | Add process-table scan (T4); add Codex/OpenCode session paths           |
+| State machine     | `terminal-store.ts` (`status: active/exited`)            | Add 5-state model: `Working/Idle/Waiting/Compacting/Finished`           |
+| Message bus       | `WebSocket server` (channels: terminal/session/events)   | Add `sos` channel; add `sos_relay_log` SQLite table                     |
+| Write-side relay  | `pty-manager.ts` → `holder-client.ts` → Unix socket      | Add `POST /api/sessions/:id/inject`; optionally integrate Claudraband   |
+| Context survival  | `pty-holder.cjs` (5000-line scrollback, `.exit` sidecar) | Add `PreCompact` hook → SQLite snapshot → re-injection on session start |
+| Knowledge plane   | `session-watcher.ts` reads JSONL                         | Add `sos_memory` table; background summarizer at `Stop` hook            |
+| HITL approval     | `notifier.cjs` → APNs → `/api/response`                  | Generalize to multi-session queue; batch concurrent requests            |
+| Isolation         | PTY per session (separate processes)                     | Add git worktree assignment via WorkForge per dispatched task           |
+| Policy            | None                                                     | Add two-tier static-rules + LLM judge; `relay_decisions` audit table    |
+
+**New SQLite tables** (all in `~/.shooter/shooter.db`):
+
+1. `sos_sessions(session_id, capability, coordinator_id, status, last_context_summary, registered_at)`
+2. `sos_relay_log(id, from_session, to_session, message_type, payload, ts, consumed_at)` — the Beads ledger
+3. `sos_memory(id, session_id, summary_text, relevance_score, created_at)` — ambient knowledge plane
+4. `relay_decisions(id, from_session, to_session, message_type, tier1_result, tier2_result, final_decision, reason, human_response, ts)` — audit log
+
+**New WebSocket event types** (extends `ws-protocol.yaml`):
+
+1. `relay_handover` — session A → coordinator: serialize context snapshot
+2. `relay_pickup` — coordinator → session B: inject context
+3. `relay_switch` — reroute channel to different holder
+4. `relay_status` — session broadcasts Working/Idle/Waiting/Compacting/Finished
+5. `sos_permission_request` — centralized permission queue event
+
+**New server modules** (under `src/lib/modules/server/sos/`):
+
+1. `coordinator.ts` — The Mayor: reads relay_log, routes messages, tracks session status
+2. `memory-gardener.ts` — ambient background process: reads JSONL, writes sos_memory
+3. `context-injector.ts` — reads sos_memory on session start, prepends to first prompt
+4. `policy-gate.ts` — two-tier relay decision engine + audit logging
+
+---
+
+## 5. Completeness Check — Thin Themes and Verification Needs
+
+### Thin in corpus
+
+| Theme                                         | Thinness                                                                                                                                                                  | What to verify                                                                                                                     |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **ACP protocol spec**                         | ACP appears in Claudraband and VibeAround but the actual spec document is not in the corpus. Both reference it as "emerging standard."                                    | Check `github.com/halfwhey/claudraband` and `github.com/jazzenchen/vibearound` for ACP spec links; verify current message schema   |
+| **OpenCode session format**                   | `opencode-watcher.ts` exists in Shooter but the corpus has very few entries on OpenCode's internal session format. Codex JSONL format is also unverified.                 | Consult `codex-format.md` and `gemini-format.md` already in `/tmp/provider-research/`; verify against agentsview's 13-agent schema |
+| **Two-way coordinator ↔ session messaging**   | All corpus entries show the coordinator WRITING to sessions; none clearly show a session proactively WRITING to the coordinator without a hook event trigger.             | Verify whether JSONL contains arbitrary agent-initiated "signal" events, or whether the only cross-session signals are hook events |
+| **Conflict resolution for concurrent writes** | The Rob Hallam case shows merge conflicts are a real problem at 10 agents without worktrees. The corpus has no detailed treatment of merge resolution strategies.         | Verify 1Code's built-in git client handles merge resolution; check if WorkForge has merge-conflict tooling                         |
+| **Non-Claude agent hooks**                    | All hook-event-based discovery and relay mechanisms assume Claude Code's hook system. Codex and OpenCode have different or no hook systems.                               | Verify Codex CLI's lifecycle events; check if agtop or agentsview expose an event API for non-Claude agents                        |
+| **MCP as inter-agent protocol**               | CrabTrap (Cua Driver, Semble) suggest exposing the SoS meta-session as an MCP server. This is mentioned in the protocols-HITL lens but no implementation detail is given. | Check if Claude Code can call an MCP tool that belongs to a sibling session; verify MCP tool-call event shape in JSONL             |
+| **Distributed / multi-machine SoS**           | Paseo mentions multiple hosts but the corpus does not detail how session state is synchronized across machines.                                                           | Paseo's GitHub repo (`getpaseo/paseo`) may have the multi-host sync protocol; verify                                               |
+
+### Verification priorities (ordered by implementation impact)
+
+1. ACP spec — needed before building the write-side relay (T2)
+2. Codex + OpenCode session formats — needed before extending `session-watcher.ts` (T4)
+3. Non-Claude hook equivalents — determines whether auto-discovery works for Codex/OpenCode or requires polling only
+4. MCP as meta-session interface — determines whether coordinator tools can be natively callable from child sessions
+
+---
+
+## 6. Quick-Reference Source Map
+
+| Video (entry ID)                     | Tool           | Technique(s)                                        |
+| ------------------------------------ | -------------- | --------------------------------------------------- |
+| `githubprojects_3899619286326340159` | Gas Town       | T1 (Beads ledger, mailboxes), T11 (worktrees)       |
+| `githubsignals_3874535135337291122`  | Claudraband    | T2 (ACP injection, HTTP daemon), T9 (HITL relay)    |
+| `githubsignals_3890103852199156424`  | VibeAround     | T2 (/handover /pickup /switch), T9                  |
+| `robhallam__3851764032377748268`     | Rob Hallam     | T3 (Claude-as-coordinator), T10 (round-robin proxy) |
+| `parasmadan.in_3877305782659851702`  | Octogent       | T3 (Octoboss + worker topology)                     |
+| `githubsignals_3877154328675116231`  | Claude Control | T4 (process-table discovery, 5-state machine), T9   |
+| `githubsignals_3876376987761906329`  | agtop          | T4 (context pressure metric)                        |
+| `githubsignals_3888917703615132104`  | Claude Harness | T5 (PreCompact hook, harness-mem)                   |
+| `githubsignals_3896549067676034823`  | Hivemind       | T6 (trace capture, skill propagation)               |
+| `wassimyounes__3886731891801439107`  | jcode          | T7 (ambient memory gardener)                        |
+| `githubprojects_3883123658403563467` | Mercury        | T7 (SQLite Second Brain)                            |
+| `githubsignals_3881292748473284075`  | CrabTrap       | T8 (policy gate, audit log)                         |
+| `github.awesome_3874757184274547172` | Paseo          | T9 (mobile HITL), T10                               |
+| `github.awesome_3813895435787141916` | 1Code          | T11 (git worktree isolation)                        |
+| `githubsignals_3873681943942715245`  | agentsview     | Pattern B (SQLite + SSE multi-agent index)          |
+| `githubsignals_3901965695855070705`  | CodexBar       | T10 (capacity-aware routing)                        |
+| `aiadventureryt_3869407061121786825` | Ruflo          | T3 (graph-structured specialization)                |
+| `aiadventureryt_3854116214570574574` | Verdant AI     | T3 (write/debug/test parallelization)               |
+| `olaconleyy_3855946079321848360`     | Capy           | T11, Pattern B (Slack as notification bus)          |

--- a/docs/SESSION-OVER-SESSIONS.md
+++ b/docs/SESSION-OVER-SESSIONS.md
@@ -1,0 +1,509 @@
+# Session Over Sessions (SoS) — Concrete Build Design for Shooter
+
+**Date:** 2026-05-29  
+**Target repo:** `juspay/shooter`  
+**Status:** Design only — no code written yet
+
+---
+
+## 1. What We Are Building
+
+A **SessionOverSessions coordinator** is a server-side meta-layer that:
+
+1. Subscribes to N concurrently-running agent sessions (any of the 9 providers in `registry.ts`) by reusing existing watchers.
+2. Merges their event streams into one unified, source-tagged transcript.
+3. Relays tagged messages between member sessions by injecting text into target PTY stdin via `pty-manager`'s `pty.write`, or by writing to a shared SQLite relay log that target sessions poll.
+4. Surfaces the merged super-session over a new WebSocket channel (`/ws/super-session/:id`) modelled on `session-handler.ts`.
+5. Lets the human approve or veto relays from the phone via APNs, extending the existing `notifier.cjs` HITL flow.
+
+This is not a monolithic orchestrator that replaces parallel sessions. It is a coordination membrane — The Mayor (Gas Town T1) — sitting between autonomous agents.
+
+---
+
+## 2. Data Model
+
+### 2.1 Tagged ConversationMessage
+
+`ConversationMessage` (in `src/lib/types/sessions.ts`) gains one optional field:
+
+```ts
+export interface ConversationMessage {
+  id: string;
+  parts: MessagePart[];
+  role: MessageRole;
+  timestamp: string;
+  // SoS extension — only present on messages inside a SuperSession transcript
+  sos?: {
+    memberId: string; // opaque member ID from sos_sessions
+    provider: SessionSource; // 'claude-code' | 'opencode' | 'codex' | …
+    sessionKey: string; // JSONL path or OpenCode session UUID
+    relayed?: boolean; // true if this message was injected by the coordinator
+  };
+}
+```
+
+The field is optional so that every existing consumer of `ConversationMessage` continues to work unchanged.
+
+### 2.2 SuperSession
+
+New hand-written type in `src/lib/types/sos.ts` (re-exported from `src/lib/types/index.ts`):
+
+```ts
+export type SosMemberStatus = 'Working' | 'Idle' | 'Waiting' | 'Compacting' | 'Finished';
+
+export interface SosMember {
+  id: string; // random hex (PK in sos_sessions)
+  sessionKey: string; // JSONL path for JSONL-based; OpenCode session UUID for SQLite-based
+  terminalId: string | null; // PtyManager terminal ID if launched via Shooter; null for external sessions
+  provider: SessionSource;
+  capability: string; // free-text tag: 'frontend' | 'backend' | 'docs' | '' etc.
+  status: SosMemberStatus;
+  lastContextSummary: string | null;
+  registeredAt: string; // ISO timestamp
+}
+
+export interface SosRoutingRule {
+  id: string;
+  superSessionId: string;
+  fromMemberId: string | 'ANY';
+  toMemberId: string | 'ANY';
+  matchPattern: string; // substring or regex string; empty = match all
+  action: 'relay' | 'block' | 'escalate';
+  priority: number; // lower = checked first
+}
+
+export interface SuperSession {
+  id: string; // random hex (URL-safe)
+  label: string; // human-readable name, e.g. "breeze-refactor"
+  members: SosMember[];
+  routingRules: SosRoutingRule[];
+  mergedTranscript: ConversationMessage[]; // source-tagged; in-memory ring buffer, max 500 entries
+  createdAt: string;
+  status: 'active' | 'paused' | 'archived';
+}
+```
+
+### 2.3 SQLite Tables (added to `~/.shooter/shooter.db`)
+
+```sql
+-- Registered sessions in a super-session
+CREATE TABLE IF NOT EXISTS sos_sessions (
+  id TEXT PRIMARY KEY,                 -- SosMember.id
+  super_session_id TEXT NOT NULL,
+  session_key TEXT NOT NULL,           -- JSONL path OR opencode UUID
+  terminal_id TEXT,                    -- ptyManager terminal ID or NULL
+  provider TEXT NOT NULL,
+  capability TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'Idle', -- Working|Idle|Waiting|Compacting|Finished
+  last_context_summary TEXT,
+  registered_at TEXT NOT NULL
+);
+
+-- The Beads ledger (T1 — Gas Town)
+-- Append-only. The coordinator writes beads; members poll for unconsumed ones.
+CREATE TABLE IF NOT EXISTS sos_relay_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  super_session_id TEXT NOT NULL,
+  from_member_id TEXT NOT NULL,        -- 'COORDINATOR' is valid
+  to_member_id TEXT NOT NULL,          -- 'ALL' broadcasts to every member
+  message_type TEXT NOT NULL,          -- 'relay' | 'precompact_snapshot' | 'context_prefix' | 'human_forward'
+  payload TEXT NOT NULL,               -- JSON-encoded
+  ts TEXT NOT NULL,                    -- ISO timestamp
+  consumed_at TEXT,                    -- NULL = unprocessed
+  relay_id TEXT                        -- echo-guard: original relay bead ID being re-emitted (NULL if origin)
+);
+
+-- Audit log for every routing decision (T8 — CrabTrap)
+CREATE TABLE IF NOT EXISTS relay_decisions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  super_session_id TEXT NOT NULL,
+  from_member_id TEXT NOT NULL,
+  to_member_id TEXT NOT NULL,
+  message_type TEXT NOT NULL,
+  tier1_result TEXT,                   -- 'allow'|'block'|'escalate'|NULL (no matching static rule)
+  tier2_result TEXT,                   -- LLM judge outcome or NULL (not consulted)
+  final_decision TEXT NOT NULL,        -- 'allow'|'block'|'escalate'|'human_approved'|'human_denied'
+  reason TEXT,
+  human_response TEXT,
+  ts TEXT NOT NULL
+);
+
+-- Ambient knowledge plane (T6 — Hivemind, T7 — jcode)
+CREATE TABLE IF NOT EXISTS sos_memory (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  super_session_id TEXT NOT NULL,
+  member_id TEXT,                      -- NULL = cross-session summary
+  summary_text TEXT NOT NULL,
+  relevance_score REAL DEFAULT 0.0,
+  created_at TEXT NOT NULL
+);
+
+-- Super-session metadata table
+CREATE TABLE IF NOT EXISTS super_sessions (
+  id TEXT PRIMARY KEY,
+  label TEXT NOT NULL,
+  routing_rules TEXT NOT NULL DEFAULT '[]', -- JSON array of SosRoutingRule
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at TEXT NOT NULL
+);
+```
+
+WAL mode must be enabled (`PRAGMA journal_mode=WAL`) so the coordinator and session-handler can read concurrently without blocking.
+
+---
+
+## 3. New Server Modules
+
+All under `src/lib/modules/server/sos/`:
+
+```text
+src/lib/modules/server/sos/
+  coordinator.ts       — SuperSession lifecycle, member subscription, relay dispatch
+  relay-store.ts       — SQLite CRUD for the four new tables (thin data-access layer)
+  policy-gate.ts       — Two-tier routing decision engine + audit logging (T8)
+  memory-gardener.ts   — Background summarizer; runs at Stop hook and on 30s idle cycles (T6, T7)
+  context-injector.ts  — Reads sos_memory, prepends context prefix to new-session stdin (T5)
+  super-session-handler.ts — WebSocket handler for /ws/super-session/:id (mirrors session-handler.ts)
+  sos-store.ts         — In-memory Map<string, SuperSession> with read/write access (singleton)
+```
+
+New API routes under `src/routes/api/sos/`:
+
+```text
+POST   /api/sos                        — create a new SuperSession
+GET    /api/sos                        — list super-sessions
+GET    /api/sos/[id]                   — fetch a SuperSession by ID
+POST   /api/sos/[id]/members           — add a member session
+DELETE /api/sos/[id]/members/[mid]     — remove a member
+POST   /api/sos/[id]/inject            — human/phone-initiated relay: forward a message to a member
+POST   /api/sos/[id]/relay             — coordinator-initiated relay (internal, auth-gated)
+GET    /api/sos/[id]/transcript        — full merged transcript (paginated)
+PATCH  /api/sos/[id]/rules             — update routing rules
+```
+
+---
+
+## 4. Integration Points (Exact Touch Points in Existing Code)
+
+### 4.1 `session-watcher.ts` + `opencode-watcher.ts` — subscribe, no changes needed
+
+`coordinator.ts` calls the existing `subscribe(sessionKey, callback)` / `watch(sessionId, callback)` APIs directly. No modifications to the watchers. The coordinator is just another subscriber, identical to the session-handler.
+
+For JSONL-backed providers (claude-code, codex, gemini, qwen, cursor, copilot, amp, iflow), it uses `sessionWatcher.subscribe(jsonlPath, onNewMessages)`.
+
+For OpenCode, it uses `openCodeWatcher.watch(opencodeSessionId, onNewMessages)`.
+
+The callback receives `ConversationMessage[]` and the coordinator immediately tags each message with `sos: { memberId, provider, sessionKey }` before appending to `mergedTranscript`.
+
+### 4.2 `registry.ts` — no changes needed
+
+`PROVIDERS` is already the single source of truth for provider resolution. The coordinator resolves a member's provider by iterating `PROVIDERS` to match on `source`. `getProviderConversation` is used to replay history for a newly joined member.
+
+### 4.3 `pty-manager.ts` — PTY injection (the write-side relay, T2 — Claudraband)
+
+`coordinator.ts` imports `ptyManager` and calls:
+
+```ts
+const terminal = ptyManager.get(member.terminalId);
+if (!terminal || terminal.status === 'exited') {
+  throw new Error('Target terminal not available for relay');
+}
+terminal.pty.write(`${injectText}\n`);
+```
+
+This is the Claudraband `cband continue <session-id> '<prompt>'` equivalent — HTTP daemon → `tmux send-keys` maps exactly to `POST /api/sos/[id]/inject` → `terminal.pty.write(text + '\n')`.
+
+**When PTY injection is used:** Any relay where the target session is a Shooter-managed terminal (i.e., `member.terminalId` is non-null and the terminal is running). This gives the lowest latency path for interactive relays.
+
+**When the relay log is used instead:** When the target session has no Shooter-managed terminal (external session not launched via Shooter), or when the target terminal is `Idle` and the relay is not time-critical. The coordinator writes a bead to `sos_relay_log`. A polling hook inside `context-injector.ts` detects unconsumed beads for a session and injects them as a context prefix on the next time the session's JSONL shows a new user-turn (approximated by watching for `role: 'user'` entries). This is the Gas Town Beads ledger pattern (T1).
+
+### 4.4 `session-handler.ts` — model for `super-session-handler.ts`
+
+`super-session-handler.ts` follows the exact same shape:
+
+- `handleSuperSessionConnection(ws, id)` — accepts `/ws/super-session/:id`
+- Sends `{ type: 'history', messages: mergedTranscript }` on connect (converted via `conversationToHistory`, extended to include the `sos` tag in each message)
+- Streams new tagged messages live as they arrive via the coordinator's `onMessage` event emitter
+- Accepts client messages: `relay-forward` (human approves forwarding a transcript message to a member), `relay-block` (human blocks a pending relay), `member-add`, `member-remove`
+
+### 4.5 `server.ts` — WebSocket upgrade routing
+
+Add one case to the existing URL-pattern switch that routes WS upgrades:
+
+```ts
+if (pathname.startsWith('/ws/super-session/')) {
+  const id = pathname.slice('/ws/super-session/'.length);
+  handleSuperSessionConnection(ws, id);
+  return;
+}
+```
+
+### 4.6 `.claude/settings.json` + `notifier.cjs` — HITL relay (T9 — Claude Control / Paseo)
+
+The `PreCompact` hook is extended: when `notifier.cjs` fires for `PreCompact`, it POSTs the snapshot to `POST /api/sos/precompact` which writes a `precompact_snapshot` bead to `sos_relay_log`. The coordinator picks this up and fans it out to all members as a context checkpoint.
+
+The existing `PermissionRequest` HITL flow is already centralized in `notifier.cjs`. The SoS coordinator registers all member sessions' PermissionRequests through the same APNs queue — no new hook code required, just the coordinator listening for `sos_permission_request` WS events from the member session's terminal.
+
+---
+
+## 5. The Three Mined Techniques (Concrete Application)
+
+### T1 — Beads Ledger / Named Mailboxes (Gas Town, `githubprojects_3899619286326340159`)
+
+**What it gives SoS:** The `sos_relay_log` SQLite table is the Beads ledger. Each row is a bead: `(from_member_id, to_member_id, message_type, payload, consumed_at)`. The coordinator is The Mayor; member sessions are Polecats. The ledger decouples the coordinator from session lifecycle — a session that restarts will find unconsumed beads waiting for it. This survives server restarts (SQLite, WAL mode), requires no IPC between sessions, and is trivially auditable.
+
+**Concretely:** When the coordinator decides to relay message M from member A to member B, it writes one bead to `sos_relay_log`. The context-injector polls every 5 seconds for beads where `to_member_id = B` and `consumed_at IS NULL`. On finding one, it calls `terminal.pty.write(payload + '\n')` (if terminal available) or prepends the payload to B's next-prompt prefix (if external session). It then marks `consumed_at = NOW()`. The `relay_id` column on the bead records the original bead ID so a re-emitted relay cannot create a second bead loop (echo guard — see Section 6).
+
+### T2 — ACP Injection / PTY stdin write (Claudraband, `githubsignals_3874535135337291122`)
+
+**What it gives SoS:** The write-side relay mechanism. Claudraband's `cband continue <session-id> '<prompt>'` → HTTP POST → daemon → `tmux send-keys` maps directly to Shooter's `POST /api/sos/[id]/inject` → `coordinator.relay(fromId, toId, text)` → `ptyManager.get(terminalId).pty.write(text + '\n')`. This is synchronous and low-latency for Shooter-managed terminals.
+
+**Concretely:** The `POST /api/sos/[id]/inject` API route is the HTTP daemon equivalent. It validates: (1) the super-session exists, (2) the target member ID is valid and belongs to this super-session, (3) the caller is authenticated (Bearer `API_KEY`), (4) the target terminal is owned by Shooter (not an externally-launched session). Then it calls `terminal.pty.write`. The `/handover` + `/pickup` VibeAround pattern maps to two WS events: `relay_handover` (serialize member A's last-N transcript to a bead) and `relay_pickup` (inject that bead as context into member B's PTY on next interaction).
+
+### T5 — PreCompact Hook Interception (Claude Harness, `githubsignals_3888917703615132104`)
+
+**What it gives SoS:** Context-boundary survival across compaction and server restarts. When Claude Code fires `PreCompact` for a member session, `notifier.cjs` intercepts it, serializes the last 20 `ConversationMessage` entries from that member's merged transcript slice into a `precompact_snapshot` bead in `sos_relay_log`, then returns `{"action":"continue"}` to allow compaction. On the member's next session start (detected by a new JSONL file appearing in the project dir), `context-injector.ts` reads the most recent unconsumed `precompact_snapshot` bead for that session key and injects it as a context prefix via `pty.write` — effectively the `harness-mem` re-injection behavior.
+
+**Concretely:** The `.claude/settings.json` hook definition:
+
+```json
+{
+  "PreCompact": [
+    {
+      "matcher": "",
+      "hooks": [{ "type": "command", "command": ".claude/hooks/notifier.cjs", "timeout": 30000 }]
+    }
+  ]
+}
+```
+
+`notifier.cjs` already dispatches on `CLAUDE_HOOK_EVENT`. Add a `PreCompact` case: POST to `/api/sos/precompact` with the session ID. The server route writes the snapshot bead and returns 200. `notifier.cjs` exits 0 so Claude Code continues. This is zero-latency from Claude's perspective and survives both compaction and server restart because the bead is persisted in SQLite.
+
+---
+
+## 6. Message Routing Algorithm
+
+### 6.1 Routing Decision Flow (Two-Tier Policy Gate, T8 — CrabTrap)
+
+Every new `ConversationMessage` arriving from a member goes through the coordinator:
+
+```text
+NEW MESSAGE from member A
+        │
+        ▼
+[Tier 1: Static Rules]
+  Scan SosRoutingRule[] ordered by priority.
+  Match: fromMemberId == A.id (or 'ANY'), matchPattern in message text.
+  → action = 'relay'     → proceed to relay dispatch
+  → action = 'block'     → log to relay_decisions, discard
+  → action = 'escalate'  → proceed to HITL queue
+  → no match             → proceed to Tier 2
+        │
+        ▼
+[Tier 2: LLM Judge] (only for ambiguous messages without a static rule)
+  Call Neurolink/Claude Haiku via POST /api/neurolink (internal, cached)
+  Prompt: "Given this message from {provider} session: {text}, should it be relayed
+           to {target}? Respond: allow | block | escalate. Reason: ..."
+  → 'allow'     → relay dispatch
+  → 'block'     → log, discard
+  → 'escalate'  → HITL queue
+  Log result to relay_decisions.
+        │
+        ▼
+[HITL Queue] (for 'escalate')
+  Send APNs notification: "Session A wants to relay to B: {preview}"
+  Block for up to PERMISSION_TIMEOUT (default 120s).
+  Human approves → relay dispatch, log 'human_approved'.
+  Human denies   → log 'human_denied', discard.
+        │
+        ▼
+[Relay Dispatch]
+  If target terminal running: ptyManager.get(terminalId).pty.write(text + '\n')
+  Else: write bead to sos_relay_log (context-injector picks it up)
+  Write bead's relay_id = null (origin relay).
+  Log to relay_decisions: final_decision = 'allow'.
+```
+
+MVP (Phase 1) skips Tier 2 LLM judge entirely. Only Tier 1 static rules + explicit human forward via WS `relay-forward` event.
+
+### 6.2 Loop / Echo Prevention
+
+Without guards, a relay from A→B could cause B to generate a response that the coordinator then relays back to A, creating an infinite loop.
+
+**Guard 1 — `relayed` flag:** Every message injected by the coordinator has `sos.relayed = true` in the tagged transcript. The routing algorithm skips Tier 1+2 for any message where `sos.relayed === true` (read-only append to merged transcript; no further relay). This is the primary loop-breaker.
+
+**Guard 2 — `relay_id` column:** Each bead written to `sos_relay_log` carries `relay_id = null` for origin relays. If a coordinator ever needs to re-emit a relay (e.g., target was offline, retry once), it sets `relay_id = original_bead_id`. The context-injector refuses to relay a bead whose `relay_id` is non-null a second time (checked by looking for a consumed bead with the same `relay_id`).
+
+**Guard 3 — Self-relay block:** The coordinator always blocks routing rules where `fromMemberId === toMemberId`. This is a hard invariant validated at rule-creation time in `POST /api/sos/[id]/rules`.
+
+**Guard 4 — Cooldown window:** After relaying any message from A to B, the coordinator suppresses further relays from A to B for a configurable window (default 5 seconds). This limits the blast radius of a misconfigured routing rule.
+
+---
+
+## 7. WebSocket Channel (`/ws/super-session/:id`)
+
+Follows `session-handler.ts` patterns exactly. New file: `super-session-handler.ts`.
+
+### Server → Client messages (extends existing WireSessionServerMessage union)
+
+```ts
+// Initial transcript replay
+{ type: 'sos-history'; messages: TaggedHistoryMessage[] }
+
+// Live merged message from any member
+{ type: 'sos-message'; memberId: string; provider: SessionSource; message: HistoryMessage; relayed: boolean }
+
+// Pending relay awaiting human approval
+{ type: 'sos-relay-pending'; relayId: string; fromMemberId: string; toMemberId: string; preview: string; expiresAt: string }
+
+// Relay was approved/denied (by human or policy)
+{ type: 'sos-relay-resolved'; relayId: string; decision: 'approved' | 'denied' | 'expired' }
+
+// Member status change
+{ type: 'sos-member-status'; memberId: string; status: SosMemberStatus }
+
+// Error
+{ type: 'sos-error'; message: string }
+```
+
+### Client → Server messages
+
+```ts
+// Human approves pending relay
+{ type: 'relay-approve'; relayId: string }
+
+// Human denies pending relay
+{ type: 'relay-deny'; relayId: string }
+
+// Human directly injects text into a member's terminal
+{ type: 'relay-forward'; toMemberId: string; text: string }
+
+// Add/remove member at runtime
+{ type: 'member-add'; sessionKey: string; provider: SessionSource; terminalId?: string; capability?: string }
+{ type: 'member-remove'; memberId: string }
+```
+
+Authentication: same ticket-store pattern as existing WS channels. Client calls `POST /api/ws-ticket` → receives short-lived ticket → connects to `/ws/super-session/:id?ticket=<token>`.
+
+---
+
+## 8. Security Model
+
+1. **Authentication:** All SoS API routes require `Authorization: Bearer <API_KEY>`. The WS channel uses the existing ticket store. No unauthenticated access.
+
+2. **Ownership validation:** Before any PTY inject (`pty.write`), the coordinator checks that `terminalId` is present in `ptyManager.list()`. This prevents injecting into a terminal that was not created by this Shooter instance.
+
+3. **Session ID validation:** All session keys (JSONL paths and OpenCode UUIDs) are validated with the same pattern as `findJsonlFileForSession`: JSONL paths must resolve within `~/.claude/projects/`, `~/.codex/sessions/`, or known provider directories. OpenCode UUIDs must match `/^[A-Za-z0-9_-]+$/`. No path traversal is possible because the coordinator never interpolates raw user input into filesystem paths — it looks up the `session_key` from the `sos_sessions` table (which was validated at insertion time).
+
+4. **Relay text cap:** Injected text is capped at 10 KB (same limit as `session-handler.ts` `send-input`). Longer payloads are rejected with a 413 error.
+
+5. **LLM judge for ambiguous relays:** The Tier 2 judge is called via the local Neurolink proxy — not directly via Anthropic API — so the relay text never leaves the local machine unintentionally.
+
+6. **Human approval for unknown routes:** Any relay where Tier 1 returns no matching rule is escalated to the human (HITL) rather than silently allowed. This is the safe default.
+
+---
+
+## 9. Phased Build Plan
+
+### Phase 1 — MVP: Observe + Merge + Manual Relay (2–3 days)
+
+**Goal:** A working super-session that passively aggregates N sessions into one unified transcript, with human-controlled forwarding from the phone.
+
+**Files to create:**
+
+- `src/lib/types/sos.ts` — `SosMember`, `SuperSession`, `SosRoutingRule`, `SosMemberStatus`; re-export from `src/lib/types/index.ts`
+- `src/lib/modules/server/sos/relay-store.ts` — SQLite CRUD for all four new tables; runs `CREATE TABLE IF NOT EXISTS` on module load using the existing `better-sqlite3` instance from `terminal-store.ts`
+- `src/lib/modules/server/sos/sos-store.ts` — singleton `Map<string, SuperSession>`; `get`, `create`, `addMember`, `removeMember`
+- `src/lib/modules/server/sos/coordinator.ts` — `SuperSessionCoordinator` class; `subscribe(member)` calls the right watcher; merges tagged messages into `mergedTranscript`; emits events; no auto-relay in Phase 1
+- `src/lib/modules/server/sos/super-session-handler.ts` — WS handler for `/ws/super-session/:id`; sends history + live stream; handles `relay-forward` by calling `terminal.pty.write` directly
+- `src/routes/api/sos/+server.ts` — `POST /api/sos` (create), `GET /api/sos` (list)
+- `src/routes/api/sos/[id]/+server.ts` — `GET`, `PATCH`, `DELETE`
+- `src/routes/api/sos/[id]/members/+server.ts` — `POST` (add member), `DELETE /[mid]`
+- `src/routes/api/sos/[id]/inject/+server.ts` — `POST` (human relay inject)
+- `server.ts` — add `/ws/super-session/` upgrade route
+
+**Integration tests:** Create a super-session with 2 Claude sessions, verify merged transcript on WS, verify `relay-forward` injects into target PTY.
+
+---
+
+### Phase 2 — Rule-Based Auto-Relay (3–4 days)
+
+**Goal:** Static routing rules automatically relay messages between members without human approval for trusted patterns.
+
+**Files to create:**
+
+- `src/lib/modules/server/sos/policy-gate.ts` — Tier 1 static rule evaluator; writes to `relay_decisions`; `escalate` action sends APNs notification via existing `sendNotification` path
+- `src/routes/api/sos/[id]/rules/+server.ts` — `GET`, `PATCH` routing rules
+- Extend `coordinator.ts` — on each new tagged message, run `policyGate.evaluate(message, rules)` and dispatch accordingly
+- Extend `super-session-handler.ts` — send `sos-relay-pending` / `sos-relay-resolved` messages; accept `relay-approve` / `relay-deny` from client
+- Loop / echo guards (Section 6) fully implemented
+
+---
+
+### Phase 3 — Ambient Memory + Context Survival (2–3 days)
+
+**Goal:** Sessions share knowledge across restarts via the PreCompact snapshot and memory summarizer.
+
+**Files to create:**
+
+- `src/lib/modules/server/sos/memory-gardener.ts` — background coroutine; `setInterval(30_000)`; reads JSONL via `sessionWatcher.getHistory`, writes summaries to `sos_memory`; calls Neurolink Haiku for consolidation
+- `src/lib/modules/server/sos/context-injector.ts` — reads top-3 `sos_memory` entries by `relevance_score`; writes context prefix bead to `sos_relay_log`; injects on session start detection
+- `notifier.cjs` — add `PreCompact` hook case: POST `/api/sos/precompact`
+- `src/routes/api/sos/precompact/+server.ts` — serialize last-20 messages into `precompact_snapshot` bead
+
+---
+
+### Phase 4 — Capacity-Aware Dispatch + Worktree Isolation (stretch)
+
+**Goal:** Coordinator dispatches new tasks to the member session with the most available capacity, and each dispatched task gets a WorkForge git worktree.
+
+**Files to create:**
+
+- `src/lib/modules/server/sos/capacity-monitor.ts` — polls `sos_sessions.status` and optional rate-limit headers to score each member's current capacity
+- `src/routes/api/sos/[id]/dispatch/+server.ts` — `POST`: accepts `{ task: string; capability?: string }`, selects best member, injects task via PTY, optionally creates worktree via WorkForge CLI
+- `ANTHROPIC_BASE_URL` injection in `pty-holder.cjs` environment when a local CLIProxyAPI instance is available (env-var controlled, disabled by default)
+
+---
+
+## 10. File Map Summary
+
+| New file                                              | Phase | Purpose                                   |
+| ----------------------------------------------------- | ----- | ----------------------------------------- |
+| `src/lib/types/sos.ts`                                | 1     | SoS type definitions                      |
+| `src/lib/modules/server/sos/relay-store.ts`           | 1     | SQLite CRUD for all SoS tables            |
+| `src/lib/modules/server/sos/sos-store.ts`             | 1     | In-memory SuperSession registry           |
+| `src/lib/modules/server/sos/coordinator.ts`           | 1     | Subscriber, merger, relay dispatch        |
+| `src/lib/modules/server/sos/super-session-handler.ts` | 1     | WS handler for /ws/super-session/:id      |
+| `src/routes/api/sos/+server.ts`                       | 1     | Create + list super-sessions              |
+| `src/routes/api/sos/[id]/+server.ts`                  | 1     | Get/update/delete super-session           |
+| `src/routes/api/sos/[id]/members/+server.ts`          | 1     | Add/remove members                        |
+| `src/routes/api/sos/[id]/inject/+server.ts`           | 1     | Human-initiated relay inject              |
+| `src/lib/modules/server/sos/policy-gate.ts`           | 2     | Tier 1 static rule evaluator + audit log  |
+| `src/routes/api/sos/[id]/rules/+server.ts`            | 2     | CRUD for routing rules                    |
+| `src/lib/modules/server/sos/memory-gardener.ts`       | 3     | Background knowledge summarizer           |
+| `src/lib/modules/server/sos/context-injector.ts`      | 3     | Context prefix injection on session start |
+| `src/routes/api/sos/precompact/+server.ts`            | 3     | PreCompact snapshot endpoint              |
+| `src/lib/modules/server/sos/capacity-monitor.ts`      | 4     | Member capacity scoring                   |
+| `src/routes/api/sos/[id]/dispatch/+server.ts`         | 4     | Task dispatch to best-capacity member     |
+
+**Modified files:**
+
+| File                         | Change                                            |
+| ---------------------------- | ------------------------------------------------- |
+| `src/lib/types/sessions.ts`  | Add optional `sos` field to `ConversationMessage` |
+| `src/lib/types/index.ts`     | Re-export from `sos.ts`                           |
+| `server.ts`                  | Add `/ws/super-session/` upgrade routing          |
+| `.claude/settings.json`      | Add `PreCompact` hook (Phase 3)                   |
+| `.claude/hooks/notifier.cjs` | Handle `PreCompact` event (Phase 3)               |
+
+---
+
+## 11. Thin Areas and Open Questions
+
+1. **Non-Claude session hooks (T4 observation):** Codex and OpenCode have no hook system equivalent to Claude Code's `PreCompact`. For those providers, the context-survival mechanism relies on polling `sos_relay_log` for precompact snapshots generated by the coordinator watching the JSONL/SQLite stream for `compaction` part types (OpenCode emits a `compaction` part type — `opencode-watcher.ts` currently skips it; that skip should be changed to emit a coordinator event).
+
+2. **LLM judge latency (Phase 2 Tier 2):** Calling Neurolink Haiku synchronously on each message would add 200–500ms to the relay path. Mitigation: run the judge asynchronously. Messages routed via Tier 2 are queued; delivery is delayed, not blocking. This is acceptable for non-time-critical relays.
+
+3. **External session relay (no terminal):** For sessions not launched via Shooter's PTY manager (e.g., a Cursor session Shooter is only observing), PTY inject is impossible. The relay log bead approach is the only path, and delivery depends on the human or the agent periodically checking a "pending context" endpoint. This limitation should be surfaced clearly in the UI.
+
+4. **MCP as meta-session interface:** The coordinator could expose a local MCP server so child Claude sessions can call `sos_relay(target, text)` as a native tool. This is a Phase 4+ idea; it requires verifying that Claude Code can call an MCP tool that targets a sibling session without creating a circular tool-call loop.

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "format:generated": "prettier --write ./src/lib/types/generated/*",
     "quality:all": "pnpm run lint && pnpm run format:check && pnpm run check",
     "gen:types": "npx type-crafter generate typescript-with-decoders ./specs/types/index.yaml ./src/lib/types/generated SingleFile SingleFile && bash scripts/postgen-types.sh && pnpm run format:generated",
-    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/plan-mode-routing.test.cjs && node tests/dynamic-options-extraction.test.cjs && node tests/codex-parser.test.cjs && node tests/provider-readers.test.cjs && node tests/generic-watcher.test.cjs",
+    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/plan-mode-routing.test.cjs && node tests/dynamic-options-extraction.test.cjs && node tests/codex-parser.test.cjs && node tests/provider-readers.test.cjs && node tests/generic-watcher.test.cjs && node tests/sos-coordinator.test.cjs && node tests/sos-policy.test.cjs && node tests/pty-input.test.cjs",
     "setup": "node scripts/setup.cjs",
     "prepare": "husky || true",
     "prepublishOnly": "pnpm build"

--- a/scripts/e2e-all-features.sh
+++ b/scripts/e2e-all-features.sh
@@ -85,11 +85,46 @@ else no "conversation read" "no claude session found"; fi
 [ "$(hcode "${A[@]}" "${J[@]}" -X POST -d '{"sessionId":"../etc","cwd":"/tmp"}' "${BASE}/api/sessions/connect")" = 400 ] && ok "/api/sessions/connect rejects path-traversal id (400)" || no "connect id guard" "no 400"
 [ "$(hcode "${A[@]}" "${J[@]}" -X POST -d '{"sessionId":"abc","cwd":"/etc"}' "${BASE}/api/sessions/connect")" = 400 ] && ok "/api/sessions/connect rejects cwd outside home (400)" || no "connect cwd guard" "no 400"
 
+echo ""; echo "── 5b. Session-Over-Sessions (SoS coordinator) ──"
+SS=$(curl -s "${A[@]}" "${J[@]}" -X POST -d '{"label":"e2e-sos"}' "${BASE}/api/sos")
+SSID=$(echo "$SS" | jget "d['id']")
+[ -n "$SSID" ] && ok "POST /api/sos creates super-session" || no "create super-session" "no id ($SS)"
+if [ -n "$SSID" ] && curl -s "${A[@]}" "${BASE}/api/sos" | grep -q "$SSID"; then
+  ok "GET /api/sos lists it"
+else
+  no "list super-sessions" "missing"
+fi
+CJ=$(find "$HOME/.claude/projects" -name "*.jsonl" -size +2k 2>/dev/null | head -1)
+MID=""
+if [ -n "$CJ" ]; then
+  MADD=$(hcode "${A[@]}" "${J[@]}" -X POST -d "{\"sessionKey\":\"${CJ}\",\"provider\":\"claude-code\"}" "${BASE}/api/sos/${SSID}/members")
+  [ "$MADD" = 201 ] && ok "POST /api/sos/[id]/members adds a member (201)" || no "add member" "got $MADD"
+  MID=$(curl -s "${A[@]}" "${BASE}/api/sos/${SSID}" | jget "d['members'][0]['id']")
+  [ -n "$MID" ] && ok "GET /api/sos/[id] returns the added member" || no "get super-session member" "no member"
+  if [ -n "$MID" ]; then
+    RG=$(hcode "${A[@]}" "${J[@]}" -X POST -d "{\"toMemberId\":\"${MID}\",\"text\":\"x\"}" "${BASE}/api/sos/${SSID}/inject")
+    [ "$RG" = 400 ] && ok "/api/sos/[id]/inject guards a member with no terminal (400)" || no "inject guard" "got $RG"
+  else
+    no "inject guard" "skipped: member id unavailable"
+  fi
+else
+  no "add member" "no claude session on disk to add"
+  no "inject guard" "skipped: no member to inject into"
+fi
+MV=$(hcode "${A[@]}" "${J[@]}" -X POST -d "{\"sessionKey\":\"${HOME}/x\",\"provider\":\"evil\"}" "${BASE}/api/sos/${SSID}/members")
+[ "$MV" = 400 ] && ok "/api/sos/[id]/members validates provider (400)" || no "member validation" "got $MV"
+[ "$(hcode "${A[@]}" "${J[@]}" -X DELETE "${BASE}/api/sos/${SSID}")" = 200 ] && ok "DELETE /api/sos/[id] (200)" || no "delete super-session" "not 200"
+[ "$(hcode "${A[@]}" "${BASE}/api/sos/${SSID}")" = 404 ] && ok "GET deleted super-session → 404" || no "super-session gone" "not 404"
+
 echo ""; echo "── 6. Terminals: create / list / get / resize / paste / delete ──"
 TA=$(curl -s "${A[@]}" "${J[@]}" -X POST -d "{\"command\":\"bash\",\"cwd\":\"${HOME}\"}" "${BASE}/api/terminals")
 TAID=$(echo "$TA" | python3 -c "import json,sys;print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
 [ -n "$TAID" ] && { TERMS="$TERMS $TAID"; ok "POST /api/terminals creates terminal ($TAID)"; } || no "create terminal" "no id"
-curl -s "${A[@]}" "${BASE}/api/terminals" | grep -q "$TAID" && ok "GET /api/terminals lists it" || no "list terminals" "missing"
+if [ -n "$TAID" ] && curl -s "${A[@]}" "${BASE}/api/terminals" | grep -q "$TAID"; then
+  ok "GET /api/terminals lists it"
+else
+  no "list terminals" "missing"
+fi
 [ "$(hcode "${A[@]}" "${BASE}/api/terminals/${TAID}")" = 200 ] && ok "GET /api/terminals/[id] 200" || no "get terminal" "not 200"
 [ "$(hcode "${A[@]}" "${J[@]}" -X POST -d '{"cols":120,"rows":40}' "${BASE}/api/terminals/${TAID}/resize")" = 200 ] && ok "POST /resize 200" || no "resize" "not 200"
 PNG='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
@@ -155,7 +190,11 @@ HPID=$(pgrep -f "pty-holder.cjs ${TBID}" | head -1)
 lsof -ti "tcp:${PORT}" | xargs kill -9 2>/dev/null || true; sleep 2
 start_server; ensure_up || no "restart" "server did not come back"
 sleep 2
-curl -s "${A[@]}" "${BASE}/api/terminals" | grep -q "$TBID" && ok "persistence: terminal survived restart (reconnected from holder)" || no "persistence reconnect" "$TBID gone after restart"
+if [ -n "$TBID" ] && curl -s "${A[@]}" "${BASE}/api/terminals" | grep -q "$TBID"; then
+  ok "persistence: terminal survived restart (reconnected from holder)"
+else
+  no "persistence reconnect" "$TBID gone after restart"
+fi
 # holder still alive?
 pgrep -f "pty-holder.cjs ${TBID}" >/dev/null && ok "persistence: same holder process still owns the PTY" || no "holder survived" "holder died"
 

--- a/server.ts
+++ b/server.ts
@@ -24,9 +24,11 @@ if (!existsSync(handlerPath)) {
 
 const { handler } = await import('./build/handler.js');
 import { isReadOnlyProviderPath } from './src/lib/modules/server/sessions/provider-paths.js';
+import { sosCoordinator } from './src/lib/modules/server/sos/coordinator.js';
 import { codexWatcher } from './src/lib/modules/server/terminal/codex-watcher.js';
 import { genericSessionWatcher } from './src/lib/modules/server/terminal/generic-session-watcher.js';
 import { openCodeWatcher } from './src/lib/modules/server/terminal/opencode-watcher.js';
+import { ptySubmitSequence } from './src/lib/modules/server/terminal/pty-input.js';
 import { ptyManager } from './src/lib/modules/server/terminal/pty-manager.js';
 import { sessionWatcher } from './src/lib/modules/server/terminal/session-watcher.js';
 import { startKeepalive, stopKeepalive } from './src/lib/modules/server/ws/keepalive.js';
@@ -121,8 +123,31 @@ setTerminalHandlerPtyManager(ptyManagerAdapter);
 setSessionHandlerPtyManager(ptyManagerAdapter);
 setSessionWatcher(sessionWatcherAdapter);
 
+// The SoS coordinator reuses the same watcher adapter (so it supports every
+// provider) and injects relays through PtyManager, which server.ts owns.
+sosCoordinator.setWatcher(sessionWatcherAdapter);
+sosCoordinator.setInjector((terminalId: string, text: string) => {
+  const terminal = ptyManager.get(terminalId);
+  if (!terminal || terminal.status === 'exited') {
+    return { error: 'Target terminal not available', ok: false };
+  }
+  // Deliver + submit via a bracketed paste, not a bare newline. Agent TUIs read
+  // the PTY in raw mode where LF never submits and a trailing CR in the same
+  // write is absorbed as paste content; ptySubmitSequence() wraps the body in a
+  // bracketed paste so the closing CR is a real Enter. See pty-input.ts.
+  try {
+    terminal.pty.write(ptySubmitSequence(text));
+    return { ok: true };
+  } catch {
+    return { error: 'Failed to write to target terminal', ok: false };
+  }
+});
+
 // Recover persisted terminals before accepting connections
 await ptyManager.reconnectAll();
+
+// Rebuild persisted super-sessions and re-subscribe their members.
+sosCoordinator.reconnectAll();
 
 // ── HTTP server wrapping SvelteKit ───────────────────────────────────
 

--- a/src/lib/modules/server/sos/coordinator.ts
+++ b/src/lib/modules/server/sos/coordinator.ts
@@ -1,0 +1,492 @@
+/**
+ * SuperSessionCoordinator — the Session-Over-Sessions meta-layer.
+ *
+ * Subscribes to N running agent sessions (any provider) by reusing the very
+ * same session-watcher adapter the WS session handler uses, so it inherits
+ * support for all eight providers with no new watching code. It merges each
+ * member's messages into one source-tagged transcript and fans live updates
+ * out to WebSocket listeners. Phase 1: observe + merge + human-driven
+ * relay-forward. Phase 2 (this file): static routing rules auto-relay messages
+ * between members (relay/block/escalate) and a human approve/deny path for
+ * escalations.
+ *
+ * Loop guards: an injected (relayed) entry is never itself re-evaluated;
+ * self-relay rules are rejected; and a per-pair cooldown rate-limits a chatty
+ * rule. NOTE these stop self-cascade and throttle but do NOT stop a bidirectional
+ * ping-pong: with both A→B and B→A rules, the target's genuine response arrives
+ * via the watcher (relayed=false) and is evaluated, so the pair can exchange one
+ * volley per cooldown indefinitely. Full cycle detection is future work.
+ *
+ * Dependencies (watcher + injector) are injected from server.ts so this module
+ * has no direct PTY/watcher imports and is trivially testable with fakes.
+ */
+
+import type {
+  SessionSource,
+  SessionWatcherLike,
+  SosInjector,
+  SosListener,
+  SosMember,
+  SosRoutingRule,
+  SosServerMessage,
+  SosTranscriptEntry,
+  SuperSession,
+  SuperSessionRuntime,
+} from '$lib/types';
+
+import { randomBytes } from 'crypto';
+
+import { evaluateRelayRule, isValidRoutingRule } from './policy-gate';
+import { relayStore } from './relay-store';
+
+const MAX_TRANSCRIPT = 500;
+const MAX_LABEL_LEN = 200;
+const RELAY_COOLDOWN_MS = 5000;
+const ESCALATE_TIMEOUT_MS = 120_000;
+const MAX_RELAY_TEXT = 10240; // 10 KB — same cap manual forward enforces at the route/WS layer
+
+class SuperSessionCoordinator {
+  private injector: null | SosInjector = null;
+  private runtimes = new Map<string, SuperSessionRuntime>();
+  private watcher: null | SessionWatcherLike = null;
+
+  /**
+   * Add a member to a super-session: persist it, replay its history into the
+   * merged transcript, and subscribe for live updates. Returns the new member,
+   * or null if the super-session does not exist.
+   */
+  addMember(
+    superSessionId: string,
+    spec: {
+      capability?: string;
+      provider: SessionSource;
+      sessionKey: string;
+      terminalId?: null | string;
+    }
+  ): null | SosMember {
+    const rt = this.runtimes.get(superSessionId);
+    if (!rt) {
+      return null;
+    }
+    const member: SosMember = {
+      capability: spec.capability ?? '',
+      id: randomBytes(8).toString('hex'),
+      provider: spec.provider,
+      registeredAt: new Date().toISOString(),
+      sessionKey: spec.sessionKey,
+      status: 'Idle',
+      terminalId: spec.terminalId ?? null,
+    };
+    rt.session.members.push(member);
+    relayStore.addMember(superSessionId, member);
+    this.subscribeMember(rt, member);
+    this.emit(rt, { member, type: 'sos-member-added' });
+    return member;
+  }
+
+  /** Human approves an escalated relay: inject it now, then resolve. */
+  approveRelay(superSessionId: string, relayId: string): boolean {
+    const rt = this.runtimes.get(superSessionId);
+    const pending = rt?.pending.get(relayId);
+    if (!rt || !pending) {
+      return false;
+    }
+    const result = this.doRelay(rt, pending.toMemberId, pending.text);
+    if (!result.ok) {
+      this.emit(rt, { message: result.error ?? 'Injection failed', type: 'sos-error' });
+      return false;
+    }
+    this.resolvePending(rt, relayId, 'approved');
+    return true;
+  }
+
+  createSuperSession(label: string): SuperSession {
+    const session: SuperSession = {
+      createdAt: new Date().toISOString(),
+      id: randomBytes(8).toString('hex'),
+      label: label.slice(0, MAX_LABEL_LEN),
+      members: [],
+      routingRules: [],
+      status: 'active',
+      transcript: [],
+    };
+    relayStore.createSuperSession(session);
+    this.runtimes.set(session.id, {
+      cooldowns: new Map(),
+      listeners: new Set(),
+      pending: new Map(),
+      session,
+      unsubscribes: new Map(),
+    });
+    return session;
+  }
+
+  deleteSuperSession(id: string): boolean {
+    const rt = this.runtimes.get(id);
+    if (!rt) {
+      return false;
+    }
+    for (const unsub of rt.unsubscribes.values()) {
+      unsub();
+    }
+    rt.unsubscribes.clear();
+    for (const p of rt.pending.values()) {
+      if (p.timer) {
+        clearTimeout(p.timer);
+      }
+    }
+    rt.pending.clear();
+    relayStore.deleteSuperSession(id);
+    this.runtimes.delete(id);
+    return true;
+  }
+
+  /** Human denies an escalated relay: drop it. */
+  denyRelay(superSessionId: string, relayId: string): boolean {
+    const rt = this.runtimes.get(superSessionId);
+    if (!rt?.pending.has(relayId)) {
+      return false;
+    }
+    this.resolvePending(rt, relayId, 'denied');
+    return true;
+  }
+
+  getRoutingRules(superSessionId: string): null | SosRoutingRule[] {
+    return this.runtimes.get(superSessionId)?.session.routingRules ?? null;
+  }
+
+  getSuperSession(id: string): SuperSession | undefined {
+    return this.runtimes.get(id)?.session;
+  }
+
+  listSuperSessions(): SuperSession[] {
+    return [...this.runtimes.values()].map((rt) => rt.session);
+  }
+
+  /** Rebuild persisted super-sessions and re-subscribe members. Call once on boot. */
+  reconnectAll(): void {
+    // Idempotent: tear down any existing runtimes (subscriptions + timers) so a
+    // second call cannot double-subscribe watchers or leak pending timers.
+    for (const rt of this.runtimes.values()) {
+      for (const unsub of rt.unsubscribes.values()) {
+        unsub();
+      }
+      for (const p of rt.pending.values()) {
+        if (p.timer) {
+          clearTimeout(p.timer);
+        }
+      }
+    }
+    this.runtimes.clear();
+
+    for (const session of relayStore.loadAll()) {
+      const rt: SuperSessionRuntime = {
+        cooldowns: new Map(),
+        listeners: new Set(),
+        pending: new Map(),
+        session: { ...session, transcript: [] },
+        unsubscribes: new Map(),
+      };
+      this.runtimes.set(session.id, rt);
+      for (const member of rt.session.members) {
+        this.subscribeMember(rt, member);
+      }
+    }
+  }
+
+  /**
+   * Human-driven relay: inject text into a member's Shooter-owned terminal and
+   * record it as a relayed entry in the transcript. Returns an error string on
+   * failure, or null on success.
+   */
+  relayForward(superSessionId: string, toMemberId: string, text: string): null | string {
+    const rt = this.runtimes.get(superSessionId);
+    if (!rt) {
+      return 'Super-session not found';
+    }
+    const member = rt.session.members.find((m) => m.id === toMemberId);
+    if (!member) {
+      return 'Target member not found';
+    }
+    if (!member.terminalId) {
+      return 'Target member has no Shooter-owned terminal (cannot inject into an observed session)';
+    }
+    if (!this.injector) {
+      return 'Injector not configured';
+    }
+    const result = this.doRelay(rt, toMemberId, text);
+    return result.ok ? null : (result.error ?? 'Injection failed');
+  }
+
+  removeMember(superSessionId: string, memberId: string): boolean {
+    const rt = this.runtimes.get(superSessionId);
+    if (!rt) {
+      return false;
+    }
+    const idx = rt.session.members.findIndex((m) => m.id === memberId);
+    if (idx === -1) {
+      return false;
+    }
+    rt.unsubscribes.get(memberId)?.();
+    rt.unsubscribes.delete(memberId);
+    rt.session.members.splice(idx, 1);
+    relayStore.removeMember(memberId);
+    this.emit(rt, { memberId, type: 'sos-member-removed' });
+    return true;
+  }
+
+  /** Inject the relay function (server.ts owns PtyManager). */
+  setInjector(injector: SosInjector): void {
+    this.injector = injector;
+  }
+
+  /**
+   * Replace a super-session's routing rules (Phase 2). Rejects self-relay rules.
+   * Returns an error string on invalid input, or null on success.
+   */
+  setRoutingRules(superSessionId: string, rules: SosRoutingRule[]): null | string {
+    const rt = this.runtimes.get(superSessionId);
+    if (!rt) {
+      return 'Super-session not found';
+    }
+    for (const rule of rules) {
+      if (!isValidRoutingRule(rule)) {
+        return `Invalid rule ${rule.id}: a rule may not relay a member to itself or to ANY`;
+      }
+    }
+    rt.session.routingRules = rules;
+    relayStore.createSuperSession(rt.session); // INSERT OR REPLACE rewrites routing_rules
+    return null;
+  }
+
+  /** Update a super-session's lifecycle status. Returns false if unknown id. */
+  setStatus(id: string, status: SuperSession['status']): boolean {
+    const rt = this.runtimes.get(id);
+    if (!rt) {
+      return false;
+    }
+    rt.session.status = status;
+    relayStore.updateSuperSessionStatus(id, status);
+    return true;
+  }
+
+  /** Inject the session-watcher adapter (same one the WS session handler uses). */
+  setWatcher(watcher: SessionWatcherLike): void {
+    this.watcher = watcher;
+  }
+
+  /**
+   * Register a WS listener for a super-session and replay the current merged
+   * transcript to it. Returns an unsubscribe function, or null if unknown id.
+   */
+  subscribe(superSessionId: string, listener: SosListener): (() => void) | null {
+    const rt = this.runtimes.get(superSessionId);
+    if (!rt) {
+      return null;
+    }
+    rt.listeners.add(listener);
+    listener({ entries: [...rt.session.transcript], type: 'sos-history' });
+    return () => {
+      rt.listeners.delete(listener);
+    };
+  }
+
+  private appendEntry(rt: SuperSessionRuntime, entry: SosTranscriptEntry): void {
+    rt.session.transcript.push(entry);
+    if (rt.session.transcript.length > MAX_TRANSCRIPT) {
+      rt.session.transcript.splice(0, rt.session.transcript.length - MAX_TRANSCRIPT);
+    }
+    this.emit(rt, { entry, type: 'sos-message' });
+  }
+
+  /** Run Tier-1 routing for one new message and dispatch the matched action. */
+  private applyPolicy(rt: SuperSessionRuntime, fromMemberId: string, text: string): void {
+    if (!text) {
+      return;
+    }
+    const rule = evaluateRelayRule(rt.session.routingRules, fromMemberId, text);
+    if (!rule) {
+      return;
+    }
+    if (rule.action === 'relay') {
+      this.autoRelay(rt, fromMemberId, rule.toMemberId, text);
+    } else if (rule.action === 'escalate') {
+      this.escalate(rt, fromMemberId, rule.toMemberId, text);
+    }
+    // 'block' → intentionally do nothing (the message merges but is not relayed).
+  }
+
+  /** Rule-driven relay, suppressed by the per-pair cooldown. */
+  private autoRelay(
+    rt: SuperSessionRuntime,
+    fromMemberId: string,
+    toMemberId: string,
+    text: string
+  ): void {
+    const key = `${fromMemberId}:${toMemberId}`;
+    const now = Date.now();
+    if (now - (rt.cooldowns.get(key) ?? 0) < RELAY_COOLDOWN_MS) {
+      return; // cooldown active — bound the blast radius of a chatty rule
+    }
+    rt.cooldowns.set(key, now);
+    this.doRelay(rt, toMemberId, text);
+  }
+
+  /**
+   * Inject text into a member's terminal and record a relayed transcript entry
+   * (relayed=true is the primary loop guard). Shared by manual + auto relay.
+   */
+  private doRelay(
+    rt: SuperSessionRuntime,
+    toMemberId: string,
+    text: string
+  ): { error?: string; ok: boolean } {
+    const member = rt.session.members.find((m) => m.id === toMemberId);
+    if (!member) {
+      return { error: 'Target member not found', ok: false };
+    }
+    if (!member.terminalId) {
+      return {
+        error:
+          'Target member has no Shooter-owned terminal (cannot inject into an observed session)',
+        ok: false,
+      };
+    }
+    if (!this.injector) {
+      return { error: 'Injector not configured', ok: false };
+    }
+    // Cap injected text so auto-relay can't dump an oversized agent message into
+    // a PTY — matches the 10 KB limit manual forward enforces at the boundary.
+    const capped = text.length > MAX_RELAY_TEXT ? text.slice(0, MAX_RELAY_TEXT) : text;
+    const result = this.injector(member.terminalId, capped);
+    if (!result.ok) {
+      return { error: result.error ?? 'Injection failed', ok: false };
+    }
+    this.appendEntry(rt, {
+      memberId: toMemberId,
+      message: {
+        id: `relay-${randomBytes(6).toString('hex')}`,
+        parts: [{ content: capped, type: 'text' }],
+        role: 'user',
+        timestamp: new Date().toISOString(),
+      },
+      provider: member.provider,
+      relayed: true,
+    });
+    return { ok: true };
+  }
+
+  private emit(rt: SuperSessionRuntime, msg: SosServerMessage): void {
+    for (const listener of rt.listeners) {
+      try {
+        listener(msg);
+      } catch (err) {
+        console.error('[sos] listener error:', err);
+      }
+    }
+  }
+
+  /** Queue an escalated relay for human approval and notify listeners. */
+  private escalate(
+    rt: SuperSessionRuntime,
+    fromMemberId: string,
+    toMemberId: string,
+    text: string
+  ): void {
+    const relayId = randomBytes(8).toString('hex');
+    const expiresAt = new Date(Date.now() + ESCALATE_TIMEOUT_MS).toISOString();
+    const timer = setTimeout(() => {
+      this.resolvePending(rt, relayId, 'expired');
+    }, ESCALATE_TIMEOUT_MS);
+    if (typeof timer.unref === 'function') {
+      timer.unref();
+    }
+    rt.pending.set(relayId, {
+      createdAt: new Date().toISOString(),
+      expiresAt,
+      fromMemberId,
+      id: relayId,
+      text,
+      timer,
+      toMemberId,
+    });
+    this.emit(rt, {
+      expiresAt,
+      fromMemberId,
+      preview: text.slice(0, 200),
+      relayId,
+      toMemberId,
+      type: 'sos-relay-pending',
+    });
+  }
+
+  private resolvePending(
+    rt: SuperSessionRuntime,
+    relayId: string,
+    decision: 'approved' | 'denied' | 'expired'
+  ): void {
+    const pending = rt.pending.get(relayId);
+    if (!pending) {
+      return;
+    }
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+    }
+    rt.pending.delete(relayId);
+    this.emit(rt, { decision, relayId, type: 'sos-relay-resolved' });
+  }
+
+  /** Replay history + subscribe a single member to the merged transcript. */
+  private subscribeMember(rt: SuperSessionRuntime, member: SosMember): void {
+    if (!this.watcher) {
+      return;
+    }
+    // Replay current history as tagged entries.
+    try {
+      for (const message of this.watcher.getHistory(member.sessionKey)) {
+        this.appendEntry(rt, {
+          memberId: member.id,
+          message,
+          provider: member.provider,
+          relayed: false,
+        });
+      }
+    } catch (err) {
+      console.error(`[sos] history replay failed for ${member.sessionKey}:`, err);
+    }
+    // Subscribe for live updates (the watcher emits only post-subscribe messages).
+    try {
+      const unsub = this.watcher.subscribe(member.sessionKey, (messages) => {
+        for (const message of messages) {
+          this.appendEntry(rt, {
+            memberId: member.id,
+            message,
+            provider: member.provider,
+            relayed: false,
+          });
+          // Phase 2: evaluate routing rules against genuinely-new member output.
+          this.applyPolicy(rt, member.id, textOf(message));
+        }
+      });
+      rt.unsubscribes.set(member.id, unsub);
+    } catch (err) {
+      console.error(`[sos] subscribe failed for ${member.sessionKey}:`, err);
+    }
+  }
+}
+
+/** Concatenate the text parts of a message (the basis for rule matching). */
+function textOf(message: SosTranscriptEntry['message']): string {
+  return message.parts
+    .filter((p) => p.type === 'text')
+    .map((p) => (p.type === 'text' ? p.content : ''))
+    .join(' ')
+    .trim();
+}
+
+// Single shared instance across module loaders.
+const SC_GLOBAL_KEY = '__shooter_sos_coordinator';
+export const sosCoordinator: SuperSessionCoordinator =
+  ((globalThis as Record<string, unknown>)[SC_GLOBAL_KEY] as SuperSessionCoordinator) ||
+  new SuperSessionCoordinator();
+(globalThis as Record<string, unknown>)[SC_GLOBAL_KEY] = sosCoordinator;

--- a/src/lib/modules/server/sos/policy-gate.ts
+++ b/src/lib/modules/server/sos/policy-gate.ts
@@ -1,0 +1,56 @@
+/**
+ * Tier-1 static routing policy for the SoS coordinator (Phase 2).
+ *
+ * Pure, side-effect-free evaluation: given a super-session's routing rules and a
+ * new message from a member, return the first matching rule (lowest `priority`
+ * wins) or null. The coordinator decides what to do with the result
+ * (relay / block / escalate). The Tier-2 LLM judge from the design is a later
+ * phase and is intentionally absent here.
+ */
+
+import type { SosRoutingRule } from '$lib/types';
+
+/**
+ * First matching rule for a message, or null when none match (default: no
+ * relay — rules are opt-in). Rules are evaluated in ascending `priority`.
+ */
+export function evaluateRelayRule(
+  rules: SosRoutingRule[],
+  fromMemberId: string,
+  text: string
+): null | SosRoutingRule {
+  const ordered = [...rules].sort((a, b) => a.priority - b.priority);
+  for (const rule of ordered) {
+    if (rule.fromMemberId !== 'ANY' && rule.fromMemberId !== fromMemberId) {
+      continue;
+    }
+    // An ANY-source rule must never relay a member's own message back to itself
+    // (explicit from === to rules are already rejected at rule-creation time).
+    if (rule.toMemberId === fromMemberId) {
+      continue;
+    }
+    if (!matchesPattern(text, rule.matchPattern)) {
+      continue;
+    }
+    return rule;
+  }
+  return null;
+}
+
+/**
+ * A rule is valid when it does not self-relay (from === to would loop) and it
+ * targets a concrete member (broadcast 'ANY' as a destination is not supported
+ * in Phase 2). ANY-source rules are additionally guarded at evaluation time so
+ * they never match a message originating from their own target.
+ */
+export function isValidRoutingRule(rule: SosRoutingRule): boolean {
+  return rule.toMemberId !== 'ANY' && rule.fromMemberId !== rule.toMemberId;
+}
+
+/** Empty pattern matches everything; otherwise a case-insensitive substring test. */
+function matchesPattern(text: string, pattern: string): boolean {
+  if (!pattern) {
+    return true;
+  }
+  return text.toLowerCase().includes(pattern.toLowerCase());
+}

--- a/src/lib/modules/server/sos/relay-store.ts
+++ b/src/lib/modules/server/sos/relay-store.ts
@@ -1,0 +1,159 @@
+/**
+ * RelayStore — SQLite persistence for Session-Over-Sessions metadata.
+ *
+ * Persists super-sessions and their member rows to ~/.shooter/shooter.db so a
+ * super-session survives a server restart (the coordinator re-subscribes each
+ * member on boot). The merged transcript itself is an in-memory ring buffer and
+ * is intentionally NOT persisted — it is rebuilt from each member's history on
+ * reconnect. Uses its own WAL connection to the shared db, exactly like
+ * terminal-store.
+ *
+ * The Phase 2/3 tables (sos_relay_log, relay_decisions, sos_memory) from the
+ * design are not created here yet — this is the Phase 1 MVP.
+ */
+
+import type { SosMember, SuperSession } from '$lib/types';
+
+import Database from 'better-sqlite3';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const DB_DIR = path.join(os.homedir(), '.shooter');
+const DB_PATH = path.join(DB_DIR, 'shooter.db');
+
+class RelayStore {
+  private db: Database.Database;
+
+  constructor() {
+    fs.mkdirSync(DB_DIR, { recursive: true });
+    this.db = new Database(DB_PATH);
+    this.db.pragma('journal_mode = WAL');
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS super_sessions (
+        id            TEXT PRIMARY KEY,
+        label         TEXT NOT NULL,
+        routing_rules TEXT NOT NULL DEFAULT '[]',
+        status        TEXT NOT NULL DEFAULT 'active',
+        created_at    TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS sos_sessions (
+        id                TEXT PRIMARY KEY,
+        super_session_id  TEXT NOT NULL,
+        session_key       TEXT NOT NULL,
+        terminal_id       TEXT,
+        provider          TEXT NOT NULL,
+        capability        TEXT NOT NULL DEFAULT '',
+        status            TEXT NOT NULL DEFAULT 'Idle',
+        registered_at     TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_sos_sessions_super ON sos_sessions(super_session_id);
+    `);
+  }
+
+  addMember(superSessionId: string, member: SosMember): void {
+    this.db
+      .prepare(
+        `INSERT OR REPLACE INTO sos_sessions
+         (id, super_session_id, session_key, terminal_id, provider, capability, status, registered_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        member.id,
+        superSessionId,
+        member.sessionKey,
+        member.terminalId,
+        member.provider,
+        member.capability,
+        member.status,
+        member.registeredAt
+      );
+  }
+
+  createSuperSession(session: SuperSession): void {
+    this.db
+      .prepare(
+        `INSERT OR REPLACE INTO super_sessions (id, label, routing_rules, status, created_at)
+         VALUES (?, ?, ?, ?, ?)`
+      )
+      .run(
+        session.id,
+        session.label,
+        JSON.stringify(session.routingRules),
+        session.status,
+        session.createdAt
+      );
+  }
+
+  deleteSuperSession(id: string): void {
+    // Atomic: both dependent deletes succeed or neither does, so an interruption
+    // cannot leave orphaned member rows behind their parent super-session.
+    const tx = this.db.transaction((sid: string) => {
+      this.db.prepare('DELETE FROM sos_sessions WHERE super_session_id = ?').run(sid);
+      this.db.prepare('DELETE FROM super_sessions WHERE id = ?').run(sid);
+    });
+    tx(id);
+  }
+
+  /** Rebuild every persisted super-session (members included, transcript empty). */
+  loadAll(): SuperSession[] {
+    const rows = this.db.prepare('SELECT * FROM super_sessions').all() as Record<string, unknown>[];
+    return rows.map((row) => {
+      const id = row.id as string;
+      const memberRows = this.db
+        .prepare('SELECT * FROM sos_sessions WHERE super_session_id = ? ORDER BY registered_at')
+        .all(id) as Record<string, unknown>[];
+      return {
+        createdAt: row.created_at as string,
+        id,
+        label: row.label as string,
+        members: memberRows.map(rowToMember),
+        routingRules: safeParseRules(row.routing_rules),
+        status: row.status as SuperSession['status'],
+        transcript: [],
+      };
+    });
+  }
+
+  removeMember(memberId: string): void {
+    this.db.prepare('DELETE FROM sos_sessions WHERE id = ?').run(memberId);
+  }
+
+  updateMemberStatus(memberId: string, status: SosMember['status']): void {
+    this.db.prepare('UPDATE sos_sessions SET status = ? WHERE id = ?').run(status, memberId);
+  }
+
+  updateSuperSessionStatus(id: string, status: SuperSession['status']): void {
+    this.db.prepare('UPDATE super_sessions SET status = ? WHERE id = ?').run(status, id);
+  }
+}
+
+function rowToMember(row: Record<string, unknown>): SosMember {
+  return {
+    capability: (row.capability as string) ?? '',
+    id: row.id as string,
+    provider: row.provider as SosMember['provider'],
+    registeredAt: row.registered_at as string,
+    sessionKey: row.session_key as string,
+    status: row.status as SosMember['status'],
+    terminalId: (row.terminal_id as string) ?? null,
+  };
+}
+
+function safeParseRules(raw: unknown): SuperSession['routingRules'] {
+  if (typeof raw !== 'string') {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as SuperSession['routingRules']) : [];
+  } catch {
+    return [];
+  }
+}
+
+// Single shared instance across module loaders.
+const RS_GLOBAL_KEY = '__shooter_relay_store';
+export const relayStore: RelayStore =
+  ((globalThis as Record<string, unknown>)[RS_GLOBAL_KEY] as RelayStore) || new RelayStore();
+(globalThis as Record<string, unknown>)[RS_GLOBAL_KEY] = relayStore;

--- a/src/lib/modules/server/terminal/pty-input.ts
+++ b/src/lib/modules/server/terminal/pty-input.ts
@@ -1,0 +1,37 @@
+/**
+ * PTY input helpers.
+ *
+ * Submitting text to an interactive agent TUI (codex, claude, gemini, qwen, …)
+ * is not as simple as appending a newline. These TUIs read the PTY in raw mode:
+ *
+ *   - A bare LF (`\n`) is NOT the Enter key — it types a literal newline into
+ *     the prompt and never submits. (Verified: LF leaves codex sitting on its
+ *     prompt; the message just accumulates.)
+ *   - Even `"<text>\r"` written as a SINGLE chunk is treated as a bracketed
+ *     paste by the TUI, so the trailing CR is absorbed into the pasted body
+ *     instead of submitting. (Verified: codex types the text but does not run.)
+ *
+ * The reliable approach — the same bytes a real terminal emulator sends when a
+ * human pastes and presses Enter — is to wrap the body in an explicit bracketed
+ * paste (`ESC[200~` … `ESC[201~`) and then send a CR. The paste-end marker
+ * closes the paste unambiguously, so the following CR is a real Enter. This
+ * also preserves embedded newlines in multi-line messages (the whole point of
+ * bracketed paste) and submits correctly in modern interactive shells, where
+ * bracketed paste is enabled by default.
+ *
+ * Verified empirically against codex 0.136 and claude 2.1 — both receive the
+ * message and complete a turn.
+ */
+
+const PASTE_START = '\x1b[200~';
+const PASTE_END = '\x1b[201~';
+
+/**
+ * Build the PTY byte sequence that delivers `text` to an interactive terminal
+ * and submits it (presses Enter). Any trailing newline the caller added is
+ * stripped — the CR after the paste-end marker is what submits.
+ */
+export function ptySubmitSequence(text: string): string {
+  const body = text.replace(/[\r\n]+$/, '');
+  return `${PASTE_START}${body}${PASTE_END}\r`;
+}

--- a/src/lib/modules/server/ws/server.ts
+++ b/src/lib/modules/server/ws/server.ts
@@ -15,6 +15,7 @@ import {
   handleEventsConnection,
 } from './events-handler.js';
 import { handleSessionConnection } from './session-handler.js';
+import { handleSuperSessionConnection } from './super-session-handler.js';
 import { handleTerminalConnection } from './terminal-handler.js';
 export type { WireShooterEvent as ShooterEvent } from '$lib/types';
 
@@ -61,10 +62,11 @@ export function setupWebSocketHandlers(
 
   // Route matching
   const terminalMatch = /^\/ws\/terminal\/(.+)$/.exec(pathname);
+  const superSessionMatch = /^\/ws\/super-session\/(.+)$/.exec(pathname);
   const sessionMatch = /^\/ws\/session\/(.+)$/.exec(pathname);
   const isEvents = pathname === '/ws/events';
 
-  if (!terminalMatch && !sessionMatch && !isEvents) {
+  if (!terminalMatch && !superSessionMatch && !sessionMatch && !isEvents) {
     socket.destroy();
     return;
   }
@@ -83,6 +85,9 @@ export function setupWebSocketHandlers(
     if (terminalMatch) {
       const terminalId = terminalMatch[1];
       handleTerminalConnection(ws, terminalId);
+    } else if (superSessionMatch) {
+      const superSessionId = superSessionMatch[1];
+      handleSuperSessionConnection(ws, superSessionId);
     } else if (sessionMatch) {
       const sessionId = sessionMatch[1];
       handleSessionConnection(ws, sessionId);

--- a/src/lib/modules/server/ws/session-handler.ts
+++ b/src/lib/modules/server/ws/session-handler.ts
@@ -23,6 +23,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { findCodexRolloutById } from '../sessions/codex-reader';
+import { ptySubmitSequence } from '../terminal/pty-input';
 
 // ── Module-level references ──────────────────────────────────────────
 
@@ -547,7 +548,11 @@ function wireClientMessages(ws: WebSocket, state: ConnectionState): void {
             safeSend(ws, { message: 'Terminal has exited', type: 'error' });
             return;
           }
-          currentTerminal.pty.write(`${msg.text}\n`);
+          // Deliver + submit via a bracketed paste (see pty-input.ts): a bare
+          // LF never submits to an agent TUI and a trailing CR in the same
+          // write is absorbed as paste content. Bracketed paste closes the
+          // paste explicitly so the following CR is a real Enter.
+          currentTerminal.pty.write(ptySubmitSequence(msg.text));
           break;
         }
 

--- a/src/lib/modules/server/ws/super-session-handler.ts
+++ b/src/lib/modules/server/ws/super-session-handler.ts
@@ -1,0 +1,200 @@
+// WebSocket handler for /ws/super-session/:id — the merged Session-Over-Sessions
+// stream. On connect it replays the merged transcript (sos-history) and then
+// streams live tagged messages from every member. Accepts human-driven control
+// messages: relay-forward (inject into a member's terminal), member-add,
+// member-remove. Mirrors session-handler.ts in shape.
+
+import type { SessionSource, SosClientMessage, SosServerMessage } from '$lib/types';
+import type { WebSocket } from 'ws';
+
+import * as path from 'path';
+
+import { PROVIDERS } from '../sessions/registry';
+import { sosCoordinator } from '../sos/coordinator';
+
+const MAX_RELAY_TEXT = 10240; // 10 KB, same cap as /ws/session send-input
+// Stop streaming to a client whose outbound buffer exceeds this — bounds memory
+// growth when a slow consumer can't drain sos-history replay or a live burst.
+const MAX_WS_BUFFERED_BYTES = 1_000_000;
+const VALID_SOURCES = new Set<string>(PROVIDERS.map((p) => p.source));
+
+export function handleSuperSessionConnection(ws: WebSocket, id: string): void {
+  const session = sosCoordinator.getSuperSession(id);
+  if (!session) {
+    safeSend(ws, { message: `Super-session not found: ${id}`, type: 'sos-error' });
+    ws.close(1008, 'Super-session not found');
+    return;
+  }
+
+  // subscribe() replays the current transcript as an sos-history message, then
+  // streams live sos-message / sos-member-* events. If a send fails (socket
+  // closed or buffer over cap), stop feeding this client to bound memory.
+  let unsubscribe: (() => void) | null = null;
+  unsubscribe = sosCoordinator.subscribe(id, (msg) => {
+    if (!safeSend(ws, msg)) {
+      unsubscribe?.();
+      unsubscribe = null;
+    }
+  });
+
+  ws.on('message', (raw: Buffer | string) => {
+    const data = typeof raw === 'string' ? raw : raw.toString('utf-8');
+    const msg = parseClientMessage(data);
+    if (!msg) {
+      // Surface schema drift instead of silently dropping the frame — a dead
+      // control in the UI is much harder to debug than an explicit error.
+      safeSend(ws, { message: 'Invalid super-session control message', type: 'sos-error' });
+      return;
+    }
+    handleClientMessage(ws, id, msg);
+  });
+
+  ws.on('close', () => {
+    unsubscribe?.();
+  });
+  ws.on('error', () => {
+    // cleanup happens in 'close'
+  });
+}
+
+/** True when the string is a known provider source. */
+export function isValidProvider(value: string): value is SessionSource {
+  return VALID_SOURCES.has(value);
+}
+
+/** True for a bare session id (OpenCode) or an absolute path under HOME. */
+export function isValidSessionKey(key: string): boolean {
+  if (/^[A-Za-z0-9_-]+$/.test(key)) {
+    return true;
+  }
+  const home = process.env.HOME || '';
+  if (home === '' || !path.isAbsolute(key)) {
+    return false;
+  }
+  // Resolve before comparing so `..` segments cannot escape the HOME sandbox
+  // (e.g. /home/user/../etc/passwd passes a raw prefix check but not this).
+  const relative = path.relative(path.resolve(home), path.resolve(key));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function handleClientMessage(ws: WebSocket, superSessionId: string, msg: SosClientMessage): void {
+  switch (msg.type) {
+    case 'member-add': {
+      const member = sosCoordinator.addMember(superSessionId, {
+        capability: msg.capability,
+        provider: msg.provider,
+        sessionKey: msg.sessionKey,
+        terminalId: msg.terminalId ?? null,
+      });
+      if (!member) {
+        safeSend(ws, { message: 'Failed to add member', type: 'sos-error' });
+      }
+      break;
+    }
+    case 'member-remove': {
+      const ok = sosCoordinator.removeMember(superSessionId, msg.memberId);
+      if (!ok) {
+        safeSend(ws, { message: 'Member not found', type: 'sos-error' });
+      }
+      break;
+    }
+    case 'relay-approve': {
+      if (!sosCoordinator.approveRelay(superSessionId, msg.relayId)) {
+        safeSend(ws, { message: 'Pending relay not found', type: 'sos-error' });
+      }
+      break;
+    }
+    case 'relay-deny': {
+      if (!sosCoordinator.denyRelay(superSessionId, msg.relayId)) {
+        safeSend(ws, { message: 'Pending relay not found', type: 'sos-error' });
+      }
+      break;
+    }
+    case 'relay-forward': {
+      const error = sosCoordinator.relayForward(superSessionId, msg.toMemberId, msg.text);
+      if (error) {
+        safeSend(ws, { message: error, type: 'sos-error' });
+      }
+      break;
+    }
+  }
+}
+
+function parseClientMessage(raw: string): null | SosClientMessage {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return null;
+  }
+  const msg = parsed as Record<string, unknown>;
+
+  switch (msg.type) {
+    case 'member-add': {
+      if (
+        typeof msg.sessionKey !== 'string' ||
+        !isValidSessionKey(msg.sessionKey) ||
+        typeof msg.provider !== 'string' ||
+        !isValidProvider(msg.provider)
+      ) {
+        return null;
+      }
+      return {
+        capability: typeof msg.capability === 'string' ? msg.capability : undefined,
+        provider: msg.provider,
+        sessionKey: msg.sessionKey,
+        terminalId: typeof msg.terminalId === 'string' ? msg.terminalId : undefined,
+        type: 'member-add',
+      };
+    }
+    case 'member-remove': {
+      if (typeof msg.memberId !== 'string' || msg.memberId.length === 0) {
+        return null;
+      }
+      return { memberId: msg.memberId, type: 'member-remove' };
+    }
+    case 'relay-approve': {
+      if (typeof msg.relayId !== 'string' || msg.relayId.length === 0) {
+        return null;
+      }
+      return { relayId: msg.relayId, type: 'relay-approve' };
+    }
+    case 'relay-deny': {
+      if (typeof msg.relayId !== 'string' || msg.relayId.length === 0) {
+        return null;
+      }
+      return { relayId: msg.relayId, type: 'relay-deny' };
+    }
+    case 'relay-forward': {
+      if (
+        typeof msg.toMemberId !== 'string' ||
+        typeof msg.text !== 'string' ||
+        msg.text.length === 0 ||
+        msg.text.length > MAX_RELAY_TEXT
+      ) {
+        return null;
+      }
+      return { text: msg.text, toMemberId: msg.toMemberId, type: 'relay-forward' };
+    }
+    default:
+      return null;
+  }
+}
+
+function safeSend(ws: WebSocket, msg: SosServerMessage): boolean {
+  try {
+    if (ws.readyState !== 1 /* OPEN */) {
+      return false;
+    }
+    if (ws.bufferedAmount > MAX_WS_BUFFERED_BYTES) {
+      return false;
+    }
+    ws.send(JSON.stringify(msg));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -12,8 +12,8 @@ export type * from './gemini';
 export * from './generated';
 export type * from './neurolink';
 export type * from './server';
-
 export type * from './sessions';
+
 // Explicit re-exports to resolve conflicts between generated types and the
 // hand-written sessions.ts versions. The generated Sessions module exports
 // wrapper-class variants (CMessagePartTextPart, etc.) with `type: string`
@@ -27,5 +27,6 @@ export type {
   ToolResultPart,
   ToolUsePart,
 } from './sessions';
+export type * from './sos';
 export type * from './terminal-client';
 export type * from './ws';

--- a/src/lib/types/sos.ts
+++ b/src/lib/types/sos.ts
@@ -1,0 +1,134 @@
+// Session-Over-Sessions (SoS) types — the coordinator that merges N running
+// agent sessions into one source-tagged super-session and relays messages
+// between them. See docs/SESSION-OVER-SESSIONS.md.
+//
+// A member's `sessionKey` is exactly what the server's session-watcher adapter
+// keys on: a JSONL/JSON file path for file-backed providers, or a bare session
+// id for OpenCode. That lets the coordinator reuse the same watcher routing the
+// WS session handler uses, covering all providers with no new watching code.
+
+import type { SessionSource } from './generated';
+import type { ConversationMessage } from './sessions';
+
+/** An escalated relay awaiting human approve/deny (Phase 2 HITL). */
+export interface PendingRelay {
+  createdAt: string;
+  expiresAt: string;
+  fromMemberId: string;
+  id: string;
+  text: string;
+  timer: null | ReturnType<typeof setTimeout>;
+  toMemberId: string;
+}
+
+/** A control message sent from a SoS client to the coordinator over /ws/super-session/:id. */
+export type SosClientMessage =
+  | {
+      capability?: string;
+      provider: SessionSource;
+      sessionKey: string;
+      terminalId?: string;
+      type: 'member-add';
+    }
+  | { memberId: string; type: 'member-remove' }
+  | { relayId: string; type: 'relay-approve' }
+  | { relayId: string; type: 'relay-deny' }
+  | { text: string; toMemberId: string; type: 'relay-forward' };
+
+/**
+ * Injects relay text into a Shooter-owned terminal's stdin. Supplied by
+ * server.ts (which owns PtyManager) so the coordinator stays free of PTY deps.
+ * Performs the ownership check (terminal exists + running) and returns the
+ * outcome.
+ */
+export type SosInjector = (terminalId: string, text: string) => { error?: string; ok: boolean };
+
+/** A WS listener registered against a super-session. */
+export type SosListener = (msg: SosServerMessage) => void;
+
+export interface SosMember {
+  /** Free-text capability tag, e.g. 'frontend' | 'backend' | '' (unused in MVP routing). */
+  capability: string;
+  /** Random hex id, primary key in sos_sessions. */
+  id: string;
+  provider: SessionSource;
+  registeredAt: string;
+  /** Watcher key: file path for file-backed providers, session id for OpenCode. */
+  sessionKey: string;
+  status: SosMemberStatus;
+  /** PtyManager terminal id when launched via Shooter; null for externally-observed sessions. */
+  terminalId: null | string;
+}
+
+// ── WebSocket protocol (/ws/super-session/:id) ──────────────────────────
+
+/** Lifecycle status of a SoS member's underlying agent session. */
+export type SosMemberStatus = 'Compacting' | 'Finished' | 'Idle' | 'Waiting' | 'Working';
+
+/**
+ * A static routing rule (Phase 2). The coordinator evaluates these in ascending
+ * `priority` against each new member message; the first match decides the
+ * action. `fromMemberId` may be 'ANY'; an empty `matchPattern` matches all text.
+ */
+export interface SosRoutingRule {
+  action: 'block' | 'escalate' | 'relay';
+  fromMemberId: string;
+  id: string;
+  matchPattern: string;
+  priority: number;
+  toMemberId: string;
+}
+
+/** A message broadcast from the coordinator to subscribed SoS clients. */
+export type SosServerMessage =
+  | {
+      decision: 'approved' | 'denied' | 'expired';
+      relayId: string;
+      type: 'sos-relay-resolved';
+    }
+  | { entries: SosTranscriptEntry[]; type: 'sos-history' }
+  | { entry: SosTranscriptEntry; type: 'sos-message' }
+  | {
+      expiresAt: string;
+      fromMemberId: string;
+      preview: string;
+      relayId: string;
+      toMemberId: string;
+      type: 'sos-relay-pending';
+    }
+  | { member: SosMember; type: 'sos-member-added' }
+  | { memberId: string; status: SosMemberStatus; type: 'sos-member-status' }
+  | { memberId: string; type: 'sos-member-removed' }
+  | { message: string; type: 'sos-error' };
+
+/** One message in the merged transcript, tagged with its origin member. */
+export interface SosTranscriptEntry {
+  memberId: string;
+  message: ConversationMessage;
+  provider: SessionSource;
+  /** True when the coordinator injected this message (loop-guard marker). */
+  relayed: boolean;
+}
+
+/** A super-session: N merged agent sessions coordinated as one. */
+export interface SuperSession {
+  createdAt: string;
+  id: string;
+  label: string;
+  members: SosMember[];
+  routingRules: SosRoutingRule[];
+  status: 'active' | 'archived' | 'paused';
+  /** Source-tagged merged transcript; in-memory ring buffer (capped). */
+  transcript: SosTranscriptEntry[];
+}
+
+/** Coordinator-internal runtime state for one live super-session. */
+export interface SuperSessionRuntime {
+  /** `${fromMemberId}:${toMemberId}` -> last auto-relay epoch ms (cooldown guard). */
+  cooldowns: Map<string, number>;
+  listeners: Set<SosListener>;
+  /** Escalated relays awaiting human decision, keyed by relayId. */
+  pending: Map<string, PendingRelay>;
+  session: SuperSession;
+  unsubscribes: Map<string, () => void>;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
   import DashboardSvg from '$lib/assets/icons/dashboard.svg?raw';
   import SettingsSvg from '$lib/assets/icons/settings.svg?raw';
   import TerminalSvg from '$lib/assets/icons/terminal.svg?raw';
+  import ToolSvg from '$lib/assets/icons/tool.svg?raw';
   import { Button, Icon, Pill } from '@juspay/svelte-ui-components';
   import { onMount, type Snippet } from 'svelte';
 
@@ -133,6 +134,10 @@
         <Icon svg={TerminalSvg} classes="icon-26" />
         <span>Terminals</span>
       </a>
+      <a href="/sos" class="tab-item" class:active={$page.url.pathname.startsWith('/sos')}>
+        <Icon svg={ToolSvg} classes="icon-26" />
+        <span>SoS</span>
+      </a>
     </div>
   </nav>
 </div>
@@ -191,6 +196,7 @@
   }
   .tab-item {
     display: flex;
+    flex: 1;
     flex-direction: column;
     align-items: center;
     justify-content: center;
@@ -199,7 +205,7 @@
     font-size: 11px;
     font-weight: 500;
     text-decoration: none;
-    padding: 6px 36px;
+    padding: 6px 8px;
     border-radius: var(--radius-md);
     transition: color var(--transition-fast);
     user-select: none;
@@ -226,7 +232,8 @@
       height: 60px;
     }
     .tab-item {
-      padding: 6px 28px;
+      padding: 6px 8px;
+      min-width: 0;
       font-size: 10px;
       gap: 3px;
       min-height: 44px;

--- a/src/routes/api/sos/+server.ts
+++ b/src/routes/api/sos/+server.ts
@@ -1,0 +1,36 @@
+import { validateAuth } from '$lib/modules/server/auth';
+import { sosCoordinator } from '$lib/modules/server/sos/coordinator';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+/** GET /api/sos — list all super-sessions. */
+export const GET: RequestHandler = ({ request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  return json({ superSessions: sosCoordinator.listSuperSessions() });
+};
+
+/** POST /api/sos — create a new super-session. */
+export const POST: RequestHandler = async ({ request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+  if (typeof body !== 'object' || body === null) {
+    return json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+  const payload = body as { label?: unknown };
+  const label =
+    typeof payload.label === 'string' && payload.label.trim() ? payload.label.trim() : 'Untitled';
+  const session = sosCoordinator.createSuperSession(label);
+  return json(session, { status: 201 });
+};

--- a/src/routes/api/sos/[id]/+server.ts
+++ b/src/routes/api/sos/[id]/+server.ts
@@ -1,0 +1,55 @@
+import { validateAuth } from '$lib/modules/server/auth';
+import { sosCoordinator } from '$lib/modules/server/sos/coordinator';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+/** GET /api/sos/[id] — fetch one super-session (incl. members + transcript). */
+export const GET: RequestHandler = ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  const session = sosCoordinator.getSuperSession(params.id ?? '');
+  if (!session) {
+    return json({ error: 'Super-session not found' }, { status: 404 });
+  }
+  return json(session);
+};
+
+/** PATCH /api/sos/[id] — update lifecycle status (active | paused | archived). */
+export const PATCH: RequestHandler = async ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+  if (typeof body !== 'object' || body === null) {
+    return json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+  const payload = body as { status?: unknown };
+  if (payload.status !== 'active' && payload.status !== 'paused' && payload.status !== 'archived') {
+    return json({ error: 'status must be active | paused | archived' }, { status: 400 });
+  }
+  if (!sosCoordinator.setStatus(params.id ?? '', payload.status)) {
+    return json({ error: 'Super-session not found' }, { status: 404 });
+  }
+  return json({ id: params.id, status: payload.status });
+};
+
+/** DELETE /api/sos/[id] — tear down a super-session (unsubscribes all members). */
+export const DELETE: RequestHandler = ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  if (!sosCoordinator.deleteSuperSession(params.id ?? '')) {
+    return json({ error: 'Super-session not found' }, { status: 404 });
+  }
+  return json({ deleted: true });
+};

--- a/src/routes/api/sos/[id]/inject/+server.ts
+++ b/src/routes/api/sos/[id]/inject/+server.ts
@@ -1,0 +1,44 @@
+import { validateAuth } from '$lib/modules/server/auth';
+import { sosCoordinator } from '$lib/modules/server/sos/coordinator';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+const MAX_RELAY_TEXT = 10240; // 10 KB, same cap as /ws/session send-input
+
+/**
+ * POST /api/sos/[id]/inject — human-initiated relay: inject text into a member's
+ * Shooter-owned terminal and record it in the merged transcript.
+ */
+export const POST: RequestHandler = async ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+  if (typeof body !== 'object' || body === null) {
+    return json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+  const payload = body as { text?: unknown; toMemberId?: unknown };
+  if (typeof payload.toMemberId !== 'string' || payload.toMemberId.length === 0) {
+    return json({ error: 'toMemberId is required (string)' }, { status: 400 });
+  }
+  if (typeof payload.text !== 'string' || payload.text.length === 0) {
+    return json({ error: 'text is required (string)' }, { status: 400 });
+  }
+  if (Buffer.byteLength(payload.text, 'utf8') > MAX_RELAY_TEXT) {
+    return json({ error: `text exceeds ${MAX_RELAY_TEXT} bytes` }, { status: 413 });
+  }
+
+  const error = sosCoordinator.relayForward(params.id ?? '', payload.toMemberId, payload.text);
+  if (error) {
+    const status = error.includes('not found') ? 404 : 400;
+    return json({ error }, { status });
+  }
+  return json({ ok: true });
+};

--- a/src/routes/api/sos/[id]/members/+server.ts
+++ b/src/routes/api/sos/[id]/members/+server.ts
@@ -1,0 +1,47 @@
+import { validateAuth } from '$lib/modules/server/auth';
+import { sosCoordinator } from '$lib/modules/server/sos/coordinator';
+import { isValidProvider, isValidSessionKey } from '$lib/modules/server/ws/super-session-handler';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+/** POST /api/sos/[id]/members — add a member session to a super-session. */
+export const POST: RequestHandler = async ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+  if (typeof body !== 'object' || body === null) {
+    return json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+  const payload = body as {
+    capability?: unknown;
+    provider?: unknown;
+    sessionKey?: unknown;
+    terminalId?: unknown;
+  };
+
+  if (typeof payload.sessionKey !== 'string' || !isValidSessionKey(payload.sessionKey)) {
+    return json({ error: 'sessionKey must be a session id or a path under home' }, { status: 400 });
+  }
+  if (typeof payload.provider !== 'string' || !isValidProvider(payload.provider)) {
+    return json({ error: 'provider must be a known session source' }, { status: 400 });
+  }
+
+  const member = sosCoordinator.addMember(params.id ?? '', {
+    capability: typeof payload.capability === 'string' ? payload.capability : undefined,
+    provider: payload.provider,
+    sessionKey: payload.sessionKey,
+    terminalId: typeof payload.terminalId === 'string' ? payload.terminalId : null,
+  });
+  if (!member) {
+    return json({ error: 'Super-session not found' }, { status: 404 });
+  }
+  return json(member, { status: 201 });
+};

--- a/src/routes/api/sos/[id]/members/[mid]/+server.ts
+++ b/src/routes/api/sos/[id]/members/[mid]/+server.ts
@@ -1,0 +1,17 @@
+import { validateAuth } from '$lib/modules/server/auth';
+import { sosCoordinator } from '$lib/modules/server/sos/coordinator';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+/** DELETE /api/sos/[id]/members/[mid] — remove a member (unsubscribes its watcher). */
+export const DELETE: RequestHandler = ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  if (!sosCoordinator.removeMember(params.id ?? '', params.mid ?? '')) {
+    return json({ error: 'Super-session or member not found' }, { status: 404 });
+  }
+  return json({ removed: true });
+};

--- a/src/routes/api/sos/[id]/rules/+server.ts
+++ b/src/routes/api/sos/[id]/rules/+server.ts
@@ -1,0 +1,85 @@
+import type { SosRoutingRule } from '$lib/types';
+
+import { validateAuth } from '$lib/modules/server/auth';
+import { sosCoordinator } from '$lib/modules/server/sos/coordinator';
+import { json } from '@sveltejs/kit';
+import { randomBytes } from 'crypto';
+
+import type { RequestHandler } from './$types';
+
+const ACTIONS = new Set(['block', 'escalate', 'relay']);
+
+/** GET /api/sos/[id]/rules — current routing rules. */
+export const GET: RequestHandler = ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  const rules = sosCoordinator.getRoutingRules(params.id ?? '');
+  if (rules === null) {
+    return json({ error: 'Super-session not found' }, { status: 404 });
+  }
+  return json({ routingRules: rules });
+};
+
+/** PATCH /api/sos/[id]/rules — replace the routing rules. */
+export const PATCH: RequestHandler = async ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+  if (typeof body !== 'object' || body === null) {
+    return json({ error: 'Invalid JSON in request body' }, { status: 400 });
+  }
+  const payload = body as { routingRules?: unknown };
+  if (!Array.isArray(payload.routingRules)) {
+    return json({ error: 'routingRules must be an array' }, { status: 400 });
+  }
+
+  const rules: SosRoutingRule[] = [];
+  for (const raw of payload.routingRules) {
+    const rule = normalizeRule(raw);
+    if (!rule) {
+      return json(
+        { error: 'Each rule needs fromMemberId, toMemberId, and action' },
+        { status: 400 }
+      );
+    }
+    rules.push(rule);
+  }
+
+  const error = sosCoordinator.setRoutingRules(params.id ?? '', rules);
+  if (error) {
+    return json({ error }, { status: error.includes('not found') ? 404 : 400 });
+  }
+  return json({ routingRules: rules });
+};
+
+function normalizeRule(raw: unknown): null | SosRoutingRule {
+  if (typeof raw !== 'object' || raw === null) {
+    return null;
+  }
+  const r = raw as Record<string, unknown>;
+  if (
+    typeof r.fromMemberId !== 'string' ||
+    typeof r.toMemberId !== 'string' ||
+    typeof r.action !== 'string' ||
+    !ACTIONS.has(r.action)
+  ) {
+    return null;
+  }
+  return {
+    action: r.action as SosRoutingRule['action'],
+    fromMemberId: r.fromMemberId,
+    id: typeof r.id === 'string' && r.id ? r.id : randomBytes(6).toString('hex'),
+    matchPattern: typeof r.matchPattern === 'string' ? r.matchPattern : '',
+    priority: typeof r.priority === 'number' ? r.priority : 100,
+    toMemberId: r.toMemberId,
+  };
+}

--- a/src/routes/sos/+page.svelte
+++ b/src/routes/sos/+page.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import type { ShooterConfig, SuperSession } from '$lib/types';
+
+  import { goto } from '$app/navigation';
+  import { Banner, Button, EmptyState, Input, Pill } from '@juspay/svelte-ui-components';
+  import { onMount } from 'svelte';
+
+  let sessions = $state<SuperSession[]>([]);
+  let loading = $state(true);
+  let error = $state('');
+  let newLabel = $state('');
+  let creating = $state(false);
+
+  function getConfig(): null | ShooterConfig {
+    try {
+      const saved = localStorage.getItem('shooter_config');
+      return saved ? (JSON.parse(saved) as ShooterConfig) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function loadSessions(): Promise<void> {
+    const config = getConfig();
+    if (!config) {
+      error = 'No configuration found. Open Settings first.';
+      loading = false;
+      return;
+    }
+    try {
+      const res = await fetch('/api/sos', {
+        headers: { Authorization: `Bearer ${config.apiKey}` },
+      });
+      if (!res.ok) {
+        error = `Failed to load (${res.status})`;
+        return;
+      }
+      const data = (await res.json()) as { superSessions: SuperSession[] };
+      sessions = data.superSessions ?? [];
+    } catch {
+      error = 'Network error — is the server running?';
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function create(): Promise<void> {
+    const config = getConfig();
+    if (!config || !newLabel.trim()) {
+      return;
+    }
+    creating = true;
+    try {
+      const res = await fetch('/api/sos', {
+        body: JSON.stringify({ label: newLabel.trim() }),
+        headers: { Authorization: `Bearer ${config.apiKey}`, 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+      if (res.ok) {
+        const created = (await res.json()) as SuperSession;
+        void goto(`/sos/${created.id}`);
+      } else {
+        const d = (await res.json().catch(() => ({}))) as { error?: string };
+        error = d.error ?? `Failed to create (${res.status})`;
+      }
+    } catch {
+      error = 'Network error — could not create super-session';
+    } finally {
+      creating = false;
+    }
+  }
+
+  onMount(() => {
+    void loadSessions();
+  });
+</script>
+
+<svelte:head><title>Session Over Sessions - Shooter</title></svelte:head>
+
+<main class="main sos-list">
+  <div class="page-head">
+    <div>
+      <h1>Session Over Sessions</h1>
+      <p class="subtitle">Coordinate multiple running agents as one super-session.</p>
+    </div>
+  </div>
+
+  <div class="create-row">
+    <Input
+      bind:value={newLabel}
+      dataType="text"
+      placeholder="New super-session label…"
+      classes="sos-create-input"
+    />
+    <Button
+      text={creating ? 'Creating…' : 'Create'}
+      disabled={creating || !newLabel.trim()}
+      onclick={create}
+      classes="btn-create"
+    />
+  </div>
+
+  {#if error}
+    <Banner text={error} classes="banner-error" />
+  {/if}
+
+  {#if loading}
+    <p class="muted">Loading…</p>
+  {:else if sessions.length === 0}
+    <EmptyState
+      title="No super-sessions yet"
+      description="Create one above, then add running agent sessions as members."
+    />
+  {:else}
+    <div class="ss-grid">
+      {#each sessions as ss (ss.id)}
+        <a class="ss-card" href={`/sos/${ss.id}`}>
+          <div class="ss-card-head">
+            <span class="ss-label">{ss.label}</span>
+            <Pill text={ss.status} classes="pill-status-unknown" />
+          </div>
+          <div class="ss-meta">
+            <span>{ss.members.length} member{ss.members.length === 1 ? '' : 's'}</span>
+            <span>{ss.routingRules.length} rule{ss.routingRules.length === 1 ? '' : 's'}</span>
+          </div>
+        </a>
+      {/each}
+    </div>
+  {/if}
+</main>
+
+<style>
+  .sos-list {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: var(--space-5) var(--space-4);
+  }
+  .page-head h1 {
+    font-size: var(--text-2xl);
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+  }
+  .subtitle {
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+    margin: var(--space-1) 0 var(--space-4);
+  }
+  .create-row {
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+    margin-bottom: var(--space-4);
+  }
+  :global(.sos-create-input) {
+    flex: 1;
+    --input-container-margin: 0;
+  }
+  .muted {
+    color: var(--text-tertiary);
+  }
+  .ss-grid {
+    display: grid;
+    gap: var(--space-3);
+  }
+  .ss-card {
+    display: block;
+    padding: var(--space-4);
+    background: var(--component-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    text-decoration: none;
+    transition: border-color var(--transition-fast);
+  }
+  .ss-card:hover {
+    border-color: var(--border-hover);
+  }
+  .ss-card-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+  }
+  .ss-label {
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .ss-meta {
+    display: flex;
+    gap: var(--space-3);
+    color: var(--text-tertiary);
+    font-size: var(--text-xs);
+    margin-top: var(--space-2);
+  }
+</style>

--- a/src/routes/sos/[id]/+page.svelte
+++ b/src/routes/sos/[id]/+page.svelte
@@ -1,0 +1,677 @@
+<script lang="ts">
+  import type {
+    ShooterConfig,
+    SosRoutingRule,
+    SosServerMessage,
+    SosTranscriptEntry,
+    SuperSession,
+  } from '$lib/types';
+
+  import { browser } from '$app/environment';
+  import { page } from '$app/stores';
+  import { Banner, Button, Input, Pill, Select } from '@juspay/svelte-ui-components';
+  import { onDestroy, onMount } from 'svelte';
+
+  const SOURCES = [
+    'claude-code',
+    'codex',
+    'opencode',
+    'gemini',
+    'qwen',
+    'cursor',
+    'copilot',
+    'amp',
+  ];
+
+  const id = $page.params.id ?? '';
+
+  let session = $state<null | SuperSession>(null);
+  let transcript = $state<SosTranscriptEntry[]>([]);
+  let pending = $state<
+    {
+      expiresAt: string;
+      fromMemberId: string;
+      preview: string;
+      relayId: string;
+      toMemberId: string;
+    }[]
+  >([]);
+  let error = $state('');
+  let ws: null | WebSocket = null;
+  let disposed = false;
+
+  // Forward form
+  let fwdMember = $state('');
+  let fwdText = $state('');
+  // Add-member form
+  let amKey = $state('');
+  let amProvider = $state('claude-code');
+  let amTerminal = $state('');
+  // Rule form
+  let rFrom = $state('');
+  let rTo = $state('');
+  let rAction = $state('relay');
+  let rPattern = $state('');
+
+  const members = $derived(session?.members ?? []);
+  const rules = $derived(session?.routingRules ?? []);
+
+  // Pin the merged transcript to the latest message so live updates stay visible.
+  let transcriptEl = $state<HTMLDivElement | undefined>(undefined);
+  $effect(() => {
+    // Reading transcript.length registers the dependency, so this re-runs on
+    // every new entry and keeps the view pinned to the latest message.
+    if (transcriptEl && transcript.length > 0) {
+      transcriptEl.scrollTop = transcriptEl.scrollHeight;
+    }
+  });
+
+  function getConfig(): null | ShooterConfig {
+    try {
+      const saved = localStorage.getItem('shooter_config');
+      return saved ? (JSON.parse(saved) as ShooterConfig) : null;
+    } catch {
+      return null;
+    }
+  }
+  function apiKey(): string {
+    return getConfig()?.apiKey ?? '';
+  }
+  function authHeaders(json = false): Record<string, string> {
+    const h: Record<string, string> = { Authorization: `Bearer ${apiKey()}` };
+    if (json) {
+      h['Content-Type'] = 'application/json';
+    }
+    return h;
+  }
+  function memberLabel(memberId: string): string {
+    const m = members.find((x) => x.id === memberId);
+    return m ? `${providerLabel(m.provider)} · ${m.id.slice(0, 6)}` : memberId.slice(0, 6);
+  }
+  function providerLabel(p: string): string {
+    return p === 'claude-code' ? 'Claude' : p.charAt(0).toUpperCase() + p.slice(1);
+  }
+  function entryText(entry: SosTranscriptEntry): string {
+    return entry.message.parts
+      .map((part) => {
+        if (part.type === 'text' || part.type === 'thinking') {
+          return part.content;
+        }
+        if (part.type === 'tool_use') {
+          return `🔧 ${part.toolName}`;
+        }
+        return `↳ ${part.output.slice(0, 200)}`;
+      })
+      .join('\n')
+      .trim();
+  }
+
+  async function loadSession(): Promise<boolean> {
+    try {
+      const res = await fetch(`/api/sos/${id}`, { headers: authHeaders() });
+      if (!res.ok) {
+        error = res.status === 404 ? 'Super-session not found' : `Failed to load (${res.status})`;
+        return false;
+      }
+      session = (await res.json()) as SuperSession;
+      transcript = session.transcript ?? [];
+      if (!fwdMember && members[0]) {
+        fwdMember = members[0].id;
+      }
+      return true;
+    } catch {
+      error = 'Network error';
+      return false;
+    }
+  }
+
+  async function connectWs(): Promise<void> {
+    try {
+      const res = await fetch('/api/ws-ticket', { headers: authHeaders(), method: 'POST' });
+      if (!res.ok) {
+        error = 'Failed to open the live connection (ticket request failed)';
+        return;
+      }
+      const { ticket } = (await res.json()) as { ticket: string };
+      if (disposed) {
+        return;
+      }
+      const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      ws = new WebSocket(
+        `${proto}//${window.location.host}/ws/super-session/${id}?ticket=${ticket}`
+      );
+      ws.onmessage = (ev): void => {
+        let msg: SosServerMessage;
+        try {
+          msg = JSON.parse(ev.data as string) as SosServerMessage;
+        } catch {
+          return;
+        }
+        handleWs(msg);
+      };
+      ws.onerror = (): void => {
+        error = 'Live connection error';
+      };
+    } catch {
+      error = 'Failed to open the live connection (network error)';
+    }
+  }
+
+  function handleWs(msg: SosServerMessage): void {
+    switch (msg.type) {
+      case 'sos-error':
+        error = msg.message;
+        break;
+      case 'sos-history':
+        transcript = msg.entries;
+        break;
+      case 'sos-member-added':
+        if (session) {
+          session = { ...session, members: [...session.members, msg.member] };
+        }
+        break;
+      case 'sos-member-removed':
+        if (session) {
+          session = { ...session, members: session.members.filter((m) => m.id !== msg.memberId) };
+        }
+        break;
+      case 'sos-message':
+        transcript = [...transcript, msg.entry];
+        break;
+      case 'sos-relay-pending':
+        pending = [
+          ...pending,
+          {
+            expiresAt: msg.expiresAt,
+            fromMemberId: msg.fromMemberId,
+            preview: msg.preview,
+            relayId: msg.relayId,
+            toMemberId: msg.toMemberId,
+          },
+        ];
+        break;
+      case 'sos-relay-resolved':
+        pending = pending.filter((p) => p.relayId !== msg.relayId);
+        break;
+    }
+  }
+
+  function sendWs(payload: Record<string, unknown>): void {
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(payload));
+    }
+  }
+
+  async function forward(): Promise<void> {
+    if (!fwdMember || !fwdText.trim()) {
+      return;
+    }
+    try {
+      const res = await fetch(`/api/sos/${id}/inject`, {
+        body: JSON.stringify({ text: fwdText, toMemberId: fwdMember }),
+        headers: authHeaders(true),
+        method: 'POST',
+      });
+      if (!res.ok) {
+        const d = (await res.json().catch(() => ({}))) as { error?: string };
+        error = d.error ?? 'Failed to forward message';
+        return;
+      }
+      fwdText = '';
+    } catch {
+      error = 'Network error — could not forward message';
+    }
+  }
+
+  async function addMember(): Promise<void> {
+    if (!amKey.trim()) {
+      return;
+    }
+    try {
+      const res = await fetch(`/api/sos/${id}/members`, {
+        body: JSON.stringify({
+          provider: amProvider,
+          sessionKey: amKey.trim(),
+          terminalId: amTerminal.trim() || undefined,
+        }),
+        headers: authHeaders(true),
+        method: 'POST',
+      });
+      if (res.ok) {
+        amKey = '';
+        amTerminal = '';
+      } else {
+        const d = (await res.json().catch(() => ({}))) as { error?: string };
+        error = d.error ?? 'Failed to add member';
+      }
+    } catch {
+      error = 'Network error — could not add member';
+    }
+  }
+
+  async function removeMember(memberId: string): Promise<void> {
+    try {
+      const res = await fetch(`/api/sos/${id}/members/${memberId}`, {
+        headers: authHeaders(),
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const d = (await res.json().catch(() => ({}))) as { error?: string };
+        error = d.error ?? 'Failed to remove member';
+      }
+    } catch {
+      error = 'Network error — could not remove member';
+    }
+  }
+
+  async function addRule(): Promise<void> {
+    if (!rFrom || !rTo) {
+      return;
+    }
+    const next: SosRoutingRule[] = [
+      ...rules,
+      {
+        action: rAction as SosRoutingRule['action'],
+        fromMemberId: rFrom,
+        id: '',
+        matchPattern: rPattern,
+        priority: rules.length + 1,
+        toMemberId: rTo,
+      },
+    ];
+    try {
+      const res = await fetch(`/api/sos/${id}/rules`, {
+        body: JSON.stringify({ routingRules: next }),
+        headers: authHeaders(true),
+        method: 'PATCH',
+      });
+      if (res.ok && session) {
+        const d = (await res.json()) as { routingRules: SosRoutingRule[] };
+        session = { ...session, routingRules: d.routingRules };
+        rPattern = '';
+      } else {
+        const d = (await res.json().catch(() => ({}))) as { error?: string };
+        error = d.error ?? 'Failed to add rule';
+      }
+    } catch {
+      error = 'Network error — could not add rule';
+    }
+  }
+
+  async function deleteRule(ruleId: string): Promise<void> {
+    const next = rules.filter((r) => r.id !== ruleId);
+    try {
+      const res = await fetch(`/api/sos/${id}/rules`, {
+        body: JSON.stringify({ routingRules: next }),
+        headers: authHeaders(true),
+        method: 'PATCH',
+      });
+      if (res.ok && session) {
+        session = { ...session, routingRules: next };
+      } else if (!res.ok) {
+        const d = (await res.json().catch(() => ({}))) as { error?: string };
+        error = d.error ?? 'Failed to delete rule';
+      }
+    } catch {
+      error = 'Network error — could not delete rule';
+    }
+  }
+
+  onMount(() => {
+    if (!browser) {
+      return;
+    }
+    // Only open the live socket when the initial load succeeded — otherwise a
+    // ticket/WS failure would overwrite the real 401/404 error message.
+    void loadSession().then((loaded) => {
+      if (loaded && !disposed) {
+        void connectWs();
+      }
+    });
+    return (): void => {
+      disposed = true;
+      ws?.close();
+    };
+  });
+  onDestroy(() => {
+    disposed = true;
+    ws?.close();
+  });
+</script>
+
+<svelte:head><title>{session?.label ?? 'Super-session'} - Shooter</title></svelte:head>
+
+<main class="main sos-view">
+  <a class="back" href="/sos">← All super-sessions</a>
+
+  {#if error}
+    <Banner text={error} classes="banner-error" />
+  {/if}
+
+  {#if session}
+    <div class="head">
+      <h1>{session.label}</h1>
+      <Pill text={`${members.length} members`} classes="pill-status-unknown" />
+    </div>
+
+    {#each pending as p (p.relayId)}
+      <div class="pending">
+        <span class="pending-text">
+          Relay {memberLabel(p.fromMemberId)} → {memberLabel(p.toMemberId)}: <em>{p.preview}</em>
+        </span>
+        <div class="pending-actions">
+          <Button
+            text="Approve"
+            classes="btn-approve"
+            onclick={(): void => {
+              sendWs({ relayId: p.relayId, type: 'relay-approve' });
+            }}
+          />
+          <Button
+            text="Deny"
+            classes="btn-deny"
+            onclick={(): void => {
+              sendWs({ relayId: p.relayId, type: 'relay-deny' });
+            }}
+          />
+        </div>
+      </div>
+    {/each}
+
+    <!-- Merged transcript -->
+    <section class="panel">
+      <h2>Merged transcript</h2>
+      <div class="transcript" bind:this={transcriptEl}>
+        {#if transcript.length === 0}
+          <p class="muted">No messages yet. Add members below.</p>
+        {/if}
+        {#each transcript as entry, i (`${entry.message.id}-${i}`)}
+          <div class="entry" class:relayed={entry.relayed}>
+            <div class="entry-tag">
+              <Pill
+                text={providerLabel(entry.provider)}
+                classes={`pill-source-${entry.provider}`}
+              />
+              <span class="member-id">{entry.memberId.slice(0, 6)}</span>
+              {#if entry.relayed}<span class="relay-badge">relayed</span>{/if}
+            </div>
+            <pre class="entry-body">{entryText(entry)}</pre>
+          </div>
+        {/each}
+      </div>
+    </section>
+
+    <!-- Forward -->
+    <section class="panel">
+      <h2>Forward to a member</h2>
+      <div class="row">
+        <Select
+          items={members.map((m) => ({ id: m.id, label: memberLabel(m.id) }))}
+          value={fwdMember ? [fwdMember] : []}
+          placeholder="Member"
+          onchange={(v: string[]): void => {
+            fwdMember = v[0] ?? '';
+          }}
+          classes="sos-select"
+        />
+        <Input
+          bind:value={fwdText}
+          dataType="text"
+          placeholder="Message to inject…"
+          classes="sos-input"
+        />
+        <Button
+          text="Send"
+          disabled={!fwdMember || !fwdText.trim()}
+          onclick={forward}
+          classes="btn-send"
+        />
+      </div>
+    </section>
+
+    <!-- Members -->
+    <section class="panel">
+      <h2>Members</h2>
+      {#each members as m (m.id)}
+        <div class="member-row">
+          <Pill text={providerLabel(m.provider)} classes={`pill-source-${m.provider}`} />
+          <span class="member-key" title={m.sessionKey}>{m.sessionKey}</span>
+          <span class="member-flag">{m.terminalId ? '⌁ terminal' : 'observed'}</span>
+          <Button
+            text="Remove"
+            classes="btn-remove"
+            onclick={(): void => {
+              void removeMember(m.id);
+            }}
+          />
+        </div>
+      {/each}
+      <div class="row add-row">
+        <Input
+          bind:value={amKey}
+          dataType="text"
+          placeholder="sessionKey (file path or session id)"
+          classes="sos-input"
+        />
+        <Select
+          items={SOURCES.map((s) => ({ id: s, label: providerLabel(s) }))}
+          value={[amProvider]}
+          onchange={(v: string[]): void => {
+            amProvider = v[0] ?? 'claude-code';
+          }}
+          classes="sos-select"
+        />
+        <Input
+          bind:value={amTerminal}
+          dataType="text"
+          placeholder="terminalId (optional)"
+          classes="sos-input"
+        />
+        <Button text="Add" disabled={!amKey.trim()} onclick={addMember} classes="btn-send" />
+      </div>
+    </section>
+
+    <!-- Routing rules -->
+    <section class="panel">
+      <h2>Routing rules</h2>
+      {#each rules as r (r.id)}
+        <div class="rule-row">
+          <span>{memberLabel(r.fromMemberId)} → {memberLabel(r.toMemberId)}</span>
+          <span class="rule-action">{r.action}</span>
+          <span class="rule-pattern">{r.matchPattern || '(any)'}</span>
+          <Button
+            text="✕"
+            classes="btn-remove"
+            onclick={(): void => {
+              void deleteRule(r.id);
+            }}
+          />
+        </div>
+      {/each}
+      <div class="row add-row">
+        <Select
+          items={members.map((m) => ({ id: m.id, label: memberLabel(m.id) }))}
+          value={rFrom ? [rFrom] : []}
+          placeholder="From"
+          onchange={(v: string[]): void => {
+            rFrom = v[0] ?? '';
+          }}
+          classes="sos-select"
+        />
+        <Select
+          items={members.map((m) => ({ id: m.id, label: memberLabel(m.id) }))}
+          value={rTo ? [rTo] : []}
+          placeholder="To"
+          onchange={(v: string[]): void => {
+            rTo = v[0] ?? '';
+          }}
+          classes="sos-select"
+        />
+        <Select
+          items={[
+            { id: 'relay', label: 'relay' },
+            { id: 'block', label: 'block' },
+            { id: 'escalate', label: 'escalate' },
+          ]}
+          value={[rAction]}
+          onchange={(v: string[]): void => {
+            rAction = v[0] ?? 'relay';
+          }}
+          classes="sos-select"
+        />
+        <Input
+          bind:value={rPattern}
+          dataType="text"
+          placeholder="match (substring, empty=any)"
+          classes="sos-input"
+        />
+        <Button text="Add rule" disabled={!rFrom || !rTo} onclick={addRule} classes="btn-send" />
+      </div>
+    </section>
+  {/if}
+</main>
+
+<style>
+  .sos-view {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: var(--space-4);
+  }
+  .back {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: var(--text-sm);
+  }
+  .head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: var(--space-3) 0;
+  }
+  .head h1 {
+    font-size: var(--text-xl);
+    font-weight: 600;
+    margin: 0;
+    color: var(--text-primary);
+  }
+  .panel {
+    background: var(--component-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-3) var(--space-4);
+    margin-bottom: var(--space-3);
+  }
+  .panel h2 {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin: 0 0 var(--space-2);
+  }
+  .transcript {
+    max-height: 50vh;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+  .entry {
+    border-left: 2px solid var(--border);
+    padding-left: var(--space-2);
+  }
+  .entry.relayed {
+    border-left-color: var(--ds-green-700);
+  }
+  .entry-tag {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+  .member-id {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+  }
+  .relay-badge {
+    font-size: var(--text-xs);
+    color: var(--ds-green-700);
+  }
+  .entry-body {
+    margin: var(--space-1) 0 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: inherit;
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+  }
+  .row {
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .add-row {
+    margin-top: var(--space-2);
+  }
+  :global(.sos-input) {
+    flex: 1;
+    min-width: 140px;
+    --input-container-margin: 0;
+  }
+  :global(.sos-select) {
+    min-width: 120px;
+  }
+  .member-row,
+  .rule-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-1) 0;
+    border-bottom: 1px solid var(--border);
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+  }
+  .member-key {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--font-mono, monospace);
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+  }
+  .member-flag,
+  .rule-action {
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+  }
+  .rule-pattern {
+    flex: 1;
+    font-family: var(--font-mono, monospace);
+    font-size: var(--text-xs);
+  }
+  .muted {
+    color: var(--text-tertiary);
+  }
+  .pending {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    background: var(--component-bg-hover);
+    border: 1px solid var(--ds-green-700);
+    border-radius: var(--radius-md);
+    margin-bottom: var(--space-2);
+  }
+  .pending-text {
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+  }
+  .pending-actions {
+    display: flex;
+    gap: var(--space-2);
+    flex-shrink: 0;
+  }
+</style>

--- a/tests/provider-readers.test.cjs
+++ b/tests/provider-readers.test.cjs
@@ -49,6 +49,7 @@ const SESSIONS = '../src/lib/modules/server/sessions';
 const cursor = require(`${SESSIONS}/cursor-reader.ts`);
 const copilot = require(`${SESSIONS}/copilot-reader.ts`);
 const amp = require(`${SESSIONS}/amp-reader.ts`);
+const providerPaths = require(`${SESSIONS}/provider-paths.ts`);
 
 let passed = 0;
 function check(name, fn) {
@@ -100,6 +101,47 @@ check('cursor tool_use blocks carry name + input', () => {
 check('cursor thinking blocks preserve their text', () => {
   const msgs = cursor.getCursorConversation('abc123');
   assert.strictEqual(firstOfType(msgs[3], 'thinking').content, 'Let me reason...');
+});
+
+// ── Launch-time discovery (the path that makes Shooter-launched live-tail engage) ──
+console.log('provider-readers: discovery');
+
+check('resolveReadOnlyProviderFile maps a cursor session id to its staged path', () => {
+  const p = providerPaths.resolveReadOnlyProviderFile('cursor', 'abc123');
+  assert.ok(typeof p === 'string' && p.endsWith('/agent-transcripts/abc123.jsonl'), `got ${p}`);
+});
+
+check('discoverReadOnlyProviderSessionFile picks a session created after launch', () => {
+  // WRITE (not copy) a fresh transcript so its birthtime == now — this models a
+  // real `cursor-agent` launch, which creates a brand-new session file. (Copying
+  // would clone the fixture's old birthtime on APFS and be wrongly filtered out.)
+  const freshDir = path.join(HOME, '.cursor/projects/-Users-dev-fresh/agent-transcripts');
+  fs.mkdirSync(freshDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(freshDir, 'fresh999.jsonl'),
+    fs.readFileSync(path.join(FIXTURES, 'cursor/transcript.jsonl'))
+  );
+  const now = Date.now();
+  const file = providerPaths.discoverReadOnlyProviderSessionFile(
+    'cursor',
+    '/Users/dev/fresh',
+    now - 3000,
+    now
+  );
+  assert.ok(typeof file === 'string' && file.endsWith('fresh999.jsonl'), `expected fresh999.jsonl, got ${file}`);
+});
+
+check('discoverReadOnlyProviderSessionFile returns null when no session started after launch', () => {
+  // Launch timestamp in the future → nothing qualifies → null (the silent-degrade
+  // branch that would leave a Shooter-launched terminal without a session key).
+  const now = Date.now();
+  const file = providerPaths.discoverReadOnlyProviderSessionFile(
+    'cursor',
+    '/Users/dev/fresh',
+    now + 100_000,
+    now + 100_000
+  );
+  assert.strictEqual(file, null);
 });
 
 // ── Copilot ─────────────────────────────────────────────────────────────

--- a/tests/pty-input.test.cjs
+++ b/tests/pty-input.test.cjs
@@ -1,0 +1,64 @@
+/**
+ * Tests for ptySubmitSequence — the PTY byte sequence that delivers and submits
+ * a message to an interactive agent TUI.
+ *
+ * The bug this guards against: a bare LF (`\n`) never submits to an agent TUI
+ * (raw mode), and `"<text>\r"` in one write is absorbed as a bracketed paste so
+ * the CR doesn't submit either. The fix wraps the body in an explicit bracketed
+ * paste (ESC[200~ … ESC[201~) followed by a CR, which submits reliably and was
+ * verified live against codex 0.136 and claude 2.1.
+ */
+
+'use strict';
+
+const assert = require('node:assert');
+
+require('tsx/cjs');
+const { ptySubmitSequence } = require('../src/lib/modules/server/terminal/pty-input.ts');
+
+const START = '\x1b[200~';
+const END = '\x1b[201~';
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`  ok ${name}`);
+}
+
+console.log('ptySubmitSequence:');
+
+test('wraps the body in a bracketed paste and ends with a single CR', () => {
+  assert.strictEqual(ptySubmitSequence('hello'), `${START}hello${END}\r`);
+});
+
+test('never emits a bare LF as the submit byte', () => {
+  const seq = ptySubmitSequence('do the thing');
+  assert.ok(!seq.endsWith('\n'), 'must not submit with LF');
+  assert.ok(seq.endsWith('\r'), 'must submit with CR');
+});
+
+test('strips a trailing newline the caller appended (LF)', () => {
+  assert.strictEqual(ptySubmitSequence('review this\n'), `${START}review this${END}\r`);
+});
+
+test('strips trailing CR / CRLF / multiple newlines', () => {
+  assert.strictEqual(ptySubmitSequence('a\r'), `${START}a${END}\r`);
+  assert.strictEqual(ptySubmitSequence('b\r\n'), `${START}b${END}\r`);
+  assert.strictEqual(ptySubmitSequence('c\n\n\n'), `${START}c${END}\r`);
+});
+
+test('preserves embedded newlines inside the paste (multi-line fidelity)', () => {
+  const body = 'line one\nline two\nline three';
+  assert.strictEqual(ptySubmitSequence(`${body}\n`), `${START}${body}${END}\r`);
+});
+
+test('produces exactly one CR (no premature submit inside the body)', () => {
+  const seq = ptySubmitSequence('para one\npara two');
+  assert.strictEqual((seq.match(/\r/g) || []).length, 1);
+});
+
+test('handles an empty string', () => {
+  assert.strictEqual(ptySubmitSequence(''), `${START}${END}\r`);
+});
+
+console.log(`\n${passed} passed`);

--- a/tests/sos-coordinator.test.cjs
+++ b/tests/sos-coordinator.test.cjs
@@ -1,0 +1,185 @@
+/**
+ * Integration test for the Session-Over-Sessions coordinator (Phase 1 MVP).
+ *
+ * Drives the real coordinator with the real generic-session-watcher (so member
+ * subscription + live merge go through production code) and a fake injector.
+ * Verifies: create, add member + history replay into the merged transcript,
+ * live merge of a new message, relay-forward (injector called + relayed entry
+ * recorded), the no-terminal guard, member removal, and delete.
+ *
+ * HOME is pointed at a temp dir BEFORE requiring the coordinator so relay-store
+ * writes its SQLite db there, not into the real ~/.shooter.
+ */
+
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'shooter-sos-'));
+process.env.HOME = HOME;
+
+require('tsx/cjs');
+const { sosCoordinator } = require('../src/lib/modules/server/sos/coordinator.ts');
+const {
+  genericSessionWatcher,
+} = require('../src/lib/modules/server/terminal/generic-session-watcher.ts');
+
+// Wire the coordinator: real watcher + a fake injector that records calls.
+const injectorCalls = [];
+sosCoordinator.setWatcher(genericSessionWatcher);
+sosCoordinator.setInjector((terminalId, text) => {
+  injectorCalls.push({ terminalId, text });
+  return { ok: true };
+});
+
+function stage(relInHome, fixtureRel) {
+  const dest = path.join(HOME, relInHome);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(path.join(FIXTURES, fixtureRel), dest);
+  return dest;
+}
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+async function waitUntil(pred, timeoutMs, stepMs = 100) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (pred()) return true;
+    await delay(stepMs);
+  }
+  return pred();
+}
+const hasText = (msg, needle) =>
+  msg.parts.some((p) => p.type === 'text' && p.content.includes(needle));
+const sosMessages = (events) => events.filter((e) => e.type === 'sos-message');
+
+let passed = 0;
+const pending = [];
+function acheck(name, fn) {
+  pending.push({ fn, name });
+}
+
+const m1File = stage('.cursor/projects/-Users-dev-a/agent-transcripts/member1.jsonl', 'cursor/transcript.jsonl');
+const m2File = stage('.cursor/projects/-Users-dev-b/agent-transcripts/member2.jsonl', 'cursor/transcript.jsonl');
+
+(async () => {
+  const events = [];
+  let superId = '';
+  let m1Id = '';
+  let m2Id = '';
+
+  acheck('createSuperSession returns an active session with an id', () => {
+    const ss = sosCoordinator.createSuperSession('test-sos');
+    superId = ss.id;
+    assert.ok(superId, 'no id');
+    assert.strictEqual(ss.status, 'active');
+    assert.strictEqual(ss.members.length, 0);
+  });
+
+  acheck('subscribe replays an (empty) sos-history immediately', () => {
+    sosCoordinator.subscribe(superId, (m) => events.push(m));
+    assert.strictEqual(events[0].type, 'sos-history');
+    assert.strictEqual(events[0].entries.length, 0);
+  });
+
+  acheck('addMember replays the member history into the merged transcript', () => {
+    const m1 = sosCoordinator.addMember(superId, {
+      provider: 'cursor',
+      sessionKey: m1File,
+      terminalId: null,
+    });
+    m1Id = m1.id;
+    const msgs = sosMessages(events);
+    assert.strictEqual(msgs.length, 6, `expected 6 replayed msgs, got ${msgs.length}`);
+    assert.strictEqual(msgs[0].entry.memberId, m1Id);
+    assert.strictEqual(msgs[0].entry.provider, 'cursor');
+    assert.strictEqual(msgs[0].entry.relayed, false);
+    assert.ok(events.some((e) => e.type === 'sos-member-added'));
+    assert.strictEqual(sosCoordinator.getSuperSession(superId).transcript.length, 6);
+  });
+
+  acheck('a new message in a member file is merged live', async () => {
+    await delay(600); // let chokidar finish attaching the member's watcher
+    const before = sosMessages(events).length;
+    fs.appendFileSync(
+      m1File,
+      `\n${JSON.stringify({ message: { content: 'SOS_LIVE_MERGE' }, role: 'user' })}\n`
+    );
+    const ok = await waitUntil(
+      () => sosMessages(events).some((e) => hasText(e.entry.message, 'SOS_LIVE_MERGE')),
+      6000
+    );
+    assert.ok(ok, 'live-merged message not received');
+    const live = sosMessages(events).find((e) => hasText(e.entry.message, 'SOS_LIVE_MERGE'));
+    assert.strictEqual(live.entry.memberId, m1Id);
+    assert.ok(sosMessages(events).length > before);
+  });
+
+  acheck('relay-forward to a member with no terminal is rejected', () => {
+    const err = sosCoordinator.relayForward(superId, m1Id, 'hi');
+    assert.ok(err && err.includes('no Shooter-owned terminal'), `expected guard error, got: ${err}`);
+    assert.strictEqual(injectorCalls.length, 0);
+  });
+
+  acheck('relay-forward to a terminal-backed member injects + records a relayed entry', () => {
+    const m2 = sosCoordinator.addMember(superId, {
+      provider: 'cursor',
+      sessionKey: m2File,
+      terminalId: 'fake-terminal-1',
+    });
+    m2Id = m2.id;
+    const err = sosCoordinator.relayForward(superId, m2Id, 'do-the-thing');
+    assert.strictEqual(err, null, `unexpected error: ${err}`);
+    assert.strictEqual(injectorCalls.length, 1);
+    assert.strictEqual(injectorCalls[0].terminalId, 'fake-terminal-1');
+    assert.strictEqual(injectorCalls[0].text, 'do-the-thing');
+    const relayed = sosMessages(events).find((e) => e.entry.relayed === true);
+    assert.ok(relayed, 'no relayed entry recorded');
+    assert.strictEqual(relayed.entry.memberId, m2Id);
+    assert.ok(hasText(relayed.entry.message, 'do-the-thing'));
+  });
+
+  acheck('relay-store persists the super-session + members for restart recovery', () => {
+    // This is exactly what coordinator.reconnectAll() reads on boot.
+    const { relayStore } = require('../src/lib/modules/server/sos/relay-store.ts');
+    const persisted = relayStore.loadAll().find((s) => s.id === superId);
+    assert.ok(persisted, 'super-session not persisted to SQLite');
+    assert.strictEqual(persisted.members.length, 2);
+    assert.ok(persisted.members.some((m) => m.terminalId === 'fake-terminal-1'));
+    assert.strictEqual(persisted.transcript.length, 0); // transcript is in-memory only by design
+  });
+
+  acheck('removeMember unsubscribes and drops the member', () => {
+    assert.strictEqual(sosCoordinator.removeMember(superId, m1Id), true);
+    assert.strictEqual(sosCoordinator.getSuperSession(superId).members.length, 1);
+    assert.ok(events.some((e) => e.type === 'sos-member-removed'));
+  });
+
+  acheck('listSuperSessions includes it; deleteSuperSession tears it down', () => {
+    assert.ok(sosCoordinator.listSuperSessions().some((s) => s.id === superId));
+    assert.strictEqual(sosCoordinator.deleteSuperSession(superId), true);
+    assert.strictEqual(sosCoordinator.getSuperSession(superId), undefined);
+  });
+
+  for (const { fn, name } of pending) {
+    try {
+      await fn();
+      passed++;
+      console.log(`  ✓ ${name}`);
+    } catch (err) {
+      console.error(`  ✗ ${name}\n    ${err.message}`);
+      process.exitCode = 1;
+    }
+  }
+
+  try {
+    genericSessionWatcher.stopAll();
+    fs.rmSync(HOME, { force: true, recursive: true });
+  } catch {
+    // best-effort
+  }
+  console.log(`\nsos-coordinator: ${passed} checks passed${process.exitCode ? ' (with failures)' : ''}`);
+})();

--- a/tests/sos-policy.test.cjs
+++ b/tests/sos-policy.test.cjs
@@ -1,0 +1,207 @@
+/**
+ * Tests for SoS Phase 2 — the Tier-1 routing policy gate and the coordinator's
+ * auto-relay path (relay / block / escalate), loop guards, and cooldown.
+ *
+ * Pure checks exercise evaluateRelayRule + isValidRoutingRule directly. The live
+ * checks drive the real coordinator (with the real generic-session-watcher and a
+ * fake injector): a routing rule auto-relays a member's new message into another
+ * member's terminal; relayed messages don't re-trigger routing (loop guard); a
+ * rapid second match is suppressed by cooldown; an escalate rule queues a
+ * pending relay that injects only on approval.
+ */
+
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'shooter-sospolicy-'));
+process.env.HOME = HOME;
+
+require('tsx/cjs');
+const { evaluateRelayRule, isValidRoutingRule } = require('../src/lib/modules/server/sos/policy-gate.ts');
+const { sosCoordinator } = require('../src/lib/modules/server/sos/coordinator.ts');
+const {
+  genericSessionWatcher,
+} = require('../src/lib/modules/server/terminal/generic-session-watcher.ts');
+
+const injectorCalls = [];
+sosCoordinator.setWatcher(genericSessionWatcher);
+sosCoordinator.setInjector((terminalId, text) => {
+  injectorCalls.push({ terminalId, text });
+  return { ok: true };
+});
+
+const rule = (o) => ({
+  action: 'relay',
+  fromMemberId: 'ANY',
+  id: 'r',
+  matchPattern: '',
+  priority: 100,
+  toMemberId: 'B',
+  ...o,
+});
+const stage = (rel, fix) => {
+  const dest = path.join(HOME, rel);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(path.join(FIXTURES, fix), dest);
+  return dest;
+};
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+async function waitUntil(pred, timeoutMs, stepMs = 100) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (pred()) return true;
+    await delay(stepMs);
+  }
+  return pred();
+}
+const appendUser = (file, content) =>
+  fs.appendFileSync(file, `\n${JSON.stringify({ message: { content }, role: 'user' })}\n`);
+
+let passed = 0;
+const pending = [];
+const check = (name, fn) => {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    console.error(`  ✗ ${name}\n    ${e.message}`);
+    process.exitCode = 1;
+  }
+};
+const acheck = (name, fn) => pending.push({ fn, name });
+
+// ── Pure policy gate ────────────────────────────────────────────────────
+console.log('sos-policy: evaluateRelayRule / isValidRoutingRule');
+
+check('matches on fromMemberId + substring pattern', () => {
+  const r = rule({ fromMemberId: 'A', matchPattern: 'deploy' });
+  assert.strictEqual(evaluateRelayRule([r], 'A', 'please DEPLOY now').id, 'r'); // case-insensitive
+  assert.strictEqual(evaluateRelayRule([r], 'B', 'please deploy now'), null); // wrong sender
+  assert.strictEqual(evaluateRelayRule([r], 'A', 'nothing here'), null); // pattern miss
+});
+
+check('fromMemberId ANY matches any sender; empty pattern matches all text', () => {
+  const r = rule({ fromMemberId: 'ANY', matchPattern: '' });
+  assert.strictEqual(evaluateRelayRule([r], 'anyone', 'whatever').id, 'r');
+});
+
+check('ANY -> member rule never matches a message from that same member (self-relay guard)', () => {
+  const r = rule({ fromMemberId: 'ANY', toMemberId: 'B' });
+  assert.strictEqual(evaluateRelayRule([r], 'B', 'whatever'), null); // would self-relay
+  assert.strictEqual(evaluateRelayRule([r], 'A', 'whatever').id, 'r'); // other senders still match
+});
+
+check('lowest priority wins', () => {
+  const lo = rule({ action: 'block', id: 'lo', priority: 1 });
+  const hi = rule({ action: 'relay', id: 'hi', priority: 9 });
+  assert.strictEqual(evaluateRelayRule([hi, lo], 'A', 'x').id, 'lo');
+});
+
+check('isValidRoutingRule rejects self-relay and ANY destination', () => {
+  assert.strictEqual(isValidRoutingRule(rule({ fromMemberId: 'A', toMemberId: 'A' })), false);
+  assert.strictEqual(isValidRoutingRule(rule({ toMemberId: 'ANY' })), false);
+  assert.strictEqual(isValidRoutingRule(rule({ fromMemberId: 'A', toMemberId: 'B' })), true);
+});
+
+// ── Live coordinator auto-relay ─────────────────────────────────────────
+const fromFile = stage('.cursor/projects/-Users-x-from/agent-transcripts/from.jsonl', 'cursor/transcript.jsonl');
+const toFile = stage('.cursor/projects/-Users-x-to/agent-transcripts/to.jsonl', 'cursor/transcript.jsonl');
+
+(async () => {
+  console.log('sos-policy: live auto-relay');
+  const ss = sosCoordinator.createSuperSession('policy');
+  const A = sosCoordinator.addMember(ss.id, { provider: 'cursor', sessionKey: fromFile, terminalId: null });
+  const B = sosCoordinator.addMember(ss.id, { provider: 'cursor', sessionKey: toFile, terminalId: 'term-B' });
+  const events = [];
+  sosCoordinator.subscribe(ss.id, (m) => events.push(m));
+  await delay(500); // let watchers attach
+
+  acheck('a relay rule auto-injects a matching member message into the target terminal', async () => {
+    sosCoordinator.setRoutingRules(ss.id, [
+      { action: 'relay', fromMemberId: A.id, id: 'r1', matchPattern: 'deploy', priority: 1, toMemberId: B.id },
+    ]);
+    appendUser(fromFile, 'please deploy the build');
+    const ok = await waitUntil(() => injectorCalls.some((c) => c.terminalId === 'term-B'), 6000);
+    assert.ok(ok, 'auto-relay did not inject into term-B');
+    assert.ok(injectorCalls.find((c) => c.terminalId === 'term-B').text.includes('deploy'));
+    assert.ok(events.some((e) => e.type === 'sos-message' && e.entry.relayed === true && e.entry.memberId === B.id));
+  });
+
+  acheck('a relayed message does not itself trigger another relay (loop guard)', async () => {
+    const before = injectorCalls.length;
+    await delay(1200); // relayed entry was appended to the transcript; ensure no cascade
+    assert.strictEqual(injectorCalls.length, before, 'a relayed entry triggered a further relay');
+  });
+
+  acheck('cooldown suppresses a rapid second matching message', async () => {
+    const before = injectorCalls.filter((c) => c.terminalId === 'term-B').length;
+    appendUser(fromFile, 'deploy again immediately');
+    await delay(1500);
+    const after = injectorCalls.filter((c) => c.terminalId === 'term-B').length;
+    assert.strictEqual(after, before, `cooldown failed: ${before} -> ${after}`);
+  });
+
+  console.log('sos-policy: live escalate (HITL)');
+  const ss2 = sosCoordinator.createSuperSession('escalate');
+  const fromFile2 = stage('.cursor/projects/-Users-y-from/agent-transcripts/from2.jsonl', 'cursor/transcript.jsonl');
+  const toFile2 = stage('.cursor/projects/-Users-y-to/agent-transcripts/to2.jsonl', 'cursor/transcript.jsonl');
+  const A2 = sosCoordinator.addMember(ss2.id, { provider: 'cursor', sessionKey: fromFile2, terminalId: null });
+  const B2 = sosCoordinator.addMember(ss2.id, { provider: 'cursor', sessionKey: toFile2, terminalId: 'term-B2' });
+  const events2 = [];
+  sosCoordinator.subscribe(ss2.id, (m) => events2.push(m));
+  await delay(500);
+
+  acheck('an escalate rule queues a pending relay without injecting', async () => {
+    sosCoordinator.setRoutingRules(ss2.id, [
+      { action: 'escalate', fromMemberId: A2.id, id: 'e1', matchPattern: 'review', priority: 1, toMemberId: B2.id },
+    ]);
+    const injectsBefore = injectorCalls.length;
+    appendUser(fromFile2, 'please review this change');
+    const ok = await waitUntil(() => events2.some((e) => e.type === 'sos-relay-pending'), 6000);
+    assert.ok(ok, 'no sos-relay-pending emitted');
+    assert.strictEqual(injectorCalls.length, injectsBefore, 'escalate injected before approval');
+  });
+
+  acheck('approving a pending relay injects it and resolves approved', async () => {
+    const pendingEvt = events2.find((e) => e.type === 'sos-relay-pending');
+    const injectsBefore = injectorCalls.length;
+    assert.strictEqual(sosCoordinator.approveRelay(ss2.id, pendingEvt.relayId), true);
+    assert.strictEqual(injectorCalls.length, injectsBefore + 1);
+    assert.strictEqual(injectorCalls.at(-1).terminalId, 'term-B2');
+    assert.ok(events2.some((e) => e.type === 'sos-relay-resolved' && e.decision === 'approved'));
+  });
+
+  acheck('self-relay routing rules are rejected by setRoutingRules', () => {
+    const err = sosCoordinator.setRoutingRules(ss.id, [
+      { action: 'relay', fromMemberId: A.id, id: 'bad', matchPattern: '', priority: 1, toMemberId: A.id },
+    ]);
+    assert.ok(typeof err === 'string' && err.includes('itself'), `expected rejection, got ${err}`);
+  });
+
+  for (const { fn, name } of pending) {
+    try {
+      await fn();
+      passed++;
+      console.log(`  ✓ ${name}`);
+    } catch (e) {
+      console.error(`  ✗ ${name}\n    ${e.message}`);
+      process.exitCode = 1;
+    }
+  }
+
+  sosCoordinator.deleteSuperSession(ss.id);
+  sosCoordinator.deleteSuperSession(ss2.id);
+  try {
+    genericSessionWatcher.stopAll();
+    fs.rmSync(HOME, { force: true, recursive: true });
+  } catch {
+    /* best effort */
+  }
+  console.log(`\nsos-policy: ${passed} checks passed${process.exitCode ? ' (with failures)' : ''}`);
+})();


### PR DESCRIPTION
Adds the **Session-Over-Sessions** coordinator that merges multiple agent sessions into one source-tagged transcript, with static-rule auto-relay, a policy gate, HITL escalation, and the `/sos` super-session UI. Relayed input is submitted via **bracketed paste** so agent TUIs actually run it (the fix that was previously unpushed on #82). Includes the SoS design docs and e2e/unit coverage.

**Depends on #84** (base branch).

---

### 📚 Stack — #82 split into 4 single-commit PRs (review & merge 1 → 4)

| # | PR | Scope |
|---|----|-------|
| 1 | #82 | Codex CLI session support |
| 2 | #83 | Provider registry + Gemini & Qwen readers |
| 3 | #84 | Cursor, Copilot & Amp read-only providers |
| 4 | #85 | Session-Over-Sessions coordinator |

Each PR is **one squashed commit**, stacked so each targets the branch below it. Together they reproduce the original #82 branch **byte-for-byte**. GitHub auto-retargets the next PR onto `release` as each one merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session‑Over‑Sessions (SoS) super‑session UI and API: create/list/view/delete, member management, routing rules, live WebSocket updates, and a new SoS nav tab
  * Server-side coordinator and inject/relay support with safe terminal input handling (bracketed‑paste)

* **Documentation**
  * Added detailed SoS concept and concrete design docs with patterns and checklist

* **Tests**
  * End-to-end and unit tests covering SoS coordinator, policy gate, PTY input, and related flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->