### PR TITLE
ci(yama): pin yama action to v2.6.0 to restore PR reviews

### DIFF
--- a/.github/workflows/yama-review.yml
+++ b/.github/workflows/yama-review.yml
@@ -91,9 +91,11 @@ jobs:
         # Don't auto-fail the job on the action's exit code — the next step maps
         # the verdict to the check result explicitly.
         continue-on-error: true
-        # External consumer → published action. For strict supply-chain
-        # immutability pin the full commit SHA behind this ref.
-        uses: juspay/yama@v2.7.1
+        # External consumer → published action. Pinned to v2.6.0 to match
+        # juspay/neurolink's working setup — v2.7.1 stopped producing review runs
+        # on this repo. For strict supply-chain immutability pin the full commit
+        # SHA behind this ref.
+        uses: juspay/yama@v2.6.0
         with:
           github-token: ${{ secrets.YAMA_GITHUB_TOKEN }}
           ai-provider: litellm


### PR DESCRIPTION
## Why

Yama (`Yama PR Review`) has produced **zero review runs on this repo since this morning** — not queued, not failed, not skipped — while every other check (CodeQL, Single-Commit, SentinelOne, CodeRabbit) still fires on each push. The workflow shows `active` and `yama-review.yml` is present on `release`, so the trigger simply isn't scheduling runs against `juspay/yama@v2.7.1`.

## Fix

`juspay/neurolink` runs the same `@juspay/yama` action pinned to **v2.6.0** and works. This pins shooter to the same known-good version (was `v2.7.1`).

```diff
- uses: juspay/yama@v2.7.1
+ uses: juspay/yama@v2.6.0
```

Only the action version changes; triggers, permissions, and the fork/secret preflight are untouched.

## After merge
This must land on `release` so the `pull_request` workflow picks up the fixed version, after which the multi-device PRs (#96–#104) get re-triggered for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to resolve a compatibility issue and maintain consistent build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->