### PR TITLE
feat(sharing): password-protected single-terminal sharing

### DIFF
--- a/docs/superpowers/plans/2026-06-11-terminal-sharing.md
+++ b/docs/superpowers/plans/2026-06-11-terminal-sharing.md
@@ -1,0 +1,1641 @@
+# Terminal Sharing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Password-protected sharing of a single terminal at its existing `/terminals/[id]` route, with per-share view-only/full-control mode, active until revoked.
+
+**Architecture:** A `terminal_shares` + `share_sessions` SQLite pair (scrypt password, sha256-hashed guest tokens) feeds a `resolveAccess()` helper that lets four endpoints accept guest bearers; WS tickets gain a `{terminalId, readOnly}` scope enforced centrally at upgrade routing and per-message in the terminal/session handlers. The page detects guest mode, gates with a password prompt, and disables input affordances in view-only mode (server drops them anyway).
+
+**Tech Stack:** SvelteKit (Svelte 5 runes), better-sqlite3, node:crypto (scrypt/sha256/timingSafeEqual), ws, type-crafter YAML types.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-terminal-sharing-design.md`
+
+**Conventions that bind every task:**
+
+- Types only in `src/lib/types/` (ESLint-enforced); import only from `$lib/types`.
+- Strict TS, no `any`, named exports, `import type` for type-only imports.
+- Tests are plain `.cjs` Node scripts in `tests/` that replicate schema/logic (no TS imports), added to the `test` script in `package.json`.
+- Validate with `pnpm gen:types` (after YAML edits), `pnpm lint`, `pnpm check`, `pnpm build`, `pnpm test`.
+- Commit per task; **final step squashes the branch to one semantic commit** (CI enforces 1 commit/branch).
+
+---
+
+### Task 1: Types (YAML specs + hand-written)
+
+**Files:**
+
+- Create: `specs/types/share.yaml`
+- Modify: `specs/types/index.yaml` (add Share group)
+- Modify: `specs/types/ws-protocol.yaml` (Ticket scope fields, TicketScope, server resize broadcast)
+- Modify: `specs/types/client.yaml` (TerminalDetailView: cols/rows/shareMode)
+- Modify: `src/lib/types/ws.ts` (WireTerminalServerMessage resize variant)
+- Modify: `src/lib/types/terminal-client.ts` (TerminalOptions readOnly/initialCols/initialRows, WsTerminalInboundMessage cols/rows, ShareGateProps, ShareSheetProps)
+
+- [ ] **Step 1: Create `specs/types/share.yaml`**
+
+```yaml
+# Terminal Sharing Type Definitions
+# Non-top file - referenced from index.yaml
+# Types for password-protected single-terminal sharing: share records,
+# guest sessions, and the share API request/response shapes.
+
+Share:
+  ShareMode:
+    type: string
+    enum:
+      - view
+      - control
+    description: What a share guest may do — watch only, or full input control
+
+  AccessLevel:
+    type: string
+    enum:
+      - owner
+      - guest
+    description: Authorization level resolved for a terminal-scoped request
+
+  AccessContext:
+    type: object
+    description: Resolved authorization for a terminal-scoped API request
+    required:
+      - level
+    properties:
+      level:
+        $ref: './specs/types/share.yaml#/Share/AccessLevel'
+        description: owner (API key) or guest (share session token)
+      mode:
+        $ref: './specs/types/share.yaml#/Share/ShareMode'
+        description: Guest access mode (present only when level is guest)
+
+  TerminalShareRecord:
+    type: object
+    description: Persisted share configuration for one terminal (terminal_shares table)
+    required:
+      - terminalId
+      - passwordHash
+      - mode
+      - createdAt
+      - updatedAt
+    properties:
+      terminalId:
+        type: string
+        description: Terminal this share belongs to (primary key)
+      passwordHash:
+        type: string
+        description: 'scrypt:<salt-hex>:<hash-hex> password hash'
+      mode:
+        $ref: './specs/types/share.yaml#/Share/ShareMode'
+        description: Access mode granted to guests
+      createdAt:
+        type: number
+        description: Unix timestamp (ms) when the share was created
+      updatedAt:
+        type: number
+        description: Unix timestamp (ms) when the share was last updated
+
+  ShareSessionRecord:
+    type: object
+    description: Persisted guest session (share_sessions table); token stored as sha256 hash
+    required:
+      - tokenHash
+      - terminalId
+      - createdAt
+      - expiresAt
+    properties:
+      tokenHash:
+        type: string
+        description: sha256 hex of the guest bearer token (primary key)
+      terminalId:
+        type: string
+        description: Terminal the session grants access to
+      createdAt:
+        type: number
+        description: Unix timestamp (ms) when the session was created
+      expiresAt:
+        type: number
+        description: Unix timestamp (ms) when the session expires (created + 7 days)
+
+  ShareInfoResponse:
+    type: object
+    description: Owner view of a terminal's share state (GET /api/terminals/[id]/share)
+    required:
+      - active
+    properties:
+      active:
+        type: boolean
+        description: Whether sharing is currently enabled for this terminal
+      mode:
+        $ref: './specs/types/share.yaml#/Share/ShareMode'
+        description: Current access mode (present when active)
+      createdAt:
+        type: number
+        description: Unix timestamp (ms) when the share was created (present when active)
+      updatedAt:
+        type: number
+        description: Unix timestamp (ms) when the share was last updated (present when active)
+
+  ShareStatusResponse:
+    type: object
+    description: Public probe response (GET /api/terminals/[id]/share/status)
+    required:
+      - shared
+    properties:
+      shared:
+        type: boolean
+        description: Whether a share exists for this terminal
+
+  ShareAuthRequest:
+    type: object
+    description: Guest password exchange request (POST /api/terminals/[id]/share/auth)
+    required:
+      - password
+    properties:
+      password:
+        type: string
+        description: The share password
+
+  ShareAuthResponse:
+    type: object
+    description: Guest session issued after successful password exchange
+    required:
+      - token
+      - mode
+      - expiresAt
+    properties:
+      token:
+        type: string
+        description: Guest bearer token (64-char hex, shown once)
+      mode:
+        $ref: './specs/types/share.yaml#/Share/ShareMode'
+        description: Access mode granted by this session
+      expiresAt:
+        type: number
+        description: Unix timestamp (ms) when this session expires
+
+  ShareConfigRequest:
+    type: object
+    description: Owner create/update share request (PUT /api/terminals/[id]/share)
+    required:
+      - mode
+    properties:
+      password:
+        type: string
+        description: New share password (min 6 chars; required on create, optional on update)
+      mode:
+        $ref: './specs/types/share.yaml#/Share/ShareMode'
+        description: Access mode to grant guests
+```
+
+- [ ] **Step 2: Register the group in `specs/types/index.yaml`**
+
+Append under `groupedTypes:` (after the `Config` entry):
+
+```yaml
+# Terminal sharing types: share records, guest sessions, share API shapes
+Share:
+  $ref: './specs/types/share.yaml#/Share'
+```
+
+- [ ] **Step 3: Extend `specs/types/ws-protocol.yaml`**
+
+(a) Replace the `Ticket` type (bottom of file) with:
+
+```yaml
+Ticket:
+  type: object
+  description: Short-lived single-use ticket for authenticating WebSocket upgrade requests
+  required:
+    - createdAt
+    - used
+  properties:
+    createdAt:
+      type: number
+      description: Unix timestamp (ms) when the ticket was created
+    used:
+      type: boolean
+      description: Whether the ticket has been consumed (single-use)
+    terminalId:
+      type: string
+      description: When set, the ticket may only open WS channels for this terminal
+    readOnly:
+      type: boolean
+      description: When true, input/resize/signal/send-input/cancel frames are dropped
+
+TicketScope:
+  type: object
+  description: Scope restriction carried by a guest WebSocket ticket
+  required:
+    - terminalId
+    - readOnly
+  properties:
+    terminalId:
+      type: string
+      description: Only WS channels for this terminal may be opened
+    readOnly:
+      type: boolean
+      description: Whether the connection is view-only (input frames dropped)
+```
+
+(b) Add the resize broadcast to the server union — in `TerminalServerMessage.oneOf`, add:
+
+```yaml
+- $ref: './specs/types/ws-protocol.yaml#/WsProtocol/TerminalResizeMessage'
+```
+
+(shape `{type:'resize', cols, rows}` is reused for the server→client PTY-resized broadcast).
+
+- [ ] **Step 4: Extend `TerminalDetailView` in `specs/types/client.yaml`**
+
+Add to its `properties` (all optional — not in `required`):
+
+```yaml
+cols:
+  type: number
+  description: Current PTY width in columns (for fixed-size guest rendering)
+rows:
+  type: number
+  description: Current PTY height in rows (for fixed-size guest rendering)
+shareMode:
+  $ref: './specs/types/share.yaml#/Share/ShareMode'
+  description: Present when fetched with a guest share token — the guest's access mode
+```
+
+- [ ] **Step 5: Regenerate** — Run: `pnpm gen:types`. Expected: `src/lib/types/generated/Share.ts` created, `WsProtocol.ts`/`Client.ts` updated, no errors.
+
+- [ ] **Step 6: Hand-written type updates**
+
+In `src/lib/types/ws.ts`, add the resize variant to `WireTerminalServerMessage`:
+
+```ts
+export type WireTerminalServerMessage =
+  | { bytes: number; type: 'output-dropped' }
+  | { chunk: number; data: string; total: number; type: 'scrollback' }
+  | { code: null | number; signal: null | string; type: 'exit' }
+  | { cols: number; rows: number; type: 'resize' }
+  | { data: string; type: 'output' }
+  | { message: string; type: 'error' };
+```
+
+In `src/lib/types/terminal-client.ts`:
+
+```ts
+// TerminalOptions — add three optional fields:
+export interface TerminalOptions {
+  apiKey?: string;
+  container: HTMLElement;
+  fontSize?: number;
+  getTicket: () => Promise<string>;
+  initialCols?: number;
+  initialRows?: number;
+  onActivity?: (active: boolean) => void;
+  onCwd?: (path: string) => void;
+  onDisconnect?: () => void;
+  onExit?: (code: number) => void;
+  onReconnect?: () => void;
+  readOnly?: boolean;
+  terminalId?: string;
+  wsUrl: string;
+}
+
+// WsTerminalInboundMessage — add cols/rows:
+export interface WsTerminalInboundMessage {
+  active?: boolean;
+  bytes?: number;
+  code?: number;
+  cols?: number;
+  data?: string;
+  path?: string;
+  rows?: number;
+  type: string;
+}
+
+// New component prop types (place alphabetically near ShortcutsHelpProps):
+export interface ShareGateProps {
+  /** Returns an error message to display, or null on success. */
+  onSubmit: (password: string) => Promise<null | string>;
+}
+
+export interface ShareSheetProps {
+  onClose: () => void;
+  open?: boolean;
+  shareUrl: string;
+  terminalId: string;
+}
+```
+
+- [ ] **Step 7: Validate & commit**
+
+Run: `pnpm check && pnpm lint`. Expected: PASS.
+
+```bash
+git add specs/types/ src/lib/types/
+git commit -m "feat(types): share, ticket-scope, and resize-broadcast types"
+```
+
+---
+
+### Task 2: Share store (SQLite) + unit test
+
+**Files:**
+
+- Create: `src/lib/modules/server/terminal/share-store.ts`
+- Create: `tests/share-store.test.cjs`
+- Modify: `package.json` (append test to `test` script)
+
+- [ ] **Step 1: Create `src/lib/modules/server/terminal/share-store.ts`**
+
+```ts
+/**
+ * Share Store — SQLite persistence for terminal sharing.
+ *
+ * terminal_shares: one share per terminal (scrypt password hash + mode).
+ * share_sessions:  guest sessions keyed by sha256(token), 7-day TTL.
+ *
+ * Database location: ~/.shooter/shooter.db (same file as terminal-store).
+ */
+
+import type { ShareMode, ShareSessionRecord, TerminalShareRecord } from '$lib/types';
+
+import Database from 'better-sqlite3';
+import { createHash, randomBytes, scryptSync, timingSafeEqual } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DB_DIR = path.join(process.env.HOME || '', '.shooter');
+const DB_PATH = path.join(DB_DIR, 'shooter.db');
+
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+// ── Password hashing (scrypt, per-share random salt) ─────────────────
+
+export function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `scrypt:${salt}:${hash}`;
+}
+
+export function verifyPassword(password: string, stored: string): boolean {
+  const parts = stored.split(':');
+  if (parts.length !== 3 || parts[0] !== 'scrypt') {
+    return false;
+  }
+  const expected = Buffer.from(parts[2], 'hex');
+  const actual = scryptSync(password, parts[1], 64);
+  return expected.length === actual.length && timingSafeEqual(actual, expected);
+}
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+// ── Row mapping ──────────────────────────────────────────────────────
+
+function rowToShare(row: Record<string, unknown>): TerminalShareRecord {
+  return {
+    createdAt: row.created_at as number,
+    mode: row.mode as ShareMode,
+    passwordHash: row.password_hash as string,
+    terminalId: row.terminal_id as string,
+    updatedAt: row.updated_at as number,
+  };
+}
+
+export class ShareStore {
+  private db: Database.Database;
+
+  constructor() {
+    fs.mkdirSync(DB_DIR, { recursive: true });
+    this.db = new Database(DB_PATH);
+    this.db.pragma('journal_mode = WAL');
+
+    this.db.exec(`
+			CREATE TABLE IF NOT EXISTS terminal_shares (
+				terminal_id   TEXT PRIMARY KEY,
+				password_hash TEXT NOT NULL,
+				mode          TEXT NOT NULL,
+				created_at    INTEGER NOT NULL,
+				updated_at    INTEGER NOT NULL
+			);
+			CREATE TABLE IF NOT EXISTS share_sessions (
+				token_hash  TEXT PRIMARY KEY,
+				terminal_id TEXT NOT NULL,
+				created_at  INTEGER NOT NULL,
+				expires_at  INTEGER NOT NULL
+			)
+		`);
+
+    this.cleanup();
+  }
+
+  /** Purge expired sessions and shares whose terminal no longer exists. */
+  cleanup(): void {
+    this.db.prepare('DELETE FROM share_sessions WHERE expires_at < ?').run(Date.now());
+    try {
+      this.db
+        .prepare('DELETE FROM terminal_shares WHERE terminal_id NOT IN (SELECT id FROM terminals)')
+        .run();
+      this.db
+        .prepare('DELETE FROM share_sessions WHERE terminal_id NOT IN (SELECT id FROM terminals)')
+        .run();
+    } catch {
+      // terminals table may not exist yet on a fresh database — skip orphan cleanup.
+    }
+  }
+
+  /** Issue a new guest session for a shared terminal. Returns the raw token (stored hashed). */
+  createSession(terminalId: string): { expiresAt: number; token: string } {
+    const token = randomBytes(32).toString('hex');
+    const now = Date.now();
+    const expiresAt = now + SESSION_TTL_MS;
+    this.db
+      .prepare(
+        'INSERT INTO share_sessions (token_hash, terminal_id, created_at, expires_at) VALUES (?, ?, ?, ?)'
+      )
+      .run(hashToken(token), terminalId, now, expiresAt);
+    return { expiresAt, token };
+  }
+
+  /** Revoke a share: delete the share row and every guest session for it. */
+  deleteShare(terminalId: string): void {
+    this.db.prepare('DELETE FROM terminal_shares WHERE terminal_id = ?').run(terminalId);
+    this.deleteSessions(terminalId);
+  }
+
+  /** Delete all guest sessions for a terminal (password change / revoke). */
+  deleteSessions(terminalId: string): void {
+    this.db.prepare('DELETE FROM share_sessions WHERE terminal_id = ?').run(terminalId);
+  }
+
+  getShare(terminalId: string): null | TerminalShareRecord {
+    const row = this.db
+      .prepare('SELECT * FROM terminal_shares WHERE terminal_id = ?')
+      .get(terminalId) as Record<string, unknown> | undefined;
+    return row ? rowToShare(row) : null;
+  }
+
+  /**
+   * Resolve a guest bearer token to its terminal + mode.
+   * Returns null if unknown, expired, or the share was revoked.
+   */
+  resolveToken(token: string): null | { mode: ShareMode; terminalId: string } {
+    if (!token) {
+      return null;
+    }
+    const row = this.db
+      .prepare(
+        `SELECT s.terminal_id, s.expires_at, sh.mode
+				 FROM share_sessions s
+				 JOIN terminal_shares sh ON sh.terminal_id = s.terminal_id
+				 WHERE s.token_hash = ?`
+      )
+      .get(hashToken(token)) as Record<string, unknown> | undefined;
+    if (!row) {
+      return null;
+    }
+    if ((row.expires_at as number) < Date.now()) {
+      this.db.prepare('DELETE FROM share_sessions WHERE token_hash = ?').run(hashToken(token));
+      return null;
+    }
+    return { mode: row.mode as ShareMode, terminalId: row.terminal_id as string };
+  }
+
+  /** Create or replace the share for a terminal. */
+  setShare(record: TerminalShareRecord): void {
+    this.db
+      .prepare(
+        `INSERT OR REPLACE INTO terminal_shares
+				 (terminal_id, password_hash, mode, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?)`
+      )
+      .run(record.terminalId, record.passwordHash, record.mode, record.createdAt, record.updatedAt);
+  }
+}
+
+// ── Singleton (globalThis bridges tsx server.ts + SvelteKit handler) ─
+
+const SS_GLOBAL_KEY = '__shooter_share_store';
+export const shareStore: ShareStore =
+  ((globalThis as Record<string, unknown>)[SS_GLOBAL_KEY] as ShareStore) || new ShareStore();
+(globalThis as Record<string, unknown>)[SS_GLOBAL_KEY] = shareStore;
+```
+
+Note: `ShareSessionRecord` is exported from the barrel for the test/docs symmetry even though the store returns a narrowed shape; do not remove it from share.yaml.
+
+- [ ] **Step 2: Create `tests/share-store.test.cjs`**
+
+Mirror the conventions of `tests/terminal-store.test.cjs` (plain `.cjs`, better-sqlite3 against `/tmp`, replicated schema + logic, `assert`-style checks, summary line, `process.exit(1)` on failure). Test cases (replicate `hashPassword`/`verifyPassword`/`hashToken` inline with `node:crypto`):
+
+1. Schema: both tables create; share INSERT OR REPLACE upsert keeps PK unique.
+2. `hashPassword` produces `scrypt:<32-hex-salt>:<128-hex-hash>`; `verifyPassword` true for correct, false for wrong password, false for malformed stored string.
+3. Session insert + join-resolve returns mode/terminal; unknown token → null.
+4. Expired session (expires_at in past) resolves to null and is purged.
+5. Revoke cascade: deleting share + sessions for terminal A leaves terminal B's intact.
+6. Orphan cleanup: with a `terminals` table containing only `t1`, shares/sessions for `t2` are deleted, `t1`'s survive.
+
+- [ ] **Step 3: Run the test**
+
+Run: `node tests/share-store.test.cjs`. Expected: all cases PASS.
+
+- [ ] **Step 4: Register in `package.json`** — append `&& node tests/share-store.test.cjs` to the `test` script.
+
+- [ ] **Step 5: Validate & commit**
+
+Run: `pnpm check && pnpm lint && pnpm test`. Expected: PASS.
+
+```bash
+git add src/lib/modules/server/terminal/share-store.ts tests/share-store.test.cjs package.json
+git commit -m "feat(sharing): share store with scrypt passwords and guest sessions"
+```
+
+---
+
+### Task 3: Access resolution helper + guest WS registry
+
+**Files:**
+
+- Create: `src/lib/modules/server/terminal/share-auth.ts`
+- Create: `src/lib/modules/server/ws/guest-registry.ts`
+
+- [ ] **Step 1: Create `src/lib/modules/server/terminal/share-auth.ts`**
+
+```ts
+// Resolves a terminal-scoped request to owner (API key) or guest (share token).
+// Kept separate from auth.ts so routes without share semantics don't pull in SQLite.
+
+import type { AccessContext } from '$lib/types';
+
+import { validateAuth } from '../auth';
+import { shareStore } from './share-store';
+
+/** Extract the Bearer token from a request, or null. */
+export function bearerToken(request: Request): null | string {
+  const auth = request.headers.get('Authorization') || request.headers.get('authorization');
+  if (!auth?.startsWith('Bearer ')) {
+    return null;
+  }
+  return auth.slice(7).trim();
+}
+
+/**
+ * Resolve access for a request targeting one terminal.
+ * Owner (valid API key) → { level: 'owner' }.
+ * Guest (valid share session for THIS terminal) → { level: 'guest', mode }.
+ * Anything else → null.
+ */
+export function resolveAccess(request: Request, terminalId: string): AccessContext | null {
+  if (validateAuth(request) === null) {
+    return { level: 'owner' };
+  }
+  const token = bearerToken(request);
+  if (!token) {
+    return null;
+  }
+  const session = shareStore.resolveToken(token);
+  if (!session || session.terminalId !== terminalId) {
+    return null;
+  }
+  return { level: 'guest', mode: session.mode };
+}
+```
+
+- [ ] **Step 2: Create `src/lib/modules/server/ws/guest-registry.ts`**
+
+```ts
+// Tracks WebSocket connections opened with a guest (scoped) ticket, per terminal,
+// so revoke / mode-change / password-change can force-close them immediately.
+// globalThis bridges the tsx server.ts and SvelteKit handler module scopes.
+
+import type { WebSocket } from 'ws';
+
+const GUESTS_KEY = '__shooter_ws_guest_conns';
+const guests: Map<string, Set<WebSocket>> = ((globalThis as Record<string, unknown>)[
+  GUESTS_KEY
+] as Map<string, Set<WebSocket>>) || new Map<string, Set<WebSocket>>();
+(globalThis as Record<string, unknown>)[GUESTS_KEY] = guests;
+
+/** Force-close every guest connection for a terminal. Returns the number closed. */
+export function closeGuests(terminalId: string): number {
+  const set = guests.get(terminalId);
+  if (!set) {
+    return 0;
+  }
+  let closed = 0;
+  for (const ws of set) {
+    try {
+      ws.close(4001, 'Share revoked');
+      closed++;
+    } catch {
+      // Already closing/closed.
+    }
+  }
+  guests.delete(terminalId);
+  return closed;
+}
+
+/** Register a guest connection; auto-removes itself on close. */
+export function registerGuest(terminalId: string, ws: WebSocket): void {
+  let set = guests.get(terminalId);
+  if (!set) {
+    set = new Set<WebSocket>();
+    guests.set(terminalId, set);
+  }
+  set.add(ws);
+  ws.on('close', () => {
+    const current = guests.get(terminalId);
+    if (current) {
+      current.delete(ws);
+      if (current.size === 0) {
+        guests.delete(terminalId);
+      }
+    }
+  });
+}
+```
+
+- [ ] **Step 3: Validate & commit**
+
+Run: `pnpm check && pnpm lint`. Expected: PASS.
+
+```bash
+git add src/lib/modules/server/terminal/share-auth.ts src/lib/modules/server/ws/guest-registry.ts
+git commit -m "feat(sharing): access resolver and guest connection registry"
+```
+
+---
+
+### Task 4: Scoped WS tickets — ticket-store, upgrade handler, routing gate
+
+**Files:**
+
+- Modify: `src/lib/modules/server/ws/ticket-store.ts`
+- Modify: `server.ts:164-184` (upgrade handler)
+- Modify: `src/lib/modules/server/ws/server.ts` (routing gate + scope pass-down + guest registration)
+
+- [ ] **Step 1: `ticket-store.ts` — scope-aware generate, Ticket-returning validate**
+
+Replace `generateTicket` and `validateTicket`:
+
+```ts
+import type { Ticket, TicketScope } from '$lib/types';
+
+/**
+ * Generate a new single-use ticket (32-byte hex string).
+ * Valid 30 seconds, single consumption. An optional scope restricts the
+ * ticket to one terminal's channels (and optionally read-only).
+ */
+export function generateTicket(scope?: TicketScope): string {
+  const ticket = randomBytes(32).toString('hex');
+  tickets.set(ticket, {
+    createdAt: Date.now(),
+    used: false,
+    ...(scope ? { readOnly: scope.readOnly, terminalId: scope.terminalId } : {}),
+  });
+  return ticket;
+}
+
+/**
+ * Validate and consume a ticket.
+ * Returns the consumed Ticket (including any scope) if valid, else null.
+ */
+export function validateTicket(ticket: null | string): null | Ticket {
+  if (!ticket) {
+    return null;
+  }
+  const entry = tickets.get(ticket);
+  if (!entry || entry.used) {
+    return null;
+  }
+  if (Date.now() - entry.createdAt > 30_000) {
+    tickets.delete(ticket);
+    return null;
+  }
+  entry.used = true;
+  return entry;
+}
+```
+
+- [ ] **Step 2: `server.ts` upgrade handler — pass scope down**
+
+Replace lines 173–183 with:
+
+```ts
+const ticket = url.searchParams.get('ticket');
+
+const ticketEntry = validateTicket(ticket);
+if (!ticketEntry) {
+  socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+  socket.destroy();
+  return;
+}
+
+// Delegate routing to the WS server module which inspects the pathname
+// and dispatches to terminal, session, or events handlers. Guest tickets
+// carry a scope that restricts which channels may be opened.
+const scope = ticketEntry.terminalId
+  ? { readOnly: ticketEntry.readOnly ?? false, terminalId: ticketEntry.terminalId }
+  : undefined;
+setupWebSocketHandlers(wss, request, socket, head, scope);
+```
+
+- [ ] **Step 3: `ws/server.ts` — central scope gate + guest registration**
+
+Add imports:
+
+```ts
+import type { TicketScope } from '$lib/types';
+
+import { registerGuest } from './guest-registry.js';
+```
+
+Change the signature and body of `setupWebSocketHandlers`:
+
+```ts
+export function setupWebSocketHandlers(
+  wss: WebSocketServer,
+  request: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+  scope?: TicketScope
+): void {
+```
+
+After the route matching block (after the `if (!terminalMatch && ...)` early return), insert:
+
+```ts
+// Scoped (guest) tickets may only open the terminal/session channels of
+// their own terminal. Events and super-session channels broadcast global
+// data, so they are denied outright.
+if (scope) {
+  const target = terminalMatch?.[1] ?? sessionMatch?.[1];
+  if (!target || superSessionMatch || target !== scope.terminalId) {
+    socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+    socket.destroy();
+    return;
+  }
+}
+```
+
+Inside `wss.handleUpgrade`, after `allConnections.add(ws);` add:
+
+```ts
+if (scope) {
+  registerGuest(scope.terminalId, ws);
+}
+```
+
+and pass scope into the two handlers:
+
+```ts
+if (terminalMatch) {
+  const terminalId = terminalMatch[1];
+  handleTerminalConnection(ws, terminalId, scope);
+} else if (superSessionMatch) {
+  const superSessionId = superSessionMatch[1];
+  handleSuperSessionConnection(ws, superSessionId);
+} else if (sessionMatch) {
+  const sessionId = sessionMatch[1];
+  handleSessionConnection(ws, sessionId, scope);
+} else if (isEvents) {
+  handleEventsConnection(ws);
+}
+```
+
+(Compile will fail until Task 5 adds the `scope` parameters — Tasks 4+5 commit together if needed, or add the params in this task as a no-op third argument. Preferred: do Step 1–3 here, then Task 5 immediately; run `pnpm check` only at Task 5's end. Single commit covering both is acceptable.)
+
+---
+
+### Task 5: Handler enforcement — read-only drops, subscribe lock, resize broadcast
+
+**Files:**
+
+- Modify: `src/lib/modules/server/ws/terminal-handler.ts`
+- Modify: `src/lib/modules/server/ws/session-handler.ts`
+- Modify: `src/lib/modules/server/terminal/pty-manager.ts:476-490` (resize broadcast for REST path)
+
+- [ ] **Step 1: `terminal-handler.ts`**
+
+(a) Add `TicketScope` to the type import from `$lib/types`.
+
+(b) Signature: `export function handleTerminalConnection(ws: WebSocket, terminalId: string, scope?: TicketScope): void`.
+
+(c) In the `ws.on('message', ...)` handler, right after the `if (!msg) return;` guard, insert:
+
+```ts
+// View-only guests: every inbound frame type mutates the PTY — drop them all.
+if (scope?.readOnly) {
+  return;
+}
+```
+
+(d) In the `case 'resize':` branch, after `terminal.pty.resize(msg.cols, msg.rows);` add a broadcast to the other attached clients so view-only guests can follow the PTY size:
+
+```ts
+        case 'resize': {
+          terminal.pty.resize(msg.cols, msg.rows);
+          const resizeMsg: ServerMessage = { cols: msg.cols, rows: msg.rows, type: 'resize' };
+          for (const client of terminal.clients) {
+            if (client !== ws) {
+              safeSend(client, resizeMsg);
+            }
+          }
+          break;
+        }
+```
+
+- [ ] **Step 2: `session-handler.ts`**
+
+(a) Add `TicketScope` to the type import from `$lib/types`.
+
+(b) Signature: `export function handleSessionConnection(ws: WebSocket, id: string, scope?: TicketScope): void` — and pass `scope` through both `wireClientMessages(ws, state, scope)` call sites.
+
+(c) `function wireClientMessages(ws: WebSocket, state: ConnectionState, scope?: TicketScope): void` — inside the message switch:
+
+- `case 'cancel':` and `case 'send-input':` — first line of each:
+
+```ts
+if (scope?.readOnly) {
+  safeSend(ws, { message: 'This shared terminal is view-only.', type: 'error' });
+  return;
+}
+```
+
+- `case 'subscribe':` — first line:
+
+```ts
+if (scope && msg.sessionId !== scope.terminalId) {
+  safeSend(ws, { message: 'Not authorized for this session.', type: 'error' });
+  return;
+}
+```
+
+- [ ] **Step 3: `pty-manager.ts` resize broadcast (REST path)**
+
+In `resize(id, cols, rows)` (line ~476), after `terminal.rows = rows;` add:
+
+```ts
+const msg = JSON.stringify({ cols, rows, type: 'resize' });
+for (const ws of terminal.clients) {
+  this.safeSend(ws, msg);
+}
+```
+
+(match `safeSend`'s actual signature in that file — it takes the ws and a pre-serialized string).
+
+- [ ] **Step 4: Validate & commit (covers Task 4 too)**
+
+Run: `pnpm check && pnpm lint`. Expected: PASS.
+
+```bash
+git add src/lib/modules/server/ws/ server.ts src/lib/modules/server/terminal/pty-manager.ts
+git commit -m "feat(sharing): scoped WS tickets with server-side enforcement"
+```
+
+---
+
+### Task 6: API endpoints
+
+**Files:**
+
+- Create: `src/routes/api/terminals/[id]/share/+server.ts` (GET/PUT/DELETE, owner)
+- Create: `src/routes/api/terminals/[id]/share/status/+server.ts` (GET, public)
+- Create: `src/routes/api/terminals/[id]/share/auth/+server.ts` (POST, public + rate-limited)
+- Modify: `src/routes/api/ws-ticket/+server.ts` (accept share tokens → scoped tickets)
+- Modify: `src/routes/api/terminals/[id]/+server.ts` (GET dual-auth + cols/rows/shareMode; DELETE revokes share)
+- Modify: `src/routes/api/terminals/[id]/resize/+server.ts` (control-mode guests)
+- Modify: `src/routes/api/terminals/[id]/paste-image/+server.ts` (control-mode guests)
+
+- [ ] **Step 1: Owner share management — `share/+server.ts`**
+
+```ts
+// /api/terminals/[id]/share — owner management of a terminal's share.
+// GET: current state. PUT: create/update. DELETE: revoke.
+// All methods require the API key (owners only).
+
+import type { ShareConfigRequest, ShareInfoResponse, ShareMode } from '$lib/types';
+
+import { validateAuth } from '$lib/modules/server/auth';
+import { ptyManager } from '$lib/modules/server/terminal/pty-manager.js';
+import { hashPassword, shareStore } from '$lib/modules/server/terminal/share-store';
+import { closeGuests } from '$lib/modules/server/ws/guest-registry';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+const MIN_PASSWORD_LENGTH = 6;
+const MODES: ShareMode[] = ['view', 'control'];
+
+function toInfo(terminalId: string): ShareInfoResponse {
+  const share = shareStore.getShare(terminalId);
+  if (!share) {
+    return { active: false };
+  }
+  return { active: true, createdAt: share.createdAt, mode: share.mode, updatedAt: share.updatedAt };
+}
+
+export const GET: RequestHandler = ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  return json(toInfo(params.id));
+};
+
+export const PUT: RequestHandler = async ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  if (!ptyManager.get(params.id)) {
+    return json({ error: 'Terminal not found' }, { status: 404 });
+  }
+
+  let body: ShareConfigRequest;
+  try {
+    body = (await request.json()) as ShareConfigRequest;
+  } catch {
+    return json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  if (!MODES.includes(body.mode)) {
+    return json({ error: "mode must be 'view' or 'control'" }, { status: 400 });
+  }
+
+  const existing = shareStore.getShare(params.id);
+  const password = typeof body.password === 'string' ? body.password : '';
+  if (!existing && password.length < MIN_PASSWORD_LENGTH) {
+    return json(
+      { error: `password is required (min ${String(MIN_PASSWORD_LENGTH)} chars)` },
+      { status: 400 }
+    );
+  }
+  if (password && password.length < MIN_PASSWORD_LENGTH) {
+    return json(
+      { error: `password must be at least ${String(MIN_PASSWORD_LENGTH)} chars` },
+      { status: 400 }
+    );
+  }
+
+  const now = Date.now();
+  shareStore.setShare({
+    createdAt: existing?.createdAt ?? now,
+    mode: body.mode,
+    passwordHash: password
+      ? hashPassword(password)
+      : (existing as NonNullable<typeof existing>).passwordHash,
+    terminalId: params.id,
+    updatedAt: now,
+  });
+
+  // New password invalidates existing guest sessions; any change to the share
+  // forces connected guests to reconnect under the new scope.
+  if (password) {
+    shareStore.deleteSessions(params.id);
+  }
+  if (password || existing?.mode !== body.mode) {
+    closeGuests(params.id);
+  }
+
+  return json(toInfo(params.id));
+};
+
+export const DELETE: RequestHandler = ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  shareStore.deleteShare(params.id);
+  const closed = closeGuests(params.id);
+  return json({ closedConnections: closed, success: true });
+};
+```
+
+- [ ] **Step 2: Public probe — `share/status/+server.ts`**
+
+```ts
+// GET /api/terminals/[id]/share/status — public probe used by the page to
+// decide whether to show the password gate. Reveals only a boolean.
+
+import { shareStore } from '$lib/modules/server/terminal/share-store';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = ({ params }) => {
+  return json({ shared: shareStore.getShare(params.id) !== null });
+};
+```
+
+- [ ] **Step 3: Guest password exchange — `share/auth/+server.ts`**
+
+```ts
+// POST /api/terminals/[id]/share/auth — exchange the share password for a
+// guest session token. Public endpoint; brute-force-limited per IP+terminal.
+
+import type { ShareAuthRequest } from '$lib/types';
+
+import { shareStore, verifyPassword } from '$lib/modules/server/terminal/share-store';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 10;
+
+const attempts = new Map<string, number[]>();
+
+function checkRateLimit(key: string): boolean {
+  const now = Date.now();
+  const recent = (attempts.get(key) ?? []).filter((t) => t > now - RATE_LIMIT_WINDOW_MS);
+  attempts.set(key, recent);
+  if (recent.length >= RATE_LIMIT_MAX) {
+    return false;
+  }
+  recent.push(now);
+  return true;
+}
+
+setInterval(() => {
+  const cutoff = Date.now() - RATE_LIMIT_WINDOW_MS;
+  for (const [key, timestamps] of attempts) {
+    const recent = timestamps.filter((t) => t > cutoff);
+    if (recent.length === 0) {
+      attempts.delete(key);
+    } else {
+      attempts.set(key, recent);
+    }
+  }
+}, 300_000).unref();
+
+export const POST: RequestHandler = async (event) => {
+  const { params, request } = event;
+
+  const share = shareStore.getShare(params.id);
+  if (!share) {
+    return json({ error: 'Not shared' }, { status: 404 });
+  }
+
+  let ip = 'unknown';
+  const cfIp = request.headers.get('cf-connecting-ip');
+  const fwd = request.headers.get('x-forwarded-for');
+  if (cfIp) {
+    ip = cfIp;
+  } else if (fwd) {
+    ip = fwd.split(',')[0].trim();
+  } else {
+    try {
+      ip = event.getClientAddress();
+    } catch {
+      // Keep 'unknown' — rate limit still applies per terminal.
+    }
+  }
+
+  if (!checkRateLimit(`${ip}:${params.id}`)) {
+    return json({ error: 'Too many attempts. Try again in a minute.' }, { status: 429 });
+  }
+
+  let body: ShareAuthRequest;
+  try {
+    body = (await request.json()) as ShareAuthRequest;
+  } catch {
+    return json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  if (typeof body.password !== 'string' || !verifyPassword(body.password, share.passwordHash)) {
+    return json({ error: 'Invalid password' }, { status: 401 });
+  }
+
+  const { expiresAt, token } = shareStore.createSession(params.id);
+  return json({ expiresAt, mode: share.mode, token });
+};
+```
+
+- [ ] **Step 4: `ws-ticket/+server.ts` — guest tokens get scoped tickets**
+
+Replace the `POST` handler body's auth section:
+
+```ts
+export const POST: RequestHandler = ({ request }) => {
+  const bearer = (
+    request.headers.get('authorization') ??
+    request.headers.get('Authorization') ??
+    ''
+  )
+    .replace(/^Bearer\s+/i, '')
+    .trim();
+
+  const authError = validateAuth(request);
+  if (authError) {
+    // Not the API key — maybe a guest share token (scoped ticket).
+    const session = bearer ? shareStore.resolveToken(bearer) : null;
+    if (!session) {
+      return authError;
+    }
+    if (!checkRateLimit(bearer)) {
+      return json(
+        { error: 'Rate limit exceeded. Maximum 30 ticket requests per minute.' },
+        { status: 429 }
+      );
+    }
+    const ticket = generateTicket({
+      readOnly: session.mode === 'view',
+      terminalId: session.terminalId,
+    });
+    return json({ expiresIn: 30, ticket });
+  }
+
+  if (!checkRateLimit(bearer)) {
+    return json(
+      { error: 'Rate limit exceeded. Maximum 30 ticket requests per minute.' },
+      { status: 429 }
+    );
+  }
+
+  const ticket = generateTicket();
+  return json({ expiresIn: 30, ticket });
+};
+```
+
+Add import: `import { shareStore } from '$lib/modules/server/terminal/share-store';`.
+
+- [ ] **Step 5: `terminals/[id]/+server.ts` — dual-auth GET, share-revoking DELETE**
+
+GET: replace the `validateAuth` block with:
+
+```ts
+const access = resolveAccess(request, params.id);
+if (!access) {
+  return json({ error: 'Unauthorized' }, { status: 401 });
+}
+```
+
+and extend the response object with:
+
+```ts
+      cols: terminal.cols,
+      rows: terminal.rows,
+      ...(access.level === 'guest' ? { shareMode: access.mode } : {}),
+```
+
+DELETE: keep `validateAuth`; in both the exited-removal branch and the kill branch, before returning success add:
+
+```ts
+shareStore.deleteShare(params.id);
+closeGuests(params.id);
+```
+
+Imports: `resolveAccess` from `$lib/modules/server/terminal/share-auth`, `shareStore` from `.../share-store`, `closeGuests` from `$lib/modules/server/ws/guest-registry`.
+
+- [ ] **Step 6: `resize/+server.ts` and `paste-image/+server.ts` — control-mode guests**
+
+In both, replace the `validateAuth` block with:
+
+```ts
+const access = resolveAccess(request, params.id);
+if (!access) {
+  return json({ error: 'Unauthorized' }, { status: 401 });
+}
+if (access.level === 'guest' && access.mode !== 'control') {
+  return json({ error: 'View-only access' }, { status: 403 });
+}
+```
+
+- [ ] **Step 7: Validate & commit**
+
+Run: `pnpm check && pnpm lint && pnpm build`. Expected: PASS.
+
+```bash
+git add src/routes/api/
+git commit -m "feat(sharing): share management, auth, and dual-auth endpoints"
+```
+
+---
+
+### Task 7: Frontend — xterm read-only mode, ShareGate, ShareSheet, page wiring
+
+**Files:**
+
+- Modify: `src/lib/modules/client/terminal/xterm-wrapper.ts`
+- Create: `src/lib/modules/client/terminal/ShareGate.svelte`
+- Create: `src/lib/modules/client/terminal/ShareSheet.svelte`
+- Modify: `src/routes/terminals/[id]/+page.svelte`
+
+- [ ] **Step 1: `xterm-wrapper.ts` read-only support**
+
+(a) Initial sizing — after `term.open(options.container);` replace `fitAddon.fit();` with:
+
+```ts
+if (options.readOnly && options.initialCols && options.initialRows) {
+  // View-only: render at the PTY's size (we may not resize the shared PTY).
+  term.resize(options.initialCols, options.initialRows);
+} else {
+  fitAddon.fit();
+}
+```
+
+(b) Paste interception — change the gate to `if (options.terminalId && options.apiKey && !options.readOnly) {`.
+
+(c) Inbound messages — add to the `onmessage` chain:
+
+```ts
+      } else if (msg.type === 'resize') {
+        if (options.readOnly && msg.cols && msg.rows) {
+          term.resize(msg.cols, msg.rows);
+        }
+      }
+```
+
+(d) Outbound input — `term.onData` handler first line: `if (options.readOnly) { return; }`.
+
+(e) ResizeObserver — first line of callback: `if (options.readOnly) { return; }`.
+
+- [ ] **Step 2: `ShareGate.svelte`** — minimal centered password form
+
+```svelte
+<script lang="ts">
+  import type { ShareGateProps } from '$lib/types';
+
+  import { Button, Input } from '@juspay/svelte-ui-components';
+
+  const { onSubmit }: ShareGateProps = $props();
+
+  let password = $state('');
+  let errorMsg = $state<null | string>(null);
+  let submitting = $state(false);
+
+  async function submit(): Promise<void> {
+    if (!password || submitting) {
+      return;
+    }
+    submitting = true;
+    errorMsg = null;
+    errorMsg = await onSubmit(password);
+    submitting = false;
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      void submit();
+    }
+  }
+</script>
+
+<div class="share-gate">
+  <div class="share-gate-card">
+    <h2 class="share-gate-title">Shared terminal</h2>
+    <p class="share-gate-sub">
+      This terminal is password protected. Enter the password to view it.
+    </p>
+    <Input
+      bind:value={password}
+      dataType="password"
+      placeholder="Password"
+      classes="share-gate-input"
+      onKeyDown={onKeydown}
+    />
+    {#if errorMsg}
+      <p class="share-gate-error">{errorMsg}</p>
+    {/if}
+    <Button
+      classes="btn-primary share-gate-btn"
+      onclick={(): void => void submit()}
+      disabled={!password || submitting}
+      showLoader={submitting}
+      text="Unlock"
+    />
+  </div>
+</div>
+
+<style>
+  .share-gate {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    padding: var(--space-4);
+  }
+  .share-gate-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    width: 100%;
+    max-width: 360px;
+    padding: var(--space-5);
+    background: var(--ds-background-100);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+  }
+  .share-gate-title {
+    margin: 0;
+    font-size: var(--text-lg);
+    color: var(--text-primary);
+  }
+  .share-gate-sub {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--text-tertiary);
+  }
+  .share-gate-error {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--ds-red-700, #ef4444);
+  }
+</style>
+```
+
+- [ ] **Step 3: `ShareSheet.svelte`** — owner share management overlay
+
+Props per `ShareSheetProps` (`onClose`, `open`, `shareUrl`, `terminalId`). Behavior:
+
+- On `open` becoming true: `GET /api/terminals/{terminalId}/share` with `Authorization: Bearer ${getApiKey()}` (import `getApiKey` from `$lib/modules/client/common/config-guard`); populate `active`, `mode`.
+- Form state: `mode` (`'view' | 'control'`, default `'view'`), `password` (text input), Generate button → `password = crypto-random 16-char base64url-ish string` (`Array.from(crypto.getRandomValues(new Uint8Array(12)), b => 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789'[b % 57]).join('')`).
+- Enable/Update button → `PUT` with `{ mode, ...(password ? { password } : {}) }`; on create, password required (disable button if `!active && password.length < 6`).
+- When active: show `shareUrl` in a readonly row with a Copy button (`navigator.clipboard.writeText`), the current mode, and a Revoke button → `DELETE`, then reset to inactive state.
+- Render nothing when `!open`. Backdrop click + Close button call `onClose`. Reuse `Button`, `Input` from `@juspay/svelte-ui-components`; simple fixed-position overlay styling consistent with the app (dark theme variables as in ShareGate).
+
+- [ ] **Step 4: Page wiring — `src/routes/terminals/[id]/+page.svelte`**
+
+(a) **Imports/types:** add `ShareAuthResponse`, `ShareMode`, `ShareStatusResponse` to the `$lib/types` import; import `ShareGate` and `ShareSheet` components.
+
+(b) **State** (after existing state declarations):
+
+```ts
+let authMode = $state<'guest' | 'owner' | null>(null);
+let guestMode = $state<null | ShareMode>(null);
+let shareGateVisible = $state(false);
+let shareSheetOpen = $state(false);
+```
+
+Derived:
+
+```ts
+const isOwner = $derived(authMode === 'owner');
+const viewOnly = $derived(authMode === 'guest' && guestMode === 'view');
+const shareUrl = $derived(
+  typeof window !== 'undefined' ? `${window.location.origin}/terminals/${terminalId}` : ''
+);
+```
+
+(c) **Token helpers** (next to `getConfig()`):
+
+```ts
+const SHARE_TOKENS_KEY = 'shooter_share_tokens';
+
+function getShareToken(): null | string {
+  try {
+    const raw = localStorage.getItem(SHARE_TOKENS_KEY);
+    if (!raw) {
+      return null;
+    }
+    const map = JSON.parse(raw) as Record<string, string>;
+    return typeof map[terminalId] === 'string' ? map[terminalId] : null;
+  } catch {
+    return null;
+  }
+}
+
+function storeShareToken(token: string): void {
+  let map: Record<string, string> = {};
+  try {
+    map = JSON.parse(localStorage.getItem(SHARE_TOKENS_KEY) ?? '{}') as Record<string, string>;
+  } catch {
+    // Corrupt entry — start fresh.
+  }
+  map[terminalId] = token;
+  localStorage.setItem(SHARE_TOKENS_KEY, JSON.stringify(map));
+}
+
+function getBearer(): null | string {
+  return getConfig()?.apiKey ?? getShareToken();
+}
+```
+
+(d) **Rework `fetchTerminal()`** to the guest-aware version:
+
+```ts
+async function fetchTerminal(): Promise<void> {
+  if (!browser) {
+    return;
+  }
+
+  const config = getConfig();
+  const bearer = config?.apiKey ?? getShareToken();
+  if (!bearer) {
+    await checkShareAccess();
+    return;
+  }
+
+  try {
+    const res = await fetch(`/api/terminals/${terminalId}`, {
+      headers: { Authorization: `Bearer ${bearer}` },
+    });
+    if (res.status === 401 && !config) {
+      // Stale/revoked guest token — fall back to the password gate.
+      await checkShareAccess();
+      return;
+    }
+    if (!res.ok) {
+      error = res.status === 404 ? 'Terminal not found' : 'Failed to load terminal';
+      loading = false;
+      return;
+    }
+    terminal = (await res.json()) as TerminalDetailView;
+    if (config) {
+      authMode = 'owner';
+    } else {
+      authMode = 'guest';
+      guestMode = terminal.shareMode ?? 'view';
+    }
+  } catch {
+    error = 'Failed to connect to server';
+  }
+  loading = false;
+}
+
+async function checkShareAccess(): Promise<void> {
+  try {
+    const res = await fetch(`/api/terminals/${terminalId}/share/status`);
+    if (res.ok) {
+      const data = (await res.json()) as ShareStatusResponse;
+      if (data.shared) {
+        shareGateVisible = true;
+        loading = false;
+        return;
+      }
+    }
+  } catch {
+    // Fall through to the configuration error.
+  }
+  error = 'No configuration found. Please configure settings first.';
+  loading = false;
+}
+
+async function submitSharePassword(password: string): Promise<null | string> {
+  try {
+    const res = await fetch(`/api/terminals/${terminalId}/share/auth`, {
+      body: JSON.stringify({ password }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+    if (res.status === 429) {
+      return 'Too many attempts — try again in a minute.';
+    }
+    if (!res.ok) {
+      return 'Incorrect password.';
+    }
+    const data = (await res.json()) as ShareAuthResponse;
+    storeShareToken(data.token);
+    shareGateVisible = false;
+    loading = true;
+    await fetchTerminal();
+    if (terminal && !error) {
+      initViews();
+    }
+    return null;
+  } catch {
+    return 'Failed to reach the server.';
+  }
+}
+```
+
+(e) **Extract the view-init tail of `onMount` into `initViews()`** so the gate path can reuse it:
+
+```ts
+function initViews(): void {
+  if (isAI && window.innerWidth < 768) {
+    viewMode = 'chat';
+  } else {
+    viewMode = 'raw';
+  }
+
+  if (viewMode === 'raw') {
+    requestAnimationFrame(() => {
+      void initRawTerminal();
+    });
+    rawInitialized = true;
+  } else {
+    void connectSessionWs();
+    chatInitialized = true;
+  }
+}
+```
+
+and `onMount` becomes: `await fetchTerminal();` → disposed guard → shortcut manager → `if (!terminal || error) return;` → `initViews();`.
+
+(f) **`getWsTicket()`** — replace `getConfig()` usage with `getBearer()`:
+
+```ts
+  async function getWsTicket(): Promise<null | string> {
+    const bearer = getBearer();
+    if (!bearer) {
+      return null;
+    }
+    try {
+      const res = await fetch('/api/ws-ticket', {
+        headers: { Authorization: `Bearer ${bearer}` },
+        method: 'POST',
+      });
+      ...
+```
+
+(g) **`initRawTerminal()`** — pass the new options:
+
+```ts
+      const instance = await createTerminal({
+        apiKey: getBearer() ?? undefined,
+        container: termContainer,
+        fontSize: window.innerWidth < 768 ? 12 : 14,
+        getTicket,
+        initialCols: terminal.cols,
+        initialRows: terminal.rows,
+        readOnly: viewOnly,
+        ...
+```
+
+(h) **Template gating:**
+
+- New branch order: `{#if loading}` → `{:else if shareGateVisible}` render `<ShareGate onSubmit={submitSharePassword} />` inside a `term-page` wrapper → `{:else if error}` → `{:else if terminal}`.
+- Back link `<a href="/terminals" class="term-back">`: wrap in `{#if isOwner}`.
+- Session link condition: `{#if isOwner && isAI && ...}` (guests cannot open `/session/[id]`).
+- Kill/Remove buttons block: wrap the whole `{#if isRunning}` button pair in `{#if isOwner}`.
+- Add a Share button (owner only) next to the shortcuts button: `{#if isOwner}<Button classes="btn-secondary btn-sm" onclick={() => { shareSheetOpen = true; }} text="Share" />{/if}` and render `<ShareSheet open={shareSheetOpen} {terminalId} {shareUrl} onClose={() => { shareSheetOpen = false; }} />` next to ShortcutsHelp at the bottom.
+- Raw input area: `{#if isRunning && viewMode === 'raw' && !viewOnly}`.
+- ChatView: `showInput={isRunning && !viewOnly}`.
+- `paletteCommands`: gate the Kill entry with `if (isRunning && isOwner)`.
+
+- [ ] **Step 5: Validate & commit**
+
+Run: `pnpm check && pnpm lint && pnpm build`. Expected: PASS.
+
+```bash
+git add src/lib/modules/client/terminal/ src/routes/terminals/
+git commit -m "feat(sharing): guest password gate, view-only mode, owner share sheet"
+```
+
+---
+
+### Task 8: Full quality pass
+
+- [ ] Run: `pnpm gen:types` — expect no diff (`git status` clean for `src/lib/types/generated/`).
+- [ ] Run: `pnpm quality:all` (lint + format:check + check). Expected: PASS. Fix `pnpm format` if format:check fails.
+- [ ] Run: `pnpm test`. Expected: all suites incl. `share-store.test.cjs` PASS.
+- [ ] Run: `pnpm build`. Expected: success.
+- [ ] Commit any fixes: `git commit -am "chore(sharing): quality pass fixes"`.
+
+---
+
+### Task 9: Live end-to-end verification
+
+Sandboxed server (isolated HOME so the real `~/.shooter/shooter.db` is untouched):
+
+```bash
+mkdir -p /tmp/shooter-e2e
+HOME=/tmp/shooter-e2e API_KEY=e2e-test-key PORT=54012 npx tsx server.ts
+```
+
+- [ ] **REST sequence (curl):**
+  1. `POST /api/terminals` (owner) `{"command":"bash"}` → capture `id`.
+  2. `GET /api/terminals/<id>/share/status` (no auth) → `{"shared":false}`.
+  3. `PUT /api/terminals/<id>/share` (owner) `{"password":"secret123","mode":"view"}` → `{active:true, mode:"view"}`.
+  4. `GET .../share/status` → `{"shared":true}`.
+  5. `POST .../share/auth` wrong password → 401. 11× wrong → 429.
+  6. `POST .../share/auth` `{"password":"secret123"}` → `{token, mode:"view", expiresAt}`.
+  7. `GET /api/terminals/<id>` with guest token → 200 incl. `shareMode:"view"`, `cols`, `rows`.
+  8. `GET /api/terminals` (list) with guest token → 401 (scope works).
+  9. `POST /api/terminals/<id>/resize` with guest token → 403 (view mode).
+  10. `POST /api/ws-ticket` with guest token → ticket.
+- [ ] **WS scope checks** (node script with the `ws` package):
+  - scoped ticket on `/ws/events` → upgrade rejected (403).
+  - scoped ticket on `/ws/terminal/<other-id>` → 403.
+  - scoped ticket on `/ws/terminal/<id>` → connects, receives scrollback; send `{"type":"input","data":"echo HACKED\r"}`; owner `GET /api/terminals/<id>` `lastOutput` must NOT contain `HACKED`.
+  - flip share to `control` (PUT) → guest socket force-closed (code 4001); re-ticket + reconnect; input now executes.
+  - `DELETE .../share` → socket closes 4001; guest token now 401 on `GET /api/terminals/<id>`.
+- [ ] **Browser pass** (debug Chrome / agent-browser against `http://localhost:54012/terminals/<id>` with cleared localStorage): password gate renders → wrong password shows error → correct password loads live terminal → typing does nothing in view mode → owner tab (configured apiKey) shows Share button and can revoke, kicking the guest.
+- [ ] Stop the sandbox server.
+
+---
+
+### Task 10: Squash to a single semantic commit
+
+CI (`single-commit-enforcement.yml`) requires exactly one commit on the branch.
+
+```bash
+git log --oneline release..HEAD   # review
+git reset --soft $(git merge-base HEAD release)
+git commit -m "feat(sharing): password-protected single-terminal sharing
+
+Share one terminal at its existing /terminals/[id] route. Per-share
+password (scrypt) and mode (view-only or full control), active until
+revoked. Guest sessions are scoped bearer tokens; WS tickets carry a
+terminal scope enforced server-side (input dropped in view mode, events
+and foreign channels denied). Owner manages shares from a Share sheet
+on the terminal page; guests get a password gate."
+```
+
+Do **not** push without explicit approval.
+
+---
+
+## Self-review notes
+
+- Spec coverage: data model (T2), owner/guest/dual-auth endpoints (T6), WS scope + read-only + subscribe lock + resize broadcast (T4/T5), guest registry force-close (T3/T6), frontend gate/view-only/share-sheet (T7), types (T1), tests+e2e (T2/T8/T9), single commit (T10). `DELETE /api/terminals/[id]` revokes share — T6 Step 5. Orphan cleanup — T2 `cleanup()`.
+- Type names consistent: `ShareMode`, `AccessContext`, `TicketScope`, `ShareAuthResponse`, `ShareStatusResponse`, `ShareInfoResponse`, `ShareConfigRequest`, `TerminalShareRecord`; store API `getShare/setShare/deleteShare/createSession/resolveToken/deleteSessions/cleanup`; helpers `resolveAccess/bearerToken`, registry `registerGuest/closeGuests`.
+- Known judgment calls: reuse of `TerminalResizeMessage` shape for the server broadcast; guests keep sessions on mode change (only sockets closed); page HTML remains public (pre-existing posture).

--- a/docs/superpowers/specs/2026-06-11-terminal-sharing-design.md
+++ b/docs/superpowers/specs/2026-06-11-terminal-sharing-design.md
@@ -1,0 +1,122 @@
+# Terminal Sharing — Design Spec
+
+**Date:** 2026-06-11
+**Branch:** `feat/terminal-sharing`
+**Status:** Approved (design approved by Sachin on 2026-06-11)
+
+## Goal
+
+Let the owner share a single terminal (e.g. `https://shooter.breezehq.dev/terminals/947cf980`) with someone who has no Shooter API key. The visitor opens the **existing route**, enters a per-share password, and gets access to **that one terminal only** — view-only or full control, chosen per share. The share stays active until revoked. Everything else in the app (other terminals, sessions, SOS, events, settings, all other API routes) remains inaccessible to the visitor.
+
+## Decisions (user-confirmed)
+
+| Decision    | Choice                                                          |
+| ----------- | --------------------------------------------------------------- |
+| Access mode | Chosen per share: `view` (watch only) or `control` (full input) |
+| Lifetime    | Until revoked (manual revoke from the terminal page)            |
+| Password    | Per-share, set (or generated) in the UI when enabling sharing   |
+| URL         | The existing `/terminals/[id]` route — no separate share URL    |
+
+## Approach
+
+Scoped share tokens layered onto the existing auth patterns (Bearer headers + short-lived WS tickets). No new dependencies; all crypto via `node:crypto`. Enforcement is server-side at every surface (REST + WebSocket), never UI-only.
+
+## Data model
+
+Two new tables in `~/.shooter/shooter.db`, managed by a new `src/lib/modules/server/terminal/share-store.ts` following the exact patterns of `terminal-store.ts` (WAL pragma, `CREATE TABLE IF NOT EXISTS`, snake_case columns, `globalThis` singleton).
+
+```sql
+CREATE TABLE IF NOT EXISTS terminal_shares (
+  terminal_id   TEXT PRIMARY KEY,
+  password_hash TEXT NOT NULL,        -- scrypt:<salt-hex>:<hash-hex>
+  mode          TEXT NOT NULL,        -- 'view' | 'control'
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS share_sessions (
+  token_hash  TEXT PRIMARY KEY,       -- sha256 hex of the guest bearer token
+  terminal_id TEXT NOT NULL,
+  created_at  INTEGER NOT NULL,
+  expires_at  INTEGER NOT NULL        -- created_at + 7 days
+);
+```
+
+- **Password hashing:** `crypto.scryptSync(password, salt, 64)` with a 16-byte random salt per share; stored as `scrypt:<salt>:<hash>`. Verified with `timingSafeEqual`.
+- **Guest tokens:** `randomBytes(32).toString('hex')` returned to the client once; only the sha256 hash is stored. Sessions expire after 7 days (guest re-enters the password); revoke deletes them immediately.
+- **Cleanup:** expired sessions purged on access/startup; shares whose `terminal_id` no longer exists in `terminals` are purged on startup (same cadence as terminal-store's 24 h cleanup).
+
+## API
+
+### Owner endpoints (Bearer `API_KEY`, via existing `validateAuth`)
+
+| Endpoint                           | Behavior                                                                                                                                                                                                                                                                                                           |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `GET /api/terminals/[id]/share`    | `{ active, mode, createdAt, updatedAt }` or `{ active: false }`                                                                                                                                                                                                                                                    |
+| `PUT /api/terminals/[id]/share`    | Body `{ password?, mode }`. Creates or updates. Password required on create (min 6 chars); omitting it on update keeps the existing one. New password ⇒ delete all guest sessions + force-close guest sockets. Mode change ⇒ force-close guest sockets (sessions stay valid; guests reconnect with the new scope). |
+| `DELETE /api/terminals/[id]/share` | Revoke: delete share + sessions, force-close guest sockets.                                                                                                                                                                                                                                                        |
+
+`DELETE /api/terminals/[id]` (kill/remove terminal) also revokes any share for that terminal.
+
+### Guest endpoints (no API key)
+
+| Endpoint                               | Behavior                                                                                                                                                                                |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/terminals/[id]/share/status` | Public probe: `{ shared: boolean }`. Never reveals mode or anything else.                                                                                                               |
+| `POST /api/terminals/[id]/share/auth`  | Body `{ password }`. Rate-limited (10 attempts/min per client-IP+terminal, in-memory; 429 on exceed). On success: `{ token, mode, expiresAt }`. 404 if no share; 401 on wrong password. |
+
+### Endpoints that additionally accept a guest token (scoped to its terminal only)
+
+A shared helper `resolveAccess(request, terminalId)` returns `{ level: 'owner' } | { level: 'guest', mode } | null`: it first runs the existing timing-safe API-key check, then looks up the presented bearer token's sha256 in `share_sessions` (matching `terminal_id`, unexpired).
+
+| Endpoint                               | Guest access                                                                                                                                                |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/terminals/[id]`              | Both modes. Response gains optional `shareMode` field when accessed by a guest (authoritative per-request, so mode changes propagate on refresh/reconnect). |
+| `POST /api/ws-ticket`                  | Both modes — but issues a **scoped** ticket (below). Rate limit keyed by token hash.                                                                        |
+| `POST /api/terminals/[id]/resize`      | `control` only.                                                                                                                                             |
+| `POST /api/terminals/[id]/paste-image` | `control` only.                                                                                                                                             |
+
+Every other route is untouched and stays API-key-only.
+
+## WebSocket enforcement
+
+The in-memory `Ticket` gains optional scope fields: `terminalId?: string`, `readOnly?: boolean` (in `specs/types/ws-protocol.yaml`).
+
+- `generateTicket(scope?)` stores the scope; `validateTicket(ticket)` now returns the consumed `Ticket | null` instead of boolean (the `server.ts` upgrade handler passes the scope down to `setupWebSocketHandlers`).
+- **Routing gate** (central, in `setupWebSocketHandlers`): a scoped ticket may only open `/ws/terminal/<scopedId>` or `/ws/session/<scopedId>`. Everything else — other ids, `/ws/events`, `/ws/super-session/*` — is destroyed. (`/ws/events` broadcasts every terminal's activity, so it is denied outright.)
+- **Terminal channel**, scoped + read-only: inbound `input`, `resize`, `signal` frames are dropped.
+- **Session channel**, scoped: `subscribe.sessionId` must equal the scoped terminal id (no pivoting to other sessions); `send-input` and `cancel` are dropped when read-only.
+- **Guest connection registry:** scoped connections are tracked per terminal (globalThis map, like the events-client set) so revoke/mode-change/password-change can force-close them.
+- **New server→client frame `{ type: 'resize', cols, rows }`** broadcast to all attached terminal-channel clients when the PTY is resized. View-only guests apply it to their xterm (they cannot resize the PTY and otherwise render garbled output after an owner resize). Existing clients ignore unknown frame types.
+
+## Frontend (`/terminals/[id]`)
+
+**Guest flow:** on mount, if no API key is configured → `GET .../share/status`. If shared, check `localStorage` (`shooter_share_tokens`: `{ [terminalId]: token }`) and try the terminal fetch with it; on 401/missing, show a password gate (ShareGate component). Successful auth stores the token and the page proceeds through the normal flow (terminal fetch → ws-ticket → WS connect) using the share token as the bearer. If not shared and no API key → existing "no configuration" error.
+
+**View-only rendering:** xterm wrapper gets a `readOnly` option — keystrokes not forwarded, no resize messages (xterm fixed to the PTY's `cols`/`rows` from the terminal record, updated by `resize` frames), paste disabled. QuickKeys hidden; ChatView input/cancel hidden; kill/delete actions hidden. `control` mode behaves like the owner view minus owner-only actions (kill, share management).
+
+**Owner share UI:** a Share button on the terminal detail page opens a ShareSheet: enable sharing (password input + "generate" button producing a 16-char random password, mode picker view/control), shows the shareable URL (the current page URL) with copy button, shows active state, allows mode change and revoke.
+
+## Types
+
+- `specs/types/share.yaml` (new group `Share` in `specs/types/index.yaml`): `ShareMode` enum, `TerminalShareRecord`, `ShareSessionRecord`, `ShareInfoResponse`, `ShareStatusResponse`, `ShareAuthRequest`, `ShareAuthResponse`, `ShareConfigRequest`, `AccessContext` (`{ level: 'owner' | 'guest', mode?: ShareMode }`).
+- `ws-protocol.yaml`: `Ticket` scope fields; terminal server message union gains `resize` frame (hand-written `Wire*` union in `src/lib/types/ws.ts` updated accordingly).
+- All imports via the `$lib/types` barrel; `pnpm gen:types` after YAML edits.
+
+## Security notes
+
+- Passwords never stored or logged in plaintext; scrypt + per-share salt; `timingSafeEqual` everywhere secrets are compared.
+- Guest tokens stored hashed at rest; transmitted only over HTTPS (Cloudflare Tunnel) as Bearer headers; WS still uses single-use 30 s tickets so tokens never appear in URLs.
+- Brute-force: per-IP+terminal rate limit on `/share/auth` (uses `cf-connecting-ip` → `x-forwarded-for` → `getClientAddress()`).
+- Page HTML was already publicly served (no SSR auth exists today); data access is what is gated — unchanged posture.
+- The public `share/status` probe leaks only the boolean existence of a share for an 8-hex-char terminal id; acceptable.
+
+## Testing & verification
+
+1. `tests/share-store.test.cjs` — mirrors repo convention (plain `.cjs`, replicated schema against `/tmp`): share CRUD, scrypt hash/verify roundtrip incl. wrong password, session create/lookup/expiry, revoke cascade, orphan cleanup. Added to the `test` script in `package.json`.
+2. `pnpm quality:all` (lint, format, svelte-check, tsc strict) + `pnpm build` + `pnpm test` all pass.
+3. **Live end-to-end:** build & run the server, create a terminal, enable a share via API, then verify with curl: status probe, wrong-password 401, rate-limit 429, auth success, guest terminal fetch, scoped ws-ticket, scoped-WS rejection of `/ws/events` and foreign terminal ids, read-only input drop, revoke force-close. Then a browser pass on the real page (password gate → live terminal; view-only typing blocked).
+
+## Done criteria
+
+An incognito browser can open `/terminals/<id>`, enter the password, and watch (or control, per share mode) that terminal live. Typing in view-only mode does nothing (server-side drop). Revoking from the owner page disconnects the guest within seconds. No other terminal, session, event stream, or API endpoint is reachable with the guest's credentials. CI quality gates pass; single squashed semantic commit.

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "format:generated": "prettier --write ./src/lib/types/generated/*",
     "quality:all": "pnpm run lint && pnpm run format:check && pnpm run check",
     "gen:types": "npx type-crafter generate typescript-with-decoders ./specs/types/index.yaml ./src/lib/types/generated SingleFile SingleFile && bash scripts/postgen-types.sh && pnpm run format:generated",
-    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/plan-mode-routing.test.cjs && node tests/dynamic-options-extraction.test.cjs && node tests/codex-parser.test.cjs && node tests/provider-readers.test.cjs && node tests/generic-watcher.test.cjs && node tests/sos-coordinator.test.cjs && node tests/sos-policy.test.cjs && node tests/pty-input.test.cjs",
+    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/plan-mode-routing.test.cjs && node tests/dynamic-options-extraction.test.cjs && node tests/codex-parser.test.cjs && node tests/provider-readers.test.cjs && node tests/generic-watcher.test.cjs && node tests/sos-coordinator.test.cjs && node tests/sos-policy.test.cjs && node tests/pty-input.test.cjs && node tests/share-store.test.cjs",
     "setup": "node scripts/setup.cjs",
     "prepare": "husky || true",
     "prepublishOnly": "pnpm build"

--- a/server.ts
+++ b/server.ts
@@ -172,15 +172,20 @@ server.on('upgrade', (request, socket, head) => {
 
   const ticket = url.searchParams.get('ticket');
 
-  if (!validateTicket(ticket)) {
+  const ticketEntry = validateTicket(ticket);
+  if (!ticketEntry) {
     socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
     socket.destroy();
     return;
   }
 
   // Delegate routing to the WS server module which inspects the pathname
-  // and dispatches to terminal, session, or events handlers.
-  setupWebSocketHandlers(wss, request, socket, head);
+  // and dispatches to terminal, session, or events handlers. Guest tickets
+  // carry a scope that restricts which channels may be opened.
+  const scope = ticketEntry.terminalId
+    ? { readOnly: ticketEntry.readOnly ?? false, terminalId: ticketEntry.terminalId }
+    : undefined;
+  setupWebSocketHandlers(wss, request, socket, head, scope);
 });
 
 // ── Start keepalive pings (30s interval, keeps Cloudflare Tunnel alive) ──

--- a/specs/types/client.yaml
+++ b/specs/types/client.yaml
@@ -157,6 +157,15 @@ Client:
       sessionWs:
         type: string
         description: WebSocket path for structured session stream
+      cols:
+        type: number
+        description: Current PTY width in columns (for fixed-size guest rendering)
+      rows:
+        type: number
+        description: Current PTY height in rows (for fixed-size guest rendering)
+      shareMode:
+        $ref: './specs/types/share.yaml#/Share/ShareMode'
+        description: Present when fetched with a guest share token — the guest's access mode
 
   # ─── Session API Response ────────────────────────────────────────
 

--- a/specs/types/index.yaml
+++ b/specs/types/index.yaml
@@ -54,3 +54,7 @@ groupedTypes:
   # Application configuration types
   Config:
     $ref: './specs/types/config.yaml#/Config'
+
+  # Terminal sharing types: share records, guest sessions, share API shapes
+  Share:
+    $ref: './specs/types/share.yaml#/Share'

--- a/specs/types/share.yaml
+++ b/specs/types/share.yaml
@@ -1,0 +1,150 @@
+# Terminal Sharing Type Definitions
+# Non-top file - referenced from index.yaml
+# Types for password-protected single-terminal sharing: share records,
+# guest sessions, and the share API request/response shapes.
+
+Share:
+  ShareMode:
+    type: string
+    enum:
+      - view
+      - control
+    description: What a share guest may do — watch only, or full input control
+
+  AccessLevel:
+    type: string
+    enum:
+      - owner
+      - guest
+    description: Authorization level resolved for a terminal-scoped request
+
+  AccessContext:
+    type: object
+    description: Resolved authorization for a terminal-scoped API request
+    required:
+      - level
+    properties:
+      level:
+        $ref: './specs/types/share.yaml#/Share/AccessLevel'
+        description: owner (API key) or guest (share session token)
+      mode:
+        $ref: './specs/types/share.yaml#/Share/ShareMode'
+        description: Guest access mode (present only when level is guest)
+
+  TerminalShareRecord:
+    type: object
+    description: Persisted share configuration for one terminal (terminal_shares table)
+    required:
+      - terminalId
+      - passwordHash
+      - mode
+      - createdAt
+      - updatedAt
+    properties:
+      terminalId:
+        type: string
+        description: Terminal this share belongs to (primary key)
+      passwordHash:
+        type: string
+        description: 'scrypt:<salt-hex>:<hash-hex> password hash'
+      mode:
+        $ref: './specs/types/share.yaml#/Share/ShareMode'
+        description: Access mode granted to guests
+      createdAt:
+        type: number
+        description: Unix timestamp (ms) when the share was created
+      updatedAt:
+        type: number
+        description: Unix timestamp (ms) when the share was last updated
+
+  ShareSessionRecord:
+    type: object
+    description: Persisted guest session (share_sessions table); token stored as sha256 hash
+    required:
+      - tokenHash
+      - terminalId
+      - createdAt
+      - expiresAt
+    properties:
+      tokenHash:
+        type: string
+        description: sha256 hex of the guest bearer token (primary key)
+      terminalId:
+        type: string
+        description: Terminal the session grants access to
+      createdAt:
+        type: number
+        description: Unix timestamp (ms) when the session was created
+      expiresAt:
+        type: number
+        description: Unix timestamp (ms) when the session expires (created + 7 days)
+
+  ShareInfoResponse:
+    type: object
+    description: Owner view of a terminal's share state (GET /api/terminals/[id]/share)
+    required:
+      - active
+    properties:
+      active:
+        type: boolean
+        description: Whether sharing is currently enabled for this terminal
+      mode:
+        $ref: './specs/types/share.yaml#/Share/ShareMode'
+        description: Current access mode (present when active)
+      createdAt:
+        type: number
+        description: Unix timestamp (ms) when the share was created (present when active)
+      updatedAt:
+        type: number
+        description: Unix timestamp (ms) when the share was last updated (present when active)
+
+  ShareStatusResponse:
+    type: object
+    description: Public probe response (GET /api/terminals/[id]/share/status)
+    required:
+      - shared
+    properties:
+      shared:
+        type: boolean
+        description: Whether a share exists for this terminal
+
+  ShareAuthRequest:
+    type: object
+    description: Guest password exchange request (POST /api/terminals/[id]/share/auth)
+    required:
+      - password
+    properties:
+      password:
+        type: string
+        description: The share password
+
+  ShareAuthResponse:
+    type: object
+    description: Guest session issued after successful password exchange
+    required:
+      - token
+      - mode
+      - expiresAt
+    properties:
+      token:
+        type: string
+        description: Guest bearer token (64-char hex, shown once)
+      mode:
+        $ref: './specs/types/share.yaml#/Share/ShareMode'
+        description: Access mode granted by this session
+      expiresAt:
+        type: number
+        description: Unix timestamp (ms) when this session expires
+
+  ShareConfigRequest:
+    type: object
+    description: Owner create/update share request (PUT /api/terminals/[id]/share)
+    required:
+      - mode
+    properties:
+      password:
+        type: string
+        description: New share password (min 6 chars; required on create, optional on update)
+      mode:
+        $ref: './specs/types/share.yaml#/Share/ShareMode'
+        description: Access mode to grant guests

--- a/specs/types/ws-protocol.yaml
+++ b/specs/types/ws-protocol.yaml
@@ -183,6 +183,7 @@ WsProtocol:
       - $ref: './specs/types/ws-protocol.yaml#/WsProtocol/TerminalScrollbackMessage'
       - $ref: './specs/types/ws-protocol.yaml#/WsProtocol/TerminalExitMessage'
       - $ref: './specs/types/ws-protocol.yaml#/WsProtocol/TerminalErrorMessage'
+      - $ref: './specs/types/ws-protocol.yaml#/WsProtocol/TerminalResizeMessage'
 
   # ═══════════════════════════════════════════════════════════════════════
   # Channel 2: Session Stream — /ws/session/:id
@@ -775,3 +776,23 @@ WsProtocol:
       used:
         type: boolean
         description: Whether the ticket has been consumed (single-use)
+      terminalId:
+        type: string
+        description: When set, the ticket may only open WS channels for this terminal
+      readOnly:
+        type: boolean
+        description: When true, input/resize/signal/send-input/cancel frames are dropped
+
+  TicketScope:
+    type: object
+    description: Scope restriction carried by a guest WebSocket ticket
+    required:
+      - terminalId
+      - readOnly
+    properties:
+      terminalId:
+        type: string
+        description: Only WS channels for this terminal may be opened
+      readOnly:
+        type: boolean
+        description: Whether the connection is view-only (input frames dropped)

--- a/src/lib/modules/client/terminal/ShareGate.svelte
+++ b/src/lib/modules/client/terminal/ShareGate.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import type { ShareGateProps } from '$lib/types';
+
+  import { Button, Input } from '@juspay/svelte-ui-components';
+
+  const { onSubmit }: ShareGateProps = $props();
+
+  let password = $state('');
+  let errorMsg = $state<null | string>(null);
+  let submitting = $state(false);
+
+  async function submit(): Promise<void> {
+    if (!password || submitting) {
+      return;
+    }
+    submitting = true;
+    errorMsg = null;
+    errorMsg = await onSubmit(password);
+    submitting = false;
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      void submit();
+    }
+  }
+</script>
+
+<div class="share-gate">
+  <div class="share-gate-card">
+    <h2 class="share-gate-title">Shared terminal</h2>
+    <p class="share-gate-sub">
+      This terminal is password protected. Enter the password to view it.
+    </p>
+    <Input
+      bind:value={password}
+      dataType="password"
+      placeholder="Password"
+      classes="share-gate-input"
+      onKeyDown={onKeydown}
+    />
+    {#if errorMsg}
+      <p class="share-gate-error">{errorMsg}</p>
+    {/if}
+    <Button
+      classes="btn-primary share-gate-btn"
+      onclick={(): void => {
+        void submit();
+      }}
+      disabled={!password || submitting}
+      showLoader={submitting}
+      text="Unlock"
+    />
+  </div>
+</div>
+
+<style>
+  .share-gate {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    padding: var(--space-4);
+  }
+
+  .share-gate-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    width: 100%;
+    max-width: 360px;
+    padding: var(--space-5);
+    background: var(--ds-background-100);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+  }
+
+  .share-gate-title {
+    margin: 0;
+    font-size: var(--text-lg);
+    color: var(--text-primary);
+  }
+
+  .share-gate-sub {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--text-tertiary);
+  }
+
+  .share-gate-error {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--ds-red-700, #ef4444);
+  }
+</style>

--- a/src/lib/modules/client/terminal/ShareSheet.svelte
+++ b/src/lib/modules/client/terminal/ShareSheet.svelte
@@ -1,0 +1,395 @@
+<script lang="ts">
+  import type { ShareInfoResponse, ShareMode, ShareSheetProps } from '$lib/types';
+
+  import { getApiKey } from '$lib/modules/client/common';
+  import { Button, Input } from '@juspay/svelte-ui-components';
+
+  const { onClose, open = false, shareUrl, terminalId }: ShareSheetProps = $props();
+
+  let active = $state(false);
+  let currentMode = $state<null | ShareMode>(null);
+  let mode = $state<ShareMode>('view');
+  let password = $state('');
+  let busy = $state(false);
+  let errorMsg = $state<null | string>(null);
+  let copied = $state(false);
+
+  // Password characters avoid ambiguous glyphs (0/O, 1/l/I).
+  const PASSWORD_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789';
+
+  const canSubmit = $derived(
+    active ? password.length === 0 || password.length >= 6 : password.length >= 6
+  );
+
+  $effect(() => {
+    if (open) {
+      void loadInfo();
+    }
+  });
+
+  async function loadInfo(): Promise<void> {
+    errorMsg = null;
+    copied = false;
+    try {
+      const res = await fetch(`/api/terminals/${terminalId}/share`, {
+        headers: { Authorization: `Bearer ${getApiKey()}` },
+      });
+      if (!res.ok) {
+        errorMsg = 'Failed to load share state.';
+        return;
+      }
+      const info = (await res.json()) as ShareInfoResponse;
+      active = info.active;
+      currentMode = info.mode ?? null;
+      mode = info.mode ?? 'view';
+      password = '';
+    } catch {
+      errorMsg = 'Failed to reach the server.';
+    }
+  }
+
+  function generatePassword(): void {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    password = Array.from(bytes, (b) => PASSWORD_ALPHABET[b % PASSWORD_ALPHABET.length]).join('');
+  }
+
+  async function saveShare(): Promise<void> {
+    if (busy || !canSubmit) {
+      return;
+    }
+    busy = true;
+    errorMsg = null;
+    try {
+      const res = await fetch(`/api/terminals/${terminalId}/share`, {
+        body: JSON.stringify({ mode, ...(password ? { password } : {}) }),
+        headers: {
+          Authorization: `Bearer ${getApiKey()}`,
+          'Content-Type': 'application/json',
+        },
+        method: 'PUT',
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        errorMsg = data.error ?? 'Failed to save share.';
+        return;
+      }
+      const info = (await res.json()) as ShareInfoResponse;
+      active = info.active;
+      currentMode = info.mode ?? null;
+      password = '';
+    } catch {
+      errorMsg = 'Failed to reach the server.';
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function revokeShare(): Promise<void> {
+    if (busy) {
+      return;
+    }
+    busy = true;
+    errorMsg = null;
+    try {
+      const res = await fetch(`/api/terminals/${terminalId}/share`, {
+        headers: { Authorization: `Bearer ${getApiKey()}` },
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        errorMsg = 'Failed to revoke share.';
+        return;
+      }
+      active = false;
+      currentMode = null;
+      password = '';
+    } catch {
+      errorMsg = 'Failed to reach the server.';
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function copyUrl(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      copied = true;
+      setTimeout(() => {
+        copied = false;
+      }, 2000);
+    } catch {
+      errorMsg = 'Failed to copy.';
+    }
+  }
+</script>
+
+{#if open}
+  <div
+    class="share-backdrop"
+    onclick={onClose}
+    onkeydown={(e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    }}
+    role="presentation"
+  >
+    <div
+      class="share-sheet"
+      onclick={(e: MouseEvent): void => {
+        e.stopPropagation();
+      }}
+      role="dialog"
+      aria-label="Share terminal"
+      tabindex="-1"
+      onkeydown={(e: KeyboardEvent): void => {
+        if (e.key === 'Escape') {
+          onClose();
+        }
+      }}
+    >
+      <div class="share-sheet-header">
+        <h2 class="share-sheet-title">Share terminal</h2>
+        <button class="share-sheet-close" onclick={onClose} aria-label="Close">&times;</button>
+      </div>
+
+      {#if active}
+        <div class="share-active-row">
+          <span class="share-active-dot"></span>
+          <span class="share-active-label">
+            Sharing is active ({currentMode === 'control' ? 'full control' : 'view only'})
+          </span>
+        </div>
+        <div class="share-url-row">
+          <span class="share-url">{shareUrl}</span>
+          <Button
+            classes="btn-secondary btn-sm"
+            onclick={(): void => {
+              void copyUrl();
+            }}
+            text={copied ? 'Copied' : 'Copy'}
+          />
+        </div>
+      {:else}
+        <p class="share-sheet-sub">
+          Anyone with this page's link and the password below can access this terminal.
+        </p>
+      {/if}
+
+      <div class="share-field">
+        <span class="share-field-label">Access</span>
+        <div class="share-mode-toggle">
+          <button
+            class="share-mode-btn {mode === 'view' ? 'share-mode-active' : ''}"
+            onclick={(): void => {
+              mode = 'view';
+            }}
+          >
+            View only
+          </button>
+          <button
+            class="share-mode-btn {mode === 'control' ? 'share-mode-active' : ''}"
+            onclick={(): void => {
+              mode = 'control';
+            }}
+          >
+            Full control
+          </button>
+        </div>
+      </div>
+
+      <div class="share-field">
+        <span class="share-field-label">
+          {active ? 'New password (leave empty to keep current)' : 'Password (min 6 chars)'}
+        </span>
+        <div class="share-password-row">
+          <Input
+            bind:value={password}
+            dataType="text"
+            placeholder="Password"
+            classes="share-password-input"
+          />
+          <Button classes="btn-secondary btn-sm" onclick={generatePassword} text="Generate" />
+        </div>
+      </div>
+
+      {#if errorMsg}
+        <p class="share-error">{errorMsg}</p>
+      {/if}
+
+      <div class="share-actions">
+        {#if active}
+          <Button
+            classes="btn-danger btn-sm"
+            onclick={(): void => {
+              void revokeShare();
+            }}
+            disabled={busy}
+            text="Stop sharing"
+          />
+        {/if}
+        <Button
+          classes="btn-primary btn-sm"
+          onclick={(): void => {
+            void saveShare();
+          }}
+          disabled={busy || !canSubmit}
+          showLoader={busy}
+          text={active ? 'Update' : 'Start sharing'}
+        />
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .share-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.5);
+    padding: var(--space-4);
+  }
+
+  .share-sheet {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    width: 100%;
+    max-width: 420px;
+    padding: var(--space-5);
+    background: var(--ds-background-100);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+  }
+
+  .share-sheet-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .share-sheet-title {
+    margin: 0;
+    font-size: var(--text-lg);
+    color: var(--text-primary);
+  }
+
+  .share-sheet-close {
+    background: none;
+    border: none;
+    color: var(--text-tertiary);
+    font-size: 22px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 4px;
+  }
+
+  .share-sheet-close:hover {
+    color: var(--text-primary);
+  }
+
+  .share-sheet-sub {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--text-tertiary);
+  }
+
+  .share-active-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .share-active-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--ds-green-500, #22c55e);
+  }
+
+  .share-active-label {
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+  }
+
+  .share-url-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2);
+    background: var(--ds-gray-200);
+    border-radius: var(--radius-md);
+  }
+
+  .share-url {
+    flex: 1;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .share-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .share-field-label {
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+  }
+
+  .share-mode-toggle {
+    display: flex;
+    gap: 2px;
+    padding: 2px;
+    background: var(--ds-gray-200);
+    border: 1px solid var(--ds-gray-400);
+    border-radius: var(--radius-md);
+    width: fit-content;
+  }
+
+  .share-mode-btn {
+    padding: 6px 12px;
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+    background: none;
+    border: none;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+
+  .share-mode-active {
+    background: var(--ds-background-100);
+    color: var(--text-primary);
+  }
+
+  .share-password-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .share-password-row :global(.share-password-input) {
+    --input-container-margin: 0;
+    flex: 1;
+  }
+
+  .share-error {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--ds-red-700, #ef4444);
+  }
+
+  .share-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-2);
+  }
+</style>

--- a/src/lib/modules/client/terminal/xterm-wrapper.ts
+++ b/src/lib/modules/client/terminal/xterm-wrapper.ts
@@ -48,7 +48,12 @@ export async function createTerminal(options: TerminalOptions): Promise<Terminal
   term.loadAddon(fitAddon);
   term.loadAddon(new WebLinksAddon());
   term.open(options.container);
-  fitAddon.fit();
+  if (options.readOnly && options.initialCols && options.initialRows) {
+    // View-only: render at the PTY's size (we may not resize the shared PTY).
+    term.resize(options.initialCols, options.initialRows);
+  } else {
+    fitAddon.fit();
+  }
 
   // Block browser-level Cmd/Ctrl shortcuts from reaching the PTY.
   // Allow Ctrl+<letter> terminal signals (Ctrl+C/D/L/R/Z etc.) through.
@@ -71,7 +76,7 @@ export async function createTerminal(options: TerminalOptions): Promise<Terminal
 
   // Clipboard image paste interception
   let pasteListener: ((e: ClipboardEvent) => void) | null = null;
-  if (options.terminalId && options.apiKey) {
+  if (options.terminalId && options.apiKey && !options.readOnly) {
     const pasteTermId = options.terminalId;
     const pasteApiKey = options.apiKey;
 
@@ -185,6 +190,12 @@ export async function createTerminal(options: TerminalOptions): Promise<Terminal
         options.onActivity?.(msg.active ?? false);
       } else if (msg.type === 'cwd') {
         options.onCwd?.(msg.path ?? '');
+      } else if (msg.type === 'resize') {
+        // PTY was resized by another client (e.g. the owner). View-only
+        // terminals follow it; interactive ones are governed by their fit.
+        if (options.readOnly && msg.cols && msg.rows) {
+          term.resize(msg.cols, msg.rows);
+        }
       }
     };
 
@@ -205,6 +216,9 @@ export async function createTerminal(options: TerminalOptions): Promise<Terminal
 
   // Terminal input -> WebSocket
   term.onData((data) => {
+    if (options.readOnly) {
+      return;
+    }
     if (ws?.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify({ data, type: 'input' }));
     }
@@ -212,6 +226,9 @@ export async function createTerminal(options: TerminalOptions): Promise<Terminal
 
   // Handle resize — skip when container is hidden (display:none → size 0)
   const resizeObserver = new ResizeObserver((): void => {
+    if (options.readOnly) {
+      return; // View-only terminals keep the PTY's dimensions.
+    }
     if (!options.container.offsetWidth || !options.container.offsetHeight) {
       return;
     }

--- a/src/lib/modules/server/terminal/pty-manager.ts
+++ b/src/lib/modules/server/terminal/pty-manager.ts
@@ -483,6 +483,12 @@ class PtyManager {
       terminal.pty.resize(cols, rows);
       terminal.cols = cols;
       terminal.rows = rows;
+      // Broadcast the new PTY size so attached clients (e.g. view-only
+      // guests) can follow the terminal dimensions.
+      const msg = JSON.stringify({ cols, rows, type: 'resize' });
+      for (const ws of terminal.clients) {
+        this.safeSend(ws, msg);
+      }
       return true;
     } catch {
       return false;

--- a/src/lib/modules/server/terminal/share-auth.ts
+++ b/src/lib/modules/server/terminal/share-auth.ts
@@ -1,0 +1,37 @@
+// Resolves a terminal-scoped request to owner (API key) or guest (share token).
+// Kept separate from auth.ts so routes without share semantics don't pull in SQLite.
+
+import type { AccessContext } from '$lib/types';
+
+import { validateAuth } from '../auth';
+import { shareStore } from './share-store';
+
+/** Extract the Bearer token from a request, or null. */
+export function bearerToken(request: Request): null | string {
+  const auth = request.headers.get('Authorization') || request.headers.get('authorization');
+  if (!auth?.startsWith('Bearer ')) {
+    return null;
+  }
+  return auth.slice(7).trim();
+}
+
+/**
+ * Resolve access for a request targeting one terminal.
+ * Owner (valid API key) → { level: 'owner' }.
+ * Guest (valid share session for THIS terminal) → { level: 'guest', mode }.
+ * Anything else → null.
+ */
+export function resolveAccess(request: Request, terminalId: string): AccessContext | null {
+  if (validateAuth(request) === null) {
+    return { level: 'owner', mode: null };
+  }
+  const token = bearerToken(request);
+  if (!token) {
+    return null;
+  }
+  const session = shareStore.resolveToken(token);
+  if (session?.terminalId !== terminalId) {
+    return null;
+  }
+  return { level: 'guest', mode: session.mode };
+}

--- a/src/lib/modules/server/terminal/share-store.ts
+++ b/src/lib/modules/server/terminal/share-store.ts
@@ -1,0 +1,172 @@
+/**
+ * Share Store — SQLite persistence for terminal sharing.
+ *
+ * terminal_shares: one share per terminal (scrypt password hash + mode).
+ * share_sessions:  guest sessions keyed by sha256(token), 7-day TTL.
+ *
+ * Database location: ~/.shooter/shooter.db (same file as terminal-store).
+ */
+
+import type { ShareMode, TerminalShareRecord } from '$lib/types';
+
+import Database from 'better-sqlite3';
+import { createHash, randomBytes, scryptSync, timingSafeEqual } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DB_DIR = path.join(process.env.HOME || '', '.shooter');
+const DB_PATH = path.join(DB_DIR, 'shooter.db');
+
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+// ── Password hashing (scrypt, per-share random salt) ─────────────────
+
+export class ShareStore {
+  private db: Database.Database;
+
+  constructor() {
+    fs.mkdirSync(DB_DIR, { recursive: true });
+    this.db = new Database(DB_PATH);
+    this.db.pragma('journal_mode = WAL');
+
+    this.db.exec(`
+			CREATE TABLE IF NOT EXISTS terminal_shares (
+				terminal_id   TEXT PRIMARY KEY,
+				password_hash TEXT NOT NULL,
+				mode          TEXT NOT NULL,
+				created_at    INTEGER NOT NULL,
+				updated_at    INTEGER NOT NULL
+			);
+			CREATE TABLE IF NOT EXISTS share_sessions (
+				token_hash  TEXT PRIMARY KEY,
+				terminal_id TEXT NOT NULL,
+				created_at  INTEGER NOT NULL,
+				expires_at  INTEGER NOT NULL
+			)
+		`);
+
+    this.cleanup();
+  }
+
+  /** Purge expired sessions and shares whose terminal no longer exists. */
+  cleanup(): void {
+    this.db.prepare('DELETE FROM share_sessions WHERE expires_at < ?').run(Date.now());
+    try {
+      this.db
+        .prepare('DELETE FROM terminal_shares WHERE terminal_id NOT IN (SELECT id FROM terminals)')
+        .run();
+      this.db
+        .prepare('DELETE FROM share_sessions WHERE terminal_id NOT IN (SELECT id FROM terminals)')
+        .run();
+    } catch {
+      // terminals table may not exist yet on a fresh database — skip orphan cleanup.
+    }
+  }
+
+  /** Issue a new guest session for a shared terminal. Returns the raw token (stored hashed). */
+  createSession(terminalId: string): { expiresAt: number; token: string } {
+    const token = randomBytes(32).toString('hex');
+    const now = Date.now();
+    const expiresAt = now + SESSION_TTL_MS;
+    this.db
+      .prepare(
+        'INSERT INTO share_sessions (token_hash, terminal_id, created_at, expires_at) VALUES (?, ?, ?, ?)'
+      )
+      .run(hashToken(token), terminalId, now, expiresAt);
+    return { expiresAt, token };
+  }
+
+  /** Delete all guest sessions for a terminal (password change / revoke). */
+  deleteSessions(terminalId: string): void {
+    this.db.prepare('DELETE FROM share_sessions WHERE terminal_id = ?').run(terminalId);
+  }
+
+  /** Revoke a share: delete the share row and every guest session for it. */
+  deleteShare(terminalId: string): void {
+    this.db.prepare('DELETE FROM terminal_shares WHERE terminal_id = ?').run(terminalId);
+    this.deleteSessions(terminalId);
+  }
+
+  getShare(terminalId: string): null | TerminalShareRecord {
+    const row = this.db
+      .prepare('SELECT * FROM terminal_shares WHERE terminal_id = ?')
+      .get(terminalId) as Record<string, unknown> | undefined;
+    return row ? rowToShare(row) : null;
+  }
+
+  /**
+   * Resolve a guest bearer token to its terminal + mode.
+   * Returns null if unknown, expired, or the share was revoked.
+   */
+  resolveToken(token: string): null | { mode: ShareMode; terminalId: string } {
+    if (!token) {
+      return null;
+    }
+    const row = this.db
+      .prepare(
+        `SELECT s.terminal_id, s.expires_at, sh.mode
+				 FROM share_sessions s
+				 JOIN terminal_shares sh ON sh.terminal_id = s.terminal_id
+				 WHERE s.token_hash = ?`
+      )
+      .get(hashToken(token)) as Record<string, unknown> | undefined;
+    if (!row) {
+      return null;
+    }
+    if ((row.expires_at as number) < Date.now()) {
+      this.db.prepare('DELETE FROM share_sessions WHERE token_hash = ?').run(hashToken(token));
+      return null;
+    }
+    return { mode: row.mode as ShareMode, terminalId: row.terminal_id as string };
+  }
+
+  /** Create or replace the share for a terminal. */
+  setShare(record: TerminalShareRecord): void {
+    this.db
+      .prepare(
+        `INSERT OR REPLACE INTO terminal_shares
+				 (terminal_id, password_hash, mode, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?)`
+      )
+      .run(record.terminalId, record.passwordHash, record.mode, record.createdAt, record.updatedAt);
+  }
+}
+
+export function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `scrypt:${salt}:${hash}`;
+}
+
+export function verifyPassword(password: string, stored: string): boolean {
+  const parts = stored.split(':');
+  if (parts.length !== 3 || parts[0] !== 'scrypt') {
+    return false;
+  }
+  const expected = Buffer.from(parts[2], 'hex');
+  const actual = scryptSync(password, parts[1], 64);
+  return expected.length === actual.length && timingSafeEqual(actual, expected);
+}
+
+// ── Row mapping ──────────────────────────────────────────────────────
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function rowToShare(row: Record<string, unknown>): TerminalShareRecord {
+  return {
+    createdAt: row.created_at as number,
+    mode: row.mode as ShareMode,
+    passwordHash: row.password_hash as string,
+    terminalId: row.terminal_id as string,
+    updatedAt: row.updated_at as number,
+  };
+}
+
+// ── Singleton (globalThis bridges tsx server.ts + SvelteKit handler) ─
+
+const SS_GLOBAL_KEY = '__shooter_share_store';
+export const shareStore: ShareStore =
+  ((globalThis as Record<string, unknown>)[SS_GLOBAL_KEY] as ShareStore) || new ShareStore();
+(globalThis as Record<string, unknown>)[SS_GLOBAL_KEY] = shareStore;

--- a/src/lib/modules/server/ws/guest-registry.ts
+++ b/src/lib/modules/server/ws/guest-registry.ts
@@ -1,0 +1,49 @@
+// Tracks WebSocket connections opened with a guest (scoped) ticket, per terminal,
+// so revoke / mode-change / password-change can force-close them immediately.
+// globalThis bridges the tsx server.ts and SvelteKit handler module scopes.
+
+import type { WebSocket } from 'ws';
+
+const GUESTS_KEY = '__shooter_ws_guest_conns';
+const guests: Map<string, Set<WebSocket>> = ((globalThis as Record<string, unknown>)[
+  GUESTS_KEY
+] as Map<string, Set<WebSocket>>) || new Map<string, Set<WebSocket>>();
+(globalThis as Record<string, unknown>)[GUESTS_KEY] = guests;
+
+/** Force-close every guest connection for a terminal. Returns the number closed. */
+export function closeGuests(terminalId: string): number {
+  const set = guests.get(terminalId);
+  if (!set) {
+    return 0;
+  }
+  let closed = 0;
+  for (const ws of set) {
+    try {
+      ws.close(4001, 'Share revoked');
+      closed++;
+    } catch {
+      // Already closing/closed.
+    }
+  }
+  guests.delete(terminalId);
+  return closed;
+}
+
+/** Register a guest connection; auto-removes itself on close. */
+export function registerGuest(terminalId: string, ws: WebSocket): void {
+  let set = guests.get(terminalId);
+  if (!set) {
+    set = new Set<WebSocket>();
+    guests.set(terminalId, set);
+  }
+  set.add(ws);
+  ws.on('close', () => {
+    const current = guests.get(terminalId);
+    if (current) {
+      current.delete(ws);
+      if (current.size === 0) {
+        guests.delete(terminalId);
+      }
+    }
+  });
+}

--- a/src/lib/modules/server/ws/server.ts
+++ b/src/lib/modules/server/ws/server.ts
@@ -5,6 +5,7 @@
 //   /ws/session/:id   -> Live structured session stream
 //   /ws/events         -> Global event bus (broadcasts)
 
+import type { TicketScope } from '$lib/types';
 import type { IncomingMessage } from 'http';
 import type { Duplex } from 'stream';
 import type { WebSocket, WebSocketServer } from 'ws';
@@ -14,6 +15,7 @@ import {
   getEventsClientCount,
   handleEventsConnection,
 } from './events-handler.js';
+import { registerGuest } from './guest-registry.js';
 import { handleSessionConnection } from './session-handler.js';
 import { handleSuperSessionConnection } from './super-session-handler.js';
 import { handleTerminalConnection } from './terminal-handler.js';
@@ -49,7 +51,8 @@ export function setupWebSocketHandlers(
   wss: WebSocketServer,
   request: IncomingMessage,
   socket: Duplex,
-  head: Buffer
+  head: Buffer,
+  scope?: TicketScope
 ): void {
   const host = request.headers.host ?? 'localhost';
   let pathname: string;
@@ -71,8 +74,24 @@ export function setupWebSocketHandlers(
     return;
   }
 
+  // Scoped (guest) tickets may only open the terminal/session channels of
+  // their own terminal. Events and super-session channels broadcast global
+  // data, so they are denied outright.
+  if (scope) {
+    const target = terminalMatch?.[1] ?? sessionMatch?.[1];
+    if (!target || superSessionMatch || target !== scope.terminalId) {
+      socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+  }
+
   wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
     allConnections.add(ws);
+
+    if (scope) {
+      registerGuest(scope.terminalId, ws);
+    }
 
     ws.on('close', () => {
       allConnections.delete(ws);
@@ -84,13 +103,13 @@ export function setupWebSocketHandlers(
 
     if (terminalMatch) {
       const terminalId = terminalMatch[1];
-      handleTerminalConnection(ws, terminalId);
+      handleTerminalConnection(ws, terminalId, scope);
     } else if (superSessionMatch) {
       const superSessionId = superSessionMatch[1];
       handleSuperSessionConnection(ws, superSessionId);
     } else if (sessionMatch) {
       const sessionId = sessionMatch[1];
-      handleSessionConnection(ws, sessionId);
+      handleSessionConnection(ws, sessionId, scope);
     } else if (isEvents) {
       handleEventsConnection(ws);
     }

--- a/src/lib/modules/server/ws/session-handler.ts
+++ b/src/lib/modules/server/ws/session-handler.ts
@@ -16,6 +16,7 @@ import type {
   WireSessionServerMessage as ServerMessage,
   SessionWatcherLike,
   TextContentBlock,
+  TicketScope,
 } from '$lib/types';
 import type { WebSocket } from 'ws';
 
@@ -41,7 +42,7 @@ let _sessionWatcher: null | SessionWatcherLike = null;
  * 3. If still no terminal, treat as an external session — find the JSONL
  *    file directly and stream it via the session watcher.
  */
-export function handleSessionConnection(ws: WebSocket, id: string): void {
+export function handleSessionConnection(ws: WebSocket, id: string, scope?: TicketScope): void {
   const state: ConnectionState = {
     isExternalSession: false,
     retryInterval: null,
@@ -66,7 +67,7 @@ export function handleSessionConnection(ws: WebSocket, id: string): void {
   if (terminal) {
     state.terminalId = terminal.id;
     subscribeToSession(ws, state, terminal);
-    wireClientMessages(ws, state);
+    wireClientMessages(ws, state, scope);
     wireCleanup(ws, state);
     return;
   }
@@ -76,7 +77,7 @@ export function handleSessionConnection(ws: WebSocket, id: string): void {
   if (jsonlPath) {
     state.isExternalSession = true;
     subscribeToExternalSession(ws, state, jsonlPath);
-    wireClientMessages(ws, state);
+    wireClientMessages(ws, state, scope);
     wireCleanup(ws, state);
     return;
   }
@@ -507,7 +508,7 @@ function wireCleanup(ws: WebSocket, state: ConnectionState): void {
  * Extracted so both terminal-backed and external sessions share the same
  * message loop.
  */
-function wireClientMessages(ws: WebSocket, state: ConnectionState): void {
+function wireClientMessages(ws: WebSocket, state: ConnectionState, scope?: TicketScope): void {
   ws.on('message', (raw: Buffer | string) => {
     const data = typeof raw === 'string' ? raw : raw.toString('utf-8');
     const msg = parseClientMessage(data);
@@ -518,6 +519,10 @@ function wireClientMessages(ws: WebSocket, state: ConnectionState): void {
     try {
       switch (msg.type) {
         case 'cancel': {
+          if (scope?.readOnly) {
+            safeSend(ws, { message: 'This shared terminal is view-only.', type: 'error' });
+            return;
+          }
           if (state.isExternalSession) {
             safeSend(ws, {
               message: 'Cannot cancel — this is a read-only session. Connect to a terminal first.',
@@ -535,6 +540,10 @@ function wireClientMessages(ws: WebSocket, state: ConnectionState): void {
         }
 
         case 'send-input': {
+          if (scope?.readOnly) {
+            safeSend(ws, { message: 'This shared terminal is view-only.', type: 'error' });
+            return;
+          }
           if (state.isExternalSession) {
             safeSend(ws, {
               message:
@@ -557,6 +566,11 @@ function wireClientMessages(ws: WebSocket, state: ConnectionState): void {
         }
 
         case 'subscribe': {
+          // Scoped guests may only (re)subscribe to their own terminal's session.
+          if (scope && msg.sessionId !== scope.terminalId) {
+            safeSend(ws, { message: 'Not authorized for this session.', type: 'error' });
+            return;
+          }
           // (Re)subscribe to a different session. Clean up the old subscription.
           if (state.retryInterval) {
             clearInterval(state.retryInterval);

--- a/src/lib/modules/server/ws/terminal-handler.ts
+++ b/src/lib/modules/server/ws/terminal-handler.ts
@@ -7,6 +7,7 @@ import type {
   TerminalPtyManagerLike as PtyManagerLike,
   WireTerminalServerMessage as ServerMessage,
   TerminalSignal,
+  TicketScope,
 } from '$lib/types';
 import type { WebSocket } from 'ws';
 
@@ -28,7 +29,11 @@ let _ptyManager: null | PtyManagerLike = null;
  * Attaches the client to the terminal's viewer set, replays scrollback,
  * and relays PTY I/O bidirectionally.
  */
-export function handleTerminalConnection(ws: WebSocket, terminalId: string): void {
+export function handleTerminalConnection(
+  ws: WebSocket,
+  terminalId: string,
+  scope?: TicketScope
+): void {
   // ── 1. Look up the terminal ──────────────────────────────────────
   if (!_ptyManager) {
     safeSend(ws, { message: 'PTY manager not initialised', type: 'error' });
@@ -62,6 +67,11 @@ export function handleTerminalConnection(ws: WebSocket, terminalId: string): voi
       return; // Silently ignore malformed messages.
     }
 
+    // View-only guests: every inbound frame type mutates the PTY — drop them all.
+    if (scope?.readOnly) {
+      return;
+    }
+
     // Don't allow input to exited terminals.
     if (terminal.status === 'exited') {
       safeSend(ws, { message: 'Terminal has exited', type: 'error' });
@@ -74,9 +84,18 @@ export function handleTerminalConnection(ws: WebSocket, terminalId: string): voi
           terminal.pty.write(msg.data);
           break;
 
-        case 'resize':
+        case 'resize': {
           terminal.pty.resize(msg.cols, msg.rows);
+          // Broadcast the new PTY size to the other attached clients so
+          // view-only guests can follow the owner's terminal dimensions.
+          const resizeMsg: ServerMessage = { cols: msg.cols, rows: msg.rows, type: 'resize' };
+          for (const client of terminal.clients) {
+            if (client !== ws) {
+              safeSend(client, resizeMsg);
+            }
+          }
           break;
+        }
 
         case 'signal': {
           if (msg.signal === 'SIGINT') {

--- a/src/lib/modules/server/ws/ticket-store.ts
+++ b/src/lib/modules/server/ws/ticket-store.ts
@@ -5,7 +5,7 @@
 // This avoids putting the long-lived API_KEY in WebSocket URL query parameters,
 // which would appear in proxy logs, Cloudflare access logs, and browser history.
 
-import type { Ticket } from '$lib/types';
+import type { Ticket, TicketScope } from '$lib/types';
 
 import { randomBytes } from 'crypto';
 
@@ -21,32 +21,40 @@ const tickets: Map<string, Ticket> =
 /**
  * Generate a new single-use ticket (32-byte hex string).
  * The ticket is valid for 30 seconds and can only be consumed once.
+ * An optional scope restricts the ticket to one terminal's channels
+ * (and optionally to read-only access).
  */
-export function generateTicket(): string {
+export function generateTicket(scope?: TicketScope): string {
   const ticket = randomBytes(32).toString('hex');
-  tickets.set(ticket, { createdAt: Date.now(), used: false });
+  tickets.set(ticket, {
+    createdAt: Date.now(),
+    readOnly: scope?.readOnly ?? null,
+    terminalId: scope?.terminalId ?? null,
+    used: false,
+  });
   return ticket;
 }
 
 /**
  * Validate and consume a ticket.
- * Returns true if the ticket is valid, not yet used, and not expired.
- * A valid ticket is marked as used (single-use) and cannot be reused.
+ * Returns the consumed Ticket (including any scope) if it is valid, not yet
+ * used, and not expired; otherwise null. A valid ticket is marked as used
+ * (single-use) and cannot be reused.
  */
-export function validateTicket(ticket: null | string): boolean {
+export function validateTicket(ticket: null | string): null | Ticket {
   if (!ticket) {
-    return false;
+    return null;
   }
   const entry = tickets.get(ticket);
   if (!entry || entry.used) {
-    return false;
+    return null;
   }
   if (Date.now() - entry.createdAt > 30_000) {
     tickets.delete(ticket);
-    return false;
+    return null;
   }
   entry.used = true;
-  return true;
+  return entry;
 }
 
 // Cleanup expired tickets every 30 seconds (matches ticket lifetime).

--- a/src/lib/types/generated/Client.ts
+++ b/src/lib/types/generated/Client.ts
@@ -1,4 +1,4 @@
-import { type SessionSource, decodeSessionSource } from './index';
+import { type ShareMode, decodeShareMode, type SessionSource, decodeSessionSource } from './index';
 import {
   isJSON,
   decodeString,
@@ -307,6 +307,24 @@ export type TerminalDetailView = {
    * @memberof TerminalDetailView
    */
   sessionWs: string;
+  /**
+   * @description Current PTY width in columns (for fixed-size guest rendering)
+   * @type { number }
+   * @memberof TerminalDetailView
+   */
+  cols: number | null;
+  /**
+   * @description Current PTY height in rows (for fixed-size guest rendering)
+   * @type { number }
+   * @memberof TerminalDetailView
+   */
+  rows: number | null;
+  /**
+   * @description Present when fetched with a guest share token — the guest's access mode
+   * @type { ShareMode }
+   * @memberof TerminalDetailView
+   */
+  shareMode: ShareMode | null;
 };
 
 export function decodeTerminalDetailView(rawInput: unknown): TerminalDetailView | null {
@@ -325,6 +343,9 @@ export function decodeTerminalDetailView(rawInput: unknown): TerminalDetailView 
     const decodedTimestamp = decodeString(rawInput['timestamp']);
     const decodedWs = decodeString(rawInput['ws']);
     const decodedSessionWs = decodeString(rawInput['sessionWs']);
+    const decodedCols = decodeNumber(rawInput['cols']);
+    const decodedRows = decodeNumber(rawInput['rows']);
+    const decodedShareMode = decodeShareMode(rawInput['shareMode']);
 
     if (
       decodedId === null ||
@@ -355,6 +376,9 @@ export function decodeTerminalDetailView(rawInput: unknown): TerminalDetailView 
       timestamp: decodedTimestamp,
       ws: decodedWs,
       sessionWs: decodedSessionWs,
+      cols: decodedCols,
+      rows: decodedRows,
+      shareMode: decodedShareMode,
     };
   }
   return null;

--- a/src/lib/types/generated/Share.ts
+++ b/src/lib/types/generated/Share.ts
@@ -1,0 +1,404 @@
+import {
+  isJSON,
+  decodeString,
+  _decodeString,
+  decodeNumber,
+  _decodeNumber,
+  decodeBoolean,
+  _decodeBoolean,
+} from 'type-decoder';
+
+/**
+ * @type { ShareMode }
+ * @description What a share guest may do — watch only, or full input control
+ */
+export type ShareMode = 'view' | 'control';
+
+export function decodeShareMode(rawInput: unknown): ShareMode | null {
+  switch (rawInput) {
+    case 'view':
+    case 'control':
+      return rawInput;
+  }
+  return null;
+}
+
+export function _decodeShareMode(rawInput: unknown): ShareMode | undefined {
+  switch (rawInput) {
+    case 'view':
+    case 'control':
+      return rawInput;
+  }
+  return;
+}
+
+/**
+ * @type { AccessLevel }
+ * @description Authorization level resolved for a terminal-scoped request
+ */
+export type AccessLevel = 'owner' | 'guest';
+
+export function decodeAccessLevel(rawInput: unknown): AccessLevel | null {
+  switch (rawInput) {
+    case 'owner':
+    case 'guest':
+      return rawInput;
+  }
+  return null;
+}
+
+export function _decodeAccessLevel(rawInput: unknown): AccessLevel | undefined {
+  switch (rawInput) {
+    case 'owner':
+    case 'guest':
+      return rawInput;
+  }
+  return;
+}
+
+/**
+ * @type { AccessContext }
+ * @description Resolved authorization for a terminal-scoped API request
+ */
+export type AccessContext = {
+  /**
+   * @description owner (API key) or guest (share session token)
+   * @type { AccessLevel }
+   * @memberof AccessContext
+   */
+  level: AccessLevel;
+  /**
+   * @description Guest access mode (present only when level is guest)
+   * @type { ShareMode }
+   * @memberof AccessContext
+   */
+  mode: ShareMode | null;
+};
+
+export function decodeAccessContext(rawInput: unknown): AccessContext | null {
+  if (isJSON(rawInput)) {
+    const decodedLevel = decodeAccessLevel(rawInput['level']);
+    const decodedMode = decodeShareMode(rawInput['mode']);
+
+    if (decodedLevel === null) {
+      return null;
+    }
+
+    return {
+      level: decodedLevel,
+      mode: decodedMode,
+    };
+  }
+  return null;
+}
+
+/**
+ * @type { TerminalShareRecord }
+ * @description Persisted share configuration for one terminal (terminal_shares table)
+ */
+export type TerminalShareRecord = {
+  /**
+   * @description Terminal this share belongs to (primary key)
+   * @type { string }
+   * @memberof TerminalShareRecord
+   */
+  terminalId: string;
+  /**
+   * @description scrypt:<salt-hex>:<hash-hex> password hash
+   * @type { string }
+   * @memberof TerminalShareRecord
+   */
+  passwordHash: string;
+  /**
+   * @description Access mode granted to guests
+   * @type { ShareMode }
+   * @memberof TerminalShareRecord
+   */
+  mode: ShareMode;
+  /**
+   * @description Unix timestamp (ms) when the share was created
+   * @type { number }
+   * @memberof TerminalShareRecord
+   */
+  createdAt: number;
+  /**
+   * @description Unix timestamp (ms) when the share was last updated
+   * @type { number }
+   * @memberof TerminalShareRecord
+   */
+  updatedAt: number;
+};
+
+export function decodeTerminalShareRecord(rawInput: unknown): TerminalShareRecord | null {
+  if (isJSON(rawInput)) {
+    const decodedTerminalId = decodeString(rawInput['terminalId']);
+    const decodedPasswordHash = decodeString(rawInput['passwordHash']);
+    const decodedMode = decodeShareMode(rawInput['mode']);
+    const decodedCreatedAt = decodeNumber(rawInput['createdAt']);
+    const decodedUpdatedAt = decodeNumber(rawInput['updatedAt']);
+
+    if (
+      decodedTerminalId === null ||
+      decodedPasswordHash === null ||
+      decodedMode === null ||
+      decodedCreatedAt === null ||
+      decodedUpdatedAt === null
+    ) {
+      return null;
+    }
+
+    return {
+      terminalId: decodedTerminalId,
+      passwordHash: decodedPasswordHash,
+      mode: decodedMode,
+      createdAt: decodedCreatedAt,
+      updatedAt: decodedUpdatedAt,
+    };
+  }
+  return null;
+}
+
+/**
+ * @type { ShareSessionRecord }
+ * @description Persisted guest session (share_sessions table); token stored as sha256 hash
+ */
+export type ShareSessionRecord = {
+  /**
+   * @description sha256 hex of the guest bearer token (primary key)
+   * @type { string }
+   * @memberof ShareSessionRecord
+   */
+  tokenHash: string;
+  /**
+   * @description Terminal the session grants access to
+   * @type { string }
+   * @memberof ShareSessionRecord
+   */
+  terminalId: string;
+  /**
+   * @description Unix timestamp (ms) when the session was created
+   * @type { number }
+   * @memberof ShareSessionRecord
+   */
+  createdAt: number;
+  /**
+   * @description Unix timestamp (ms) when the session expires (created + 7 days)
+   * @type { number }
+   * @memberof ShareSessionRecord
+   */
+  expiresAt: number;
+};
+
+export function decodeShareSessionRecord(rawInput: unknown): ShareSessionRecord | null {
+  if (isJSON(rawInput)) {
+    const decodedTokenHash = decodeString(rawInput['tokenHash']);
+    const decodedTerminalId = decodeString(rawInput['terminalId']);
+    const decodedCreatedAt = decodeNumber(rawInput['createdAt']);
+    const decodedExpiresAt = decodeNumber(rawInput['expiresAt']);
+
+    if (
+      decodedTokenHash === null ||
+      decodedTerminalId === null ||
+      decodedCreatedAt === null ||
+      decodedExpiresAt === null
+    ) {
+      return null;
+    }
+
+    return {
+      tokenHash: decodedTokenHash,
+      terminalId: decodedTerminalId,
+      createdAt: decodedCreatedAt,
+      expiresAt: decodedExpiresAt,
+    };
+  }
+  return null;
+}
+
+/**
+ * @type { ShareInfoResponse }
+ * @description Owner view of a terminal's share state (GET /api/terminals/[id]/share)
+ */
+export type ShareInfoResponse = {
+  /**
+   * @description Whether sharing is currently enabled for this terminal
+   * @type { boolean }
+   * @memberof ShareInfoResponse
+   */
+  active: boolean;
+  /**
+   * @description Current access mode (present when active)
+   * @type { ShareMode }
+   * @memberof ShareInfoResponse
+   */
+  mode: ShareMode | null;
+  /**
+   * @description Unix timestamp (ms) when the share was created (present when active)
+   * @type { number }
+   * @memberof ShareInfoResponse
+   */
+  createdAt: number | null;
+  /**
+   * @description Unix timestamp (ms) when the share was last updated (present when active)
+   * @type { number }
+   * @memberof ShareInfoResponse
+   */
+  updatedAt: number | null;
+};
+
+export function decodeShareInfoResponse(rawInput: unknown): ShareInfoResponse | null {
+  if (isJSON(rawInput)) {
+    const decodedActive = decodeBoolean(rawInput['active']);
+    const decodedMode = decodeShareMode(rawInput['mode']);
+    const decodedCreatedAt = decodeNumber(rawInput['createdAt']);
+    const decodedUpdatedAt = decodeNumber(rawInput['updatedAt']);
+
+    if (decodedActive === null) {
+      return null;
+    }
+
+    return {
+      active: decodedActive,
+      mode: decodedMode,
+      createdAt: decodedCreatedAt,
+      updatedAt: decodedUpdatedAt,
+    };
+  }
+  return null;
+}
+
+/**
+ * @type { ShareStatusResponse }
+ * @description Public probe response (GET /api/terminals/[id]/share/status)
+ */
+export type ShareStatusResponse = {
+  /**
+   * @description Whether a share exists for this terminal
+   * @type { boolean }
+   * @memberof ShareStatusResponse
+   */
+  shared: boolean;
+};
+
+export function decodeShareStatusResponse(rawInput: unknown): ShareStatusResponse | null {
+  if (isJSON(rawInput)) {
+    const decodedShared = decodeBoolean(rawInput['shared']);
+
+    if (decodedShared === null) {
+      return null;
+    }
+
+    return {
+      shared: decodedShared,
+    };
+  }
+  return null;
+}
+
+/**
+ * @type { ShareAuthRequest }
+ * @description Guest password exchange request (POST /api/terminals/[id]/share/auth)
+ */
+export type ShareAuthRequest = {
+  /**
+   * @description The share password
+   * @type { string }
+   * @memberof ShareAuthRequest
+   */
+  password: string;
+};
+
+export function decodeShareAuthRequest(rawInput: unknown): ShareAuthRequest | null {
+  if (isJSON(rawInput)) {
+    const decodedPassword = decodeString(rawInput['password']);
+
+    if (decodedPassword === null) {
+      return null;
+    }
+
+    return {
+      password: decodedPassword,
+    };
+  }
+  return null;
+}
+
+/**
+ * @type { ShareAuthResponse }
+ * @description Guest session issued after successful password exchange
+ */
+export type ShareAuthResponse = {
+  /**
+   * @description Guest bearer token (64-char hex, shown once)
+   * @type { string }
+   * @memberof ShareAuthResponse
+   */
+  token: string;
+  /**
+   * @description Access mode granted by this session
+   * @type { ShareMode }
+   * @memberof ShareAuthResponse
+   */
+  mode: ShareMode;
+  /**
+   * @description Unix timestamp (ms) when this session expires
+   * @type { number }
+   * @memberof ShareAuthResponse
+   */
+  expiresAt: number;
+};
+
+export function decodeShareAuthResponse(rawInput: unknown): ShareAuthResponse | null {
+  if (isJSON(rawInput)) {
+    const decodedToken = decodeString(rawInput['token']);
+    const decodedMode = decodeShareMode(rawInput['mode']);
+    const decodedExpiresAt = decodeNumber(rawInput['expiresAt']);
+
+    if (decodedToken === null || decodedMode === null || decodedExpiresAt === null) {
+      return null;
+    }
+
+    return {
+      token: decodedToken,
+      mode: decodedMode,
+      expiresAt: decodedExpiresAt,
+    };
+  }
+  return null;
+}
+
+/**
+ * @type { ShareConfigRequest }
+ * @description Owner create/update share request (PUT /api/terminals/[id]/share)
+ */
+export type ShareConfigRequest = {
+  /**
+   * @description New share password (min 6 chars; required on create, optional on update)
+   * @type { string }
+   * @memberof ShareConfigRequest
+   */
+  password: string | null;
+  /**
+   * @description Access mode to grant guests
+   * @type { ShareMode }
+   * @memberof ShareConfigRequest
+   */
+  mode: ShareMode;
+};
+
+export function decodeShareConfigRequest(rawInput: unknown): ShareConfigRequest | null {
+  if (isJSON(rawInput)) {
+    const decodedPassword = decodeString(rawInput['password']);
+    const decodedMode = decodeShareMode(rawInput['mode']);
+
+    if (decodedMode === null) {
+      return null;
+    }
+
+    return {
+      password: decodedPassword,
+      mode: decodedMode,
+    };
+  }
+  return null;
+}

--- a/src/lib/types/generated/WsProtocol.ts
+++ b/src/lib/types/generated/WsProtocol.ts
@@ -435,7 +435,8 @@ export type TerminalServerMessage =
   | CTerminalServerMessageTerminalOutputDroppedMessage
   | CTerminalServerMessageTerminalScrollbackMessage
   | CTerminalServerMessageTerminalExitMessage
-  | CTerminalServerMessageTerminalErrorMessage;
+  | CTerminalServerMessageTerminalErrorMessage
+  | CTerminalServerMessageTerminalResizeMessage;
 
 export function decodeTerminalServerMessage(rawInput: unknown): TerminalServerMessage | null {
   const result: TerminalServerMessage | null =
@@ -443,7 +444,8 @@ export function decodeTerminalServerMessage(rawInput: unknown): TerminalServerMe
     decodeCTerminalServerMessageTerminalOutputDroppedMessage(rawInput) ??
     decodeCTerminalServerMessageTerminalScrollbackMessage(rawInput) ??
     decodeCTerminalServerMessageTerminalExitMessage(rawInput) ??
-    decodeCTerminalServerMessageTerminalErrorMessage(rawInput);
+    decodeCTerminalServerMessageTerminalErrorMessage(rawInput) ??
+    decodeCTerminalServerMessageTerminalResizeMessage(rawInput);
 
   return result;
 }
@@ -531,6 +533,23 @@ export function decodeCTerminalServerMessageTerminalErrorMessage(
     return null;
   }
   return new CTerminalServerMessageTerminalErrorMessage(result);
+}
+
+export class CTerminalServerMessageTerminalResizeMessage {
+  data: TerminalResizeMessage;
+  constructor(data: TerminalResizeMessage) {
+    this.data = data;
+  }
+}
+
+export function decodeCTerminalServerMessageTerminalResizeMessage(
+  rawInput: unknown
+): CTerminalServerMessageTerminalResizeMessage | null {
+  const result = decodeTerminalResizeMessage(rawInput);
+  if (result === null) {
+    return null;
+  }
+  return new CTerminalServerMessageTerminalResizeMessage(result);
 }
 
 /**
@@ -2326,12 +2345,26 @@ export type Ticket = {
    * @memberof Ticket
    */
   used: boolean;
+  /**
+   * @description When set, the ticket may only open WS channels for this terminal
+   * @type { string }
+   * @memberof Ticket
+   */
+  terminalId: string | null;
+  /**
+   * @description When true, input/resize/signal/send-input/cancel frames are dropped
+   * @type { boolean }
+   * @memberof Ticket
+   */
+  readOnly: boolean | null;
 };
 
 export function decodeTicket(rawInput: unknown): Ticket | null {
   if (isJSON(rawInput)) {
     const decodedCreatedAt = decodeNumber(rawInput['createdAt']);
     const decodedUsed = decodeBoolean(rawInput['used']);
+    const decodedTerminalId = decodeString(rawInput['terminalId']);
+    const decodedReadOnly = decodeBoolean(rawInput['readOnly']);
 
     if (decodedCreatedAt === null || decodedUsed === null) {
       return null;
@@ -2340,6 +2373,44 @@ export function decodeTicket(rawInput: unknown): Ticket | null {
     return {
       createdAt: decodedCreatedAt,
       used: decodedUsed,
+      terminalId: decodedTerminalId,
+      readOnly: decodedReadOnly,
+    };
+  }
+  return null;
+}
+
+/**
+ * @type { TicketScope }
+ * @description Scope restriction carried by a guest WebSocket ticket
+ */
+export type TicketScope = {
+  /**
+   * @description Only WS channels for this terminal may be opened
+   * @type { string }
+   * @memberof TicketScope
+   */
+  terminalId: string;
+  /**
+   * @description Whether the connection is view-only (input frames dropped)
+   * @type { boolean }
+   * @memberof TicketScope
+   */
+  readOnly: boolean;
+};
+
+export function decodeTicketScope(rawInput: unknown): TicketScope | null {
+  if (isJSON(rawInput)) {
+    const decodedTerminalId = decodeString(rawInput['terminalId']);
+    const decodedReadOnly = decodeBoolean(rawInput['readOnly']);
+
+    if (decodedTerminalId === null || decodedReadOnly === null) {
+      return null;
+    }
+
+    return {
+      terminalId: decodedTerminalId,
+      readOnly: decodedReadOnly,
     };
   }
   return null;

--- a/src/lib/types/generated/index.ts
+++ b/src/lib/types/generated/index.ts
@@ -10,3 +10,4 @@ export * from './OpenCode';
 export * from './Notification';
 export * from './Client';
 export * from './Config';
+export * from './Share';

--- a/src/lib/types/terminal-client.ts
+++ b/src/lib/types/terminal-client.ts
@@ -80,11 +80,23 @@ export interface QuickKeysProps {
 
 // --- keyboard-shortcuts types ---
 
-export interface ShortcutManagerOptions {
-  onHelp: () => void;
+export interface ShareGateProps {
+  /** Returns an error message to display, or null on success. */
+  onSubmit: (password: string) => Promise<null | string>;
 }
 
 // --- xterm-wrapper types ---
+
+export interface ShareSheetProps {
+  onClose: () => void;
+  open?: boolean;
+  shareUrl: string;
+  terminalId: string;
+}
+
+export interface ShortcutManagerOptions {
+  onHelp: () => void;
+}
 
 export interface ShortcutsHelpProps {
   onClose: () => void;
@@ -105,11 +117,14 @@ export interface TerminalOptions {
   container: HTMLElement;
   fontSize?: number;
   getTicket: () => Promise<string>;
+  initialCols?: number;
+  initialRows?: number;
   onActivity?: (active: boolean) => void;
   onCwd?: (path: string) => void;
   onDisconnect?: () => void;
   onExit?: (code: number) => void;
   onReconnect?: () => void;
+  readOnly?: boolean;
   terminalId?: string;
   wsUrl: string;
 }
@@ -126,7 +141,9 @@ export interface WsTerminalInboundMessage {
   active?: boolean;
   bytes?: number;
   code?: number;
+  cols?: number;
   data?: string;
   path?: string;
+  rows?: number;
   type: string;
 }

--- a/src/lib/types/ws.ts
+++ b/src/lib/types/ws.ts
@@ -146,6 +146,7 @@ export type WireTerminalServerMessage =
   | { bytes: number; type: 'output-dropped' }
   | { chunk: number; data: string; total: number; type: 'scrollback' }
   | { code: null | number; signal: null | string; type: 'exit' }
+  | { cols: number; rows: number; type: 'resize' }
   | { data: string; type: 'output' }
   | { message: string; type: 'error' };
 

--- a/src/routes/api/terminals/[id]/+server.ts
+++ b/src/routes/api/terminals/[id]/+server.ts
@@ -1,6 +1,9 @@
 import { validateAuth } from '$lib/modules/server/auth';
 import { ptyManager } from '$lib/modules/server/terminal/pty-manager.js';
+import { resolveAccess } from '$lib/modules/server/terminal/share-auth';
+import { shareStore } from '$lib/modules/server/terminal/share-store';
 import { toErrorMessage } from '$lib/modules/server/utils/error';
+import { closeGuests } from '$lib/modules/server/ws/guest-registry';
 import { json } from '@sveltejs/kit';
 
 import type { RequestHandler } from './$types';
@@ -21,10 +24,11 @@ function lastScrollbackLine(scrollback: string): null | string {
 }
 
 // GET /api/terminals/:id — Get terminal details by ID
+// Accepts the API key (owner) or a share session token scoped to this terminal.
 export const GET: RequestHandler = ({ params, request }) => {
-  const authError = validateAuth(request);
-  if (authError) {
-    return authError;
+  const access = resolveAccess(request, params.id);
+  if (!access) {
+    return json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   try {
@@ -37,6 +41,7 @@ export const GET: RequestHandler = ({ params, request }) => {
     return json({
       args: terminal.args,
       clientCount: terminal.clients.size,
+      cols: terminal.cols,
       command: terminal.command,
       createdAt: terminal.createdAt.toISOString(),
       cwd: terminal.cwd,
@@ -45,10 +50,12 @@ export const GET: RequestHandler = ({ params, request }) => {
       id: terminal.id,
       lastOutput: lastScrollbackLine(terminal.scrollback),
       pid: terminal.pid,
+      rows: terminal.rows,
       sessionWs: `/ws/session/${terminal.id}`,
       status: terminal.status,
       timestamp: new Date().toISOString(),
       ws: `/ws/terminal/${terminal.id}`,
+      ...(access.level === 'guest' ? { shareMode: access.mode } : {}),
     });
   } catch (error) {
     console.error('[terminals] Failed to get terminal:', toErrorMessage(error));
@@ -72,6 +79,8 @@ export const DELETE: RequestHandler = ({ params, request }) => {
 
     if (terminal.status === 'exited') {
       ptyManager.remove(params.id);
+      shareStore.deleteShare(params.id);
+      closeGuests(params.id);
       console.log(`[terminals] Removed exited terminal ${params.id}`);
       return json({
         removed: true,
@@ -81,6 +90,8 @@ export const DELETE: RequestHandler = ({ params, request }) => {
     }
 
     ptyManager.kill(params.id);
+    shareStore.deleteShare(params.id);
+    closeGuests(params.id);
 
     console.log(`[terminals] Killed terminal ${params.id} (pid=${terminal.pid})`);
 

--- a/src/routes/api/terminals/[id]/paste-image/+server.ts
+++ b/src/routes/api/terminals/[id]/paste-image/+server.ts
@@ -1,4 +1,4 @@
-import { validateAuth } from '$lib/modules/server/auth';
+import { resolveAccess } from '$lib/modules/server/terminal/share-auth';
 import { toErrorMessage } from '$lib/modules/server/utils/error';
 import { json } from '@sveltejs/kit';
 import { mkdirSync, writeFileSync } from 'fs';
@@ -6,10 +6,14 @@ import { mkdirSync, writeFileSync } from 'fs';
 import type { RequestHandler } from './$types';
 
 // POST /api/terminals/[id]/paste-image — Write clipboard image for a terminal
+// Accepts the API key (owner) or a control-mode share token for this terminal.
 export const POST: RequestHandler = async ({ params, request }) => {
-  const authError = validateAuth(request);
-  if (authError) {
-    return authError;
+  const access = resolveAccess(request, params.id);
+  if (!access) {
+    return json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (access.level === 'guest' && access.mode !== 'control') {
+    return json({ error: 'View-only access' }, { status: 403 });
   }
 
   const terminalId = params.id;

--- a/src/routes/api/terminals/[id]/resize/+server.ts
+++ b/src/routes/api/terminals/[id]/resize/+server.ts
@@ -1,15 +1,19 @@
-import { validateAuth } from '$lib/modules/server/auth';
 import { ptyManager } from '$lib/modules/server/terminal/pty-manager.js';
+import { resolveAccess } from '$lib/modules/server/terminal/share-auth';
 import { toErrorMessage } from '$lib/modules/server/utils/error';
 import { json } from '@sveltejs/kit';
 
 import type { RequestHandler } from './$types';
 
 // POST /api/terminals/:id/resize — Resize terminal
+// Accepts the API key (owner) or a control-mode share token for this terminal.
 export const POST: RequestHandler = async ({ params, request }) => {
-  const authError = validateAuth(request);
-  if (authError) {
-    return authError;
+  const access = resolveAccess(request, params.id);
+  if (!access) {
+    return json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (access.level === 'guest' && access.mode !== 'control') {
+    return json({ error: 'View-only access' }, { status: 403 });
   }
 
   let body: { cols?: number; rows?: number };

--- a/src/routes/api/terminals/[id]/share/+server.ts
+++ b/src/routes/api/terminals/[id]/share/+server.ts
@@ -1,0 +1,98 @@
+// /api/terminals/[id]/share — owner management of a terminal's share.
+// GET: current state. PUT: create/update. DELETE: revoke.
+// All methods require the API key (owners only).
+
+import type { ShareConfigRequest, ShareInfoResponse, ShareMode } from '$lib/types';
+
+import { validateAuth } from '$lib/modules/server/auth';
+import { ptyManager } from '$lib/modules/server/terminal/pty-manager.js';
+import { hashPassword, shareStore } from '$lib/modules/server/terminal/share-store';
+import { closeGuests } from '$lib/modules/server/ws/guest-registry';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+const MIN_PASSWORD_LENGTH = 6;
+const MODES: ShareMode[] = ['view', 'control'];
+
+function toInfo(terminalId: string): ShareInfoResponse {
+  const share = shareStore.getShare(terminalId);
+  if (!share) {
+    return { active: false, createdAt: null, mode: null, updatedAt: null };
+  }
+  return { active: true, createdAt: share.createdAt, mode: share.mode, updatedAt: share.updatedAt };
+}
+
+export const GET: RequestHandler = ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  return json(toInfo(params.id));
+};
+
+export const PUT: RequestHandler = async ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  if (!ptyManager.get(params.id)) {
+    return json({ error: 'Terminal not found' }, { status: 404 });
+  }
+
+  let body: ShareConfigRequest;
+  try {
+    body = (await request.json()) as ShareConfigRequest;
+  } catch {
+    return json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  if (!MODES.includes(body.mode)) {
+    return json({ error: "mode must be 'view' or 'control'" }, { status: 400 });
+  }
+
+  const existing = shareStore.getShare(params.id);
+  const password = typeof body.password === 'string' ? body.password : '';
+  if (!existing && password.length < MIN_PASSWORD_LENGTH) {
+    return json(
+      { error: `password is required (min ${String(MIN_PASSWORD_LENGTH)} chars)` },
+      { status: 400 }
+    );
+  }
+  if (password && password.length < MIN_PASSWORD_LENGTH) {
+    return json(
+      { error: `password must be at least ${String(MIN_PASSWORD_LENGTH)} chars` },
+      { status: 400 }
+    );
+  }
+
+  const now = Date.now();
+  shareStore.setShare({
+    createdAt: existing?.createdAt ?? now,
+    mode: body.mode,
+    // `existing` is guaranteed non-null when password is empty (validated above).
+    passwordHash: password ? hashPassword(password) : (existing?.passwordHash ?? ''),
+    terminalId: params.id,
+    updatedAt: now,
+  });
+
+  // A new password invalidates existing guest sessions; any change to the
+  // share forces connected guests to reconnect under the new scope.
+  if (password) {
+    shareStore.deleteSessions(params.id);
+  }
+  if (password || existing?.mode !== body.mode) {
+    closeGuests(params.id);
+  }
+
+  return json(toInfo(params.id));
+};
+
+export const DELETE: RequestHandler = ({ params, request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  shareStore.deleteShare(params.id);
+  const closed = closeGuests(params.id);
+  return json({ closedConnections: closed, success: true });
+};

--- a/src/routes/api/terminals/[id]/share/auth/+server.ts
+++ b/src/routes/api/terminals/[id]/share/auth/+server.ts
@@ -1,0 +1,81 @@
+// POST /api/terminals/[id]/share/auth — exchange the share password for a
+// guest session token. Public endpoint; brute-force-limited per IP+terminal.
+
+import type { ShareAuthRequest } from '$lib/types';
+
+import { shareStore, verifyPassword } from '$lib/modules/server/terminal/share-store';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 10;
+
+/** Maps "ip:terminalId" -> attempt timestamps (epoch ms). */
+const attempts = new Map<string, number[]>();
+
+function checkRateLimit(key: string): boolean {
+  const now = Date.now();
+  const recent = (attempts.get(key) ?? []).filter((t) => t > now - RATE_LIMIT_WINDOW_MS);
+  attempts.set(key, recent);
+  if (recent.length >= RATE_LIMIT_MAX) {
+    return false;
+  }
+  recent.push(now);
+  return true;
+}
+
+// Cleanup stale rate limit entries every 5 minutes
+setInterval(() => {
+  const cutoff = Date.now() - RATE_LIMIT_WINDOW_MS;
+  for (const [key, timestamps] of attempts) {
+    const recent = timestamps.filter((t) => t > cutoff);
+    if (recent.length === 0) {
+      attempts.delete(key);
+    } else {
+      attempts.set(key, recent);
+    }
+  }
+}, 300_000).unref();
+
+export const POST: RequestHandler = async (event) => {
+  const { params, request } = event;
+
+  const share = shareStore.getShare(params.id);
+  if (!share) {
+    return json({ error: 'Not shared' }, { status: 404 });
+  }
+
+  // Behind Cloudflare Tunnel the connecting IP arrives in headers.
+  let ip = 'unknown';
+  const cfIp = request.headers.get('cf-connecting-ip');
+  const fwd = request.headers.get('x-forwarded-for');
+  if (cfIp) {
+    ip = cfIp;
+  } else if (fwd) {
+    ip = fwd.split(',')[0].trim();
+  } else {
+    try {
+      ip = event.getClientAddress();
+    } catch {
+      // Keep 'unknown' — the rate limit still applies per terminal.
+    }
+  }
+
+  if (!checkRateLimit(`${ip}:${params.id}`)) {
+    return json({ error: 'Too many attempts. Try again in a minute.' }, { status: 429 });
+  }
+
+  let body: ShareAuthRequest;
+  try {
+    body = (await request.json()) as ShareAuthRequest;
+  } catch {
+    return json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  if (typeof body.password !== 'string' || !verifyPassword(body.password, share.passwordHash)) {
+    return json({ error: 'Invalid password' }, { status: 401 });
+  }
+
+  const { expiresAt, token } = shareStore.createSession(params.id);
+  return json({ expiresAt, mode: share.mode, token });
+};

--- a/src/routes/api/terminals/[id]/share/status/+server.ts
+++ b/src/routes/api/terminals/[id]/share/status/+server.ts
@@ -1,0 +1,11 @@
+// GET /api/terminals/[id]/share/status — public probe used by the page to
+// decide whether to show the password gate. Reveals only a boolean.
+
+import { shareStore } from '$lib/modules/server/terminal/share-store';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = ({ params }) => {
+  return json({ shared: shareStore.getShare(params.id) !== null });
+};

--- a/src/routes/api/ws-ticket/+server.ts
+++ b/src/routes/api/ws-ticket/+server.ts
@@ -8,6 +8,7 @@
 // Rate limited to 30 requests per minute per API key.
 
 import { validateAuth } from '$lib/modules/server/auth';
+import { shareStore } from '$lib/modules/server/terminal/share-store';
 import { generateTicket } from '$lib/modules/server/ws/ticket-store';
 import { json } from '@sveltejs/kit';
 
@@ -63,15 +64,35 @@ setInterval(() => {
 // ── Endpoint ────────────────────────────────────────────────────────
 
 export const POST: RequestHandler = ({ request }) => {
+  const bearer = (
+    request.headers.get('authorization') ??
+    request.headers.get('Authorization') ??
+    ''
+  )
+    .replace(/^Bearer\s+/i, '')
+    .trim();
+
   const authError = validateAuth(request);
   if (authError) {
-    return authError;
+    // Not the API key — maybe a guest share token (issues a scoped ticket).
+    const session = bearer ? shareStore.resolveToken(bearer) : null;
+    if (!session) {
+      return authError;
+    }
+    if (!checkRateLimit(bearer)) {
+      return json(
+        { error: 'Rate limit exceeded. Maximum 30 ticket requests per minute.' },
+        { status: 429 }
+      );
+    }
+    const ticket = generateTicket({
+      readOnly: session.mode === 'view',
+      terminalId: session.terminalId,
+    });
+    return json({ expiresIn: 30, ticket });
   }
 
-  // Extract the API key for rate limiting
-  const apiKey = (request.headers.get('authorization') ?? '').substring(7).trim();
-
-  if (!checkRateLimit(apiKey)) {
+  if (!checkRateLimit(bearer)) {
     return json(
       { error: 'Rate limit exceeded. Maximum 30 ticket requests per minute.' },
       { status: 429 }

--- a/src/routes/terminals/[id]/+page.svelte
+++ b/src/routes/terminals/[id]/+page.svelte
@@ -2,6 +2,9 @@
   import type {
     ConversationMessage,
     MessagePart,
+    ShareAuthResponse,
+    ShareMode,
+    ShareStatusResponse,
     ShooterConfig,
     TerminalDetailView,
     ToolUsePart,
@@ -17,6 +20,8 @@
   import ConnectionStatus from '$lib/modules/client/terminal/ConnectionStatus.svelte';
   import { createShortcutManager } from '$lib/modules/client/terminal/keyboard-shortcuts';
   import QuickKeys from '$lib/modules/client/terminal/QuickKeys.svelte';
+  import ShareGate from '$lib/modules/client/terminal/ShareGate.svelte';
+  import ShareSheet from '$lib/modules/client/terminal/ShareSheet.svelte';
   import ShortcutsHelp from '$lib/modules/client/terminal/ShortcutsHelp.svelte';
   import {
     Button,
@@ -46,6 +51,10 @@
   let inputText = $state('');
   let chatMessages = $state<ConversationMessage[]>([]);
   let chatSessionEnded = $state(false);
+  let authMode = $state<'guest' | 'owner' | null>(null);
+  let guestMode = $state<null | ShareMode>(null);
+  let shareGateVisible = $state(false);
+  let shareSheetOpen = $state(false);
 
   // DOM references
   let termContainer = $state<HTMLDivElement | null>(null);
@@ -80,6 +89,11 @@
   );
   const tabActiveIndex = $derived(viewMode === 'raw' ? 0 : 1);
   const displayCwd = $derived(shortenPath(currentCwd || terminal?.cwd || ''));
+  const isOwner = $derived(authMode === 'owner');
+  const viewOnly = $derived(authMode === 'guest' && guestMode === 'view');
+  const shareUrl = $derived(
+    typeof window !== 'undefined' ? `${window.location.origin}/terminals/${terminalId}` : ''
+  );
   const paletteCommands = $derived.by((): { action: () => void; label: string }[] => {
     const cmds: { action: () => void; label: string }[] = [
       { action: (): void => void goto('/'), label: 'Go to Home' },
@@ -92,7 +106,7 @@
         label: 'Show keyboard shortcuts',
       },
     ];
-    if (isRunning) {
+    if (isRunning && isOwner) {
       cmds.push({ action: (): void => void killTerminal(), label: 'Kill terminal' });
     }
     return cmds;
@@ -142,6 +156,47 @@
     }
   }
 
+  // ------- Guest share tokens -------
+
+  const SHARE_TOKENS_KEY = 'shooter_share_tokens';
+
+  function getShareToken(): null | string {
+    const id = terminalId;
+    if (!id) {
+      return null;
+    }
+    try {
+      const raw = localStorage.getItem(SHARE_TOKENS_KEY);
+      if (!raw) {
+        return null;
+      }
+      const map = JSON.parse(raw) as Record<string, string>;
+      return typeof map[id] === 'string' ? map[id] : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function storeShareToken(token: string): void {
+    const id = terminalId;
+    if (!id) {
+      return;
+    }
+    let map: Record<string, string> = {};
+    try {
+      map = JSON.parse(localStorage.getItem(SHARE_TOKENS_KEY) ?? '{}') as Record<string, string>;
+    } catch {
+      // Corrupt entry — start fresh.
+    }
+    map[id] = token;
+    localStorage.setItem(SHARE_TOKENS_KEY, JSON.stringify(map));
+  }
+
+  /** Bearer for API calls: the owner's API key, or this terminal's guest token. */
+  function getBearer(): null | string {
+    return getConfig()?.apiKey ?? getShareToken();
+  }
+
   // ------- API calls -------
 
   async function fetchTerminal(): Promise<void> {
@@ -150,36 +205,92 @@
     }
 
     const config = getConfig();
-    if (!config) {
-      error = 'No configuration found. Please configure settings first.';
-      loading = false;
+    const bearer = config?.apiKey ?? getShareToken();
+    if (!bearer) {
+      await checkShareAccess();
       return;
     }
 
     try {
       const res = await fetch(`/api/terminals/${terminalId}`, {
-        headers: { Authorization: `Bearer ${config.apiKey}` },
+        headers: { Authorization: `Bearer ${bearer}` },
       });
+      if (res.status === 401 && !config) {
+        // Stale/revoked guest token — fall back to the password gate.
+        await checkShareAccess();
+        return;
+      }
       if (!res.ok) {
         error = res.status === 404 ? 'Terminal not found' : 'Failed to load terminal';
         loading = false;
         return;
       }
       terminal = (await res.json()) as TerminalDetailView;
+      if (config) {
+        authMode = 'owner';
+      } else {
+        authMode = 'guest';
+        guestMode = terminal.shareMode ?? 'view';
+      }
     } catch {
       error = 'Failed to connect to server';
     }
     loading = false;
   }
 
+  async function checkShareAccess(): Promise<void> {
+    try {
+      const res = await fetch(`/api/terminals/${terminalId}/share/status`);
+      if (res.ok) {
+        const data = (await res.json()) as ShareStatusResponse;
+        if (data.shared) {
+          shareGateVisible = true;
+          loading = false;
+          return;
+        }
+      }
+    } catch {
+      // Fall through to the configuration error.
+    }
+    error = 'No configuration found. Please configure settings first.';
+    loading = false;
+  }
+
+  async function submitSharePassword(password: string): Promise<null | string> {
+    try {
+      const res = await fetch(`/api/terminals/${terminalId}/share/auth`, {
+        body: JSON.stringify({ password }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+      if (res.status === 429) {
+        return 'Too many attempts — try again in a minute.';
+      }
+      if (!res.ok) {
+        return 'Incorrect password.';
+      }
+      const data = (await res.json()) as ShareAuthResponse;
+      storeShareToken(data.token);
+      shareGateVisible = false;
+      loading = true;
+      await fetchTerminal();
+      if (terminal && !error) {
+        initViews();
+      }
+      return null;
+    } catch {
+      return 'Failed to reach the server.';
+    }
+  }
+
   async function getWsTicket(): Promise<null | string> {
-    const config = getConfig();
-    if (!config) {
+    const bearer = getBearer();
+    if (!bearer) {
       return null;
     }
     try {
       const res = await fetch('/api/ws-ticket', {
-        headers: { Authorization: `Bearer ${config.apiKey}` },
+        headers: { Authorization: `Bearer ${bearer}` },
         method: 'POST',
       });
       if (!res.ok) {
@@ -269,10 +380,12 @@
       }
 
       const instance = await createTerminal({
-        apiKey: getConfig()?.apiKey,
+        apiKey: getBearer() ?? undefined,
         container: termContainer,
         fontSize: window.innerWidth < 768 ? 12 : 14,
         getTicket,
+        initialCols: terminal.cols ?? undefined,
+        initialRows: terminal.rows ?? undefined,
         onActivity: (active: boolean) => {
           if (!disposed) {
             isActive = active;
@@ -304,6 +417,7 @@
             rawConnectionStatus = 'connected';
           }
         },
+        readOnly: viewOnly,
         terminalId,
         wsUrl,
       });
@@ -606,23 +720,7 @@
 
   // ------- Lifecycle -------
 
-  onMount(async () => {
-    await fetchTerminal();
-    if (disposed) {
-      return;
-    }
-
-    // Set up keyboard shortcuts
-    shortcutManager = createShortcutManager({
-      onHelp: () => {
-        showShortcutsHelp = !showShortcutsHelp;
-      },
-    });
-
-    if (!terminal || error) {
-      return;
-    }
-
+  function initViews(): void {
     // Default view: Chat on mobile for AI sessions, Raw on desktop
     if (isAI && window.innerWidth < 768) {
       viewMode = 'chat';
@@ -640,6 +738,26 @@
       void connectSessionWs();
       chatInitialized = true;
     }
+  }
+
+  onMount(async () => {
+    await fetchTerminal();
+    if (disposed) {
+      return;
+    }
+
+    // Set up keyboard shortcuts
+    shortcutManager = createShortcutManager({
+      onHelp: () => {
+        showShortcutsHelp = !showShortcutsHelp;
+      },
+    });
+
+    if (!terminal || error) {
+      return;
+    }
+
+    initViews();
   });
 
   onDestroy(() => {
@@ -664,6 +782,10 @@
       <div class="skeleton" style="width: 100%; height: 100%;"></div>
     </div>
   </div>
+{:else if shareGateVisible}
+  <div class="term-page">
+    <ShareGate onSubmit={submitSharePassword} />
+  </div>
 {:else if error}
   <main class="main">
     <div class="session-back-row">
@@ -681,7 +803,9 @@
     <!-- Top Bar -->
     <div class="term-topbar">
       <div class="term-topbar-left">
-        <a href="/terminals" class="term-back" aria-label="Back to terminals">&larr;</a>
+        {#if isOwner}
+          <a href="/terminals" class="term-back" aria-label="Back to terminals">&larr;</a>
+        {/if}
         <span class="term-command-name">{commandName}</span>
         <Pill text={badgeLabel} classes={badgeClass} />
         {#if isRunning}
@@ -695,7 +819,7 @@
           </Tooltip>
         {/if}
         <ConnectionStatus status={connectionStatus} onretry={handleRetry} />
-        {#if isAI && (terminal as TerminalDetailView & { sessionFile?: string })?.sessionFile}
+        {#if isOwner && isAI && (terminal as TerminalDetailView & { sessionFile?: string })?.sessionFile}
           {@const sessionFile =
             (terminal as TerminalDetailView & { sessionFile?: string }).sessionFile ?? ''}
           <a
@@ -729,22 +853,31 @@
           ariaLabel="Keyboard shortcuts"
         />
 
-        {#if isRunning}
-          <Button
-            classes="btn-danger btn-sm"
-            onclick={killTerminal}
-            disabled={killing}
-            showLoader={killing}
-            text="Kill"
-          />
-        {:else}
+        {#if isOwner}
           <Button
             classes="btn-secondary btn-sm"
-            onclick={removeTerminal}
-            disabled={removing}
-            showLoader={removing}
-            text="Remove"
+            onclick={(): void => {
+              shareSheetOpen = true;
+            }}
+            text="Share"
           />
+          {#if isRunning}
+            <Button
+              classes="btn-danger btn-sm"
+              onclick={killTerminal}
+              disabled={killing}
+              showLoader={killing}
+              text="Kill"
+            />
+          {:else}
+            <Button
+              classes="btn-secondary btn-sm"
+              onclick={removeTerminal}
+              disabled={removing}
+              showLoader={removing}
+              text="Remove"
+            />
+          {/if}
         {/if}
       </div>
     </div>
@@ -759,7 +892,7 @@
     ></div>
 
     <!-- Raw Input Bar + Quick Keys -->
-    {#if isRunning && viewMode === 'raw'}
+    {#if isRunning && viewMode === 'raw' && !viewOnly}
       <div class="term-input-area">
         <QuickKeys onKey={handleQuickKey} />
         <div class="term-input-bar">
@@ -788,7 +921,7 @@
         messages={chatMessages}
         connectionState={connectionStatus}
         sessionEnded={chatSessionEnded}
-        showInput={isRunning}
+        showInput={isRunning && !viewOnly}
         onSendInput={handleChatSendInput}
         onCancel={handleChatCancel}
       />
@@ -813,6 +946,14 @@
   open={showShortcutsHelp}
   onClose={(): void => {
     showShortcutsHelp = false;
+  }}
+/>
+<ShareSheet
+  open={shareSheetOpen}
+  terminalId={terminalId ?? ''}
+  {shareUrl}
+  onClose={(): void => {
+    shareSheetOpen = false;
   }}
 />
 <CommandPalette

--- a/tests/share-store.test.cjs
+++ b/tests/share-store.test.cjs
@@ -1,0 +1,368 @@
+/**
+ * Unit tests for ShareStore SQLite module.
+ *
+ * Uses better-sqlite3 directly against /tmp/shooter-test-share-store.db
+ * to replicate the exact schema and operations from share-store.ts,
+ * avoiding TypeScript / path-alias complications.
+ */
+
+'use strict';
+
+const Database = require('better-sqlite3');
+const { createHash, randomBytes, scryptSync, timingSafeEqual } = require('crypto');
+const fs = require('fs');
+
+const DB_PATH = '/tmp/shooter-test-share-store.db';
+
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// ── Crypto helpers (mirror share-store.ts) ───────────────────────────
+
+function hashPassword(password) {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `scrypt:${salt}:${hash}`;
+}
+
+function verifyPassword(password, stored) {
+  const parts = stored.split(':');
+  if (parts.length !== 3 || parts[0] !== 'scrypt') {
+    return false;
+  }
+  const expected = Buffer.from(parts[2], 'hex');
+  const actual = scryptSync(password, parts[1], 64);
+  return expected.length === actual.length && timingSafeEqual(actual, expected);
+}
+
+function hashToken(token) {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+// ── ShareStore (mirrors the real class) ──────────────────────────────
+
+class ShareStore {
+  constructor(dbPath) {
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.exec(`
+			CREATE TABLE IF NOT EXISTS terminal_shares (
+				terminal_id   TEXT PRIMARY KEY,
+				password_hash TEXT NOT NULL,
+				mode          TEXT NOT NULL,
+				created_at    INTEGER NOT NULL,
+				updated_at    INTEGER NOT NULL
+			);
+			CREATE TABLE IF NOT EXISTS share_sessions (
+				token_hash  TEXT PRIMARY KEY,
+				terminal_id TEXT NOT NULL,
+				created_at  INTEGER NOT NULL,
+				expires_at  INTEGER NOT NULL
+			)
+		`);
+  }
+
+  cleanup() {
+    this.db.prepare('DELETE FROM share_sessions WHERE expires_at < ?').run(Date.now());
+    try {
+      this.db
+        .prepare('DELETE FROM terminal_shares WHERE terminal_id NOT IN (SELECT id FROM terminals)')
+        .run();
+      this.db
+        .prepare('DELETE FROM share_sessions WHERE terminal_id NOT IN (SELECT id FROM terminals)')
+        .run();
+    } catch (_) {
+      /* terminals table may not exist — skip orphan cleanup */
+    }
+  }
+
+  close() {
+    this.db.close();
+  }
+
+  createSession(terminalId) {
+    const token = randomBytes(32).toString('hex');
+    const now = Date.now();
+    const expiresAt = now + SESSION_TTL_MS;
+    this.db
+      .prepare(
+        'INSERT INTO share_sessions (token_hash, terminal_id, created_at, expires_at) VALUES (?, ?, ?, ?)'
+      )
+      .run(hashToken(token), terminalId, now, expiresAt);
+    return { expiresAt, token };
+  }
+
+  deleteSessions(terminalId) {
+    this.db.prepare('DELETE FROM share_sessions WHERE terminal_id = ?').run(terminalId);
+  }
+
+  deleteShare(terminalId) {
+    this.db.prepare('DELETE FROM terminal_shares WHERE terminal_id = ?').run(terminalId);
+    this.deleteSessions(terminalId);
+  }
+
+  getShare(terminalId) {
+    const row = this.db
+      .prepare('SELECT * FROM terminal_shares WHERE terminal_id = ?')
+      .get(terminalId);
+    if (!row) return null;
+    return {
+      createdAt: row.created_at,
+      mode: row.mode,
+      passwordHash: row.password_hash,
+      terminalId: row.terminal_id,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  resolveToken(token) {
+    if (!token) return null;
+    const row = this.db
+      .prepare(
+        `SELECT s.terminal_id, s.expires_at, sh.mode
+				 FROM share_sessions s
+				 JOIN terminal_shares sh ON sh.terminal_id = s.terminal_id
+				 WHERE s.token_hash = ?`
+      )
+      .get(hashToken(token));
+    if (!row) return null;
+    if (row.expires_at < Date.now()) {
+      this.db.prepare('DELETE FROM share_sessions WHERE token_hash = ?').run(hashToken(token));
+      return null;
+    }
+    return { mode: row.mode, terminalId: row.terminal_id };
+  }
+
+  setShare(record) {
+    this.db
+      .prepare(
+        `INSERT OR REPLACE INTO terminal_shares
+				 (terminal_id, password_hash, mode, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?)`
+      )
+      .run(record.terminalId, record.passwordHash, record.mode, record.createdAt, record.updatedAt);
+  }
+}
+
+// ── Assertions ───────────────────────────────────────────────────────
+
+function assertEqual(actual, expected, label) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(`${label}: expected ${e}, got ${a}`);
+  }
+}
+
+function assertNotNull(value, label) {
+  if (value === null || value === undefined) {
+    throw new Error(`${label}: expected non-null value`);
+  }
+}
+
+function assertTrue(value, label) {
+  if (value !== true) {
+    throw new Error(`${label}: expected true, got ${JSON.stringify(value)}`);
+  }
+}
+
+function assertFalse(value, label) {
+  if (value !== false) {
+    throw new Error(`${label}: expected false, got ${JSON.stringify(value)}`);
+  }
+}
+
+// ── Fresh DB per test ────────────────────────────────────────────────
+
+function freshStore() {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try {
+      fs.unlinkSync(DB_PATH + suffix);
+    } catch (_) {
+      /* ignore */
+    }
+  }
+  return new ShareStore(DB_PATH);
+}
+
+function makeShare(overrides = {}) {
+  return {
+    terminalId: 'term-1',
+    passwordHash: hashPassword('secret123'),
+    mode: 'view',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+  let store;
+  try {
+    store = freshStore();
+    fn(store);
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  } finally {
+    if (store) store.close();
+  }
+}
+
+console.log('\nShareStore unit tests\n');
+
+// ── Test 1: Set, get, and upsert share ───────────────────────────────
+
+runTest('Test 1: Set, get, and upsert share', (store) => {
+  const share = makeShare();
+  store.setShare(share);
+
+  const got = store.getShare('term-1');
+  assertNotNull(got, 'getShare after set');
+  assertEqual(got.mode, 'view', 'mode');
+  assertEqual(got.passwordHash, share.passwordHash, 'passwordHash');
+
+  // Upsert replaces, keeps single row per terminal (PK)
+  store.setShare(makeShare({ mode: 'control', updatedAt: share.updatedAt + 1000 }));
+  const updated = store.getShare('term-1');
+  assertEqual(updated.mode, 'control', 'mode after upsert');
+  const count = store.db.prepare('SELECT COUNT(*) AS n FROM terminal_shares').get().n;
+  assertEqual(count, 1, 'single row after upsert');
+
+  assertEqual(store.getShare('missing'), null, 'getShare for unknown terminal');
+});
+
+// ── Test 2: Password hashing ─────────────────────────────────────────
+
+runTest('Test 2: Password hash format and verification', () => {
+  const stored = hashPassword('hunter2-secret');
+  const parts = stored.split(':');
+  assertEqual(parts.length, 3, 'hash has 3 segments');
+  assertEqual(parts[0], 'scrypt', 'scheme prefix');
+  assertEqual(parts[1].length, 32, 'salt is 16 bytes hex');
+  assertEqual(parts[2].length, 128, 'hash is 64 bytes hex');
+
+  assertTrue(verifyPassword('hunter2-secret', stored), 'correct password verifies');
+  assertFalse(verifyPassword('wrong-password', stored), 'wrong password fails');
+  assertFalse(verifyPassword('hunter2-secret', 'garbage'), 'malformed stored string fails');
+  assertFalse(verifyPassword('hunter2-secret', 'md5:abc:def'), 'wrong scheme fails');
+
+  // Same password, different salts → different hashes
+  const stored2 = hashPassword('hunter2-secret');
+  if (stored === stored2) {
+    throw new Error('two hashes of the same password should differ (random salt)');
+  }
+});
+
+// ── Test 3: Session create and resolve ───────────────────────────────
+
+runTest('Test 3: Session create and resolve', (store) => {
+  store.setShare(makeShare({ mode: 'control' }));
+  const { expiresAt, token } = store.createSession('term-1');
+
+  assertEqual(token.length, 64, 'token is 32 bytes hex');
+  assertTrue(expiresAt > Date.now(), 'expiry in the future');
+
+  const resolved = store.resolveToken(token);
+  assertNotNull(resolved, 'token resolves');
+  assertEqual(resolved.terminalId, 'term-1', 'resolved terminal');
+  assertEqual(resolved.mode, 'control', 'resolved mode follows the share');
+
+  assertEqual(store.resolveToken('0'.repeat(64)), null, 'unknown token → null');
+  assertEqual(store.resolveToken(''), null, 'empty token → null');
+
+  // Token is stored hashed, never in plaintext
+  const raw = store.db.prepare('SELECT token_hash FROM share_sessions').get().token_hash;
+  assertEqual(raw, hashToken(token), 'stored value is sha256 of token');
+});
+
+// ── Test 4: Expired sessions resolve to null and are purged ──────────
+
+runTest('Test 4: Expired session purged on resolve', (store) => {
+  store.setShare(makeShare());
+  const { token } = store.createSession('term-1');
+  store.db
+    .prepare('UPDATE share_sessions SET expires_at = ? WHERE token_hash = ?')
+    .run(Date.now() - 1000, hashToken(token));
+
+  assertEqual(store.resolveToken(token), null, 'expired token → null');
+  const count = store.db.prepare('SELECT COUNT(*) AS n FROM share_sessions').get().n;
+  assertEqual(count, 0, 'expired session row purged');
+});
+
+// ── Test 5: Revoke cascade is per-terminal ───────────────────────────
+
+runTest('Test 5: Revoke cascades sessions, per terminal only', (store) => {
+  store.setShare(makeShare({ terminalId: 'term-a' }));
+  store.setShare(makeShare({ terminalId: 'term-b' }));
+  const a = store.createSession('term-a');
+  const b = store.createSession('term-b');
+
+  store.deleteShare('term-a');
+
+  assertEqual(store.getShare('term-a'), null, 'share a deleted');
+  assertEqual(store.resolveToken(a.token), null, 'session a revoked');
+  assertNotNull(store.getShare('term-b'), 'share b intact');
+  assertNotNull(store.resolveToken(b.token), 'session b intact');
+});
+
+// ── Test 6: Revoked share invalidates surviving session rows ─────────
+
+runTest('Test 6: Session without share resolves to null (join)', (store) => {
+  store.setShare(makeShare());
+  const { token } = store.createSession('term-1');
+  // Delete only the share row, leaving the session row behind
+  store.db.prepare('DELETE FROM terminal_shares WHERE terminal_id = ?').run('term-1');
+  assertEqual(store.resolveToken(token), null, 'orphan session no longer resolves');
+});
+
+// ── Test 7: Orphan cleanup against terminals table ───────────────────
+
+runTest('Test 7: Cleanup removes shares for deleted terminals', (store) => {
+  store.db.exec(
+    "CREATE TABLE terminals (id TEXT PRIMARY KEY); INSERT INTO terminals VALUES ('t1')"
+  );
+  store.setShare(makeShare({ terminalId: 't1' }));
+  store.setShare(makeShare({ terminalId: 't2' }));
+  const s1 = store.createSession('t1');
+  store.createSession('t2');
+
+  store.cleanup();
+
+  assertNotNull(store.getShare('t1'), 'share for live terminal survives');
+  assertNotNull(store.resolveToken(s1.token), 'session for live terminal survives');
+  assertEqual(store.getShare('t2'), null, 'orphan share removed');
+  const orphanSessions = store.db
+    .prepare("SELECT COUNT(*) AS n FROM share_sessions WHERE terminal_id = 't2'")
+    .get().n;
+  assertEqual(orphanSessions, 0, 'orphan sessions removed');
+});
+
+// ── Test 8: Cleanup tolerates a missing terminals table ──────────────
+
+runTest('Test 8: Cleanup without terminals table is a no-op', (store) => {
+  store.setShare(makeShare());
+  store.cleanup();
+  assertNotNull(store.getShare('term-1'), 'share survives cleanup on fresh db');
+});
+
+// ── Summary ──────────────────────────────────────────────────────────
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total\n`);
+
+for (const suffix of ['', '-wal', '-shm']) {
+  try {
+    fs.unlinkSync(DB_PATH + suffix);
+  } catch (_) {
+    /* ignore */
+  }
+}
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Share a single terminal at its existing `/terminals/[id]` route, protected by a per-share password (scrypt + per-share salt) with a per-share access mode: **view-only** or **full control**. Active until revoked.
- Guests exchange the password for a 7-day session token (stored sha256-hashed); WS tickets issued to guests carry a `{terminalId, readOnly}` scope enforced **server-side**: input/resize/signal dropped in view mode, `/ws/events`, `/ws/super-session/*` and foreign terminal/session channels denied, session-channel `subscribe` pivoting blocked.
- Owner manages sharing from a new **Share** sheet on the terminal page (enable, generate password, switch mode, copy URL, revoke — revoke/mode-change force-close connected guest sockets with code 4001). Guests get a password gate; view-only hides all input affordances and follows the owner's PTY size via a new `resize` broadcast frame.
- Everything else stays API-key-only: guests get 401 on all other API routes; brute-force protection (10 attempts/min per IP+terminal) on the password exchange.

## Design & plan
- Spec: `docs/superpowers/specs/2026-06-11-terminal-sharing-design.md`
- Plan: `docs/superpowers/plans/2026-06-11-terminal-sharing.md`

## Test plan
- [x] `tests/share-store.test.cjs` (8 cases: schema, scrypt roundtrip, session expiry, revoke cascade, orphan cleanup) — wired into `pnpm test`
- [x] `pnpm lint`, `pnpm check`, `pnpm build` green
- [x] Live E2E on a sandboxed server: 11 REST checks (status probe, wrong-password 401, 429 rate limit, guest scoping to one terminal, view-mode 403 on resize/paste) + 12 WS checks (events/foreign-channel denial, view-mode input/resize drop, control-mode input executes, force-close 4001 on mode change/revoke, token invalidation)
- [x] Browser pass (guest gate → wrong password error → unlock → live view-only terminal with no input affordances; owner Share sheet enable/copy/revoke; revoked guest locked out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password-protected terminal sharing with view-only and control-access modes.
  * Added guest authentication gate and share management UI for terminal owners.
  * Enabled server-side terminal resize synchronization for view-only guests.
  * Added share status endpoint and password exchange authentication.

* **Tests**
  * Added share store unit test suite covering session lifecycle, password verification, and token resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->