### PR TITLE
feat: make Shooter feel native — 6-slice program (nav shell, motion, Web Push, edge-swipe, Live Activity)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:name=".ShooterApplication"

--- a/android/app/src/main/kotlin/com/shooter/android/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/shooter/android/MainActivity.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
+import android.os.VibrationEffect
+import android.os.Vibrator
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -335,6 +337,25 @@ class MainActivity : AppCompatActivity() {
         fun getPlatform(): String {
             android.util.Log.d(TAG, "ShooterBridge.getPlatform() → android")
             return "android"
+        }
+
+        @JavascriptInterface
+        fun haptic(kind: String) {
+            this@MainActivity.runOnUiThread {
+                val vibrator = this@MainActivity.getSystemService(Vibrator::class.java) ?: return@runOnUiThread
+                if (!vibrator.hasVibrator()) return@runOnUiThread
+                val durationMs = when (kind) {
+                    "light" -> 10L
+                    "medium" -> 20L
+                    "heavy" -> 30L
+                    "success" -> 15L
+                    "warning" -> 25L
+                    "error" -> 40L
+                    "selection" -> 5L
+                    else -> 10L
+                }
+                vibrator.vibrate(VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE))
+            }
         }
     }
 

--- a/docs/superpowers/plans/2026-07-08-native-feel-foundation.md
+++ b/docs/superpowers/plans/2026-07-08-native-feel-foundation.md
@@ -1,0 +1,3820 @@
+# Native-Feel Foundation (Slice 1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Shooter stop looking like a website and start feeling like a native phone app — via a central amber re-theme on an upgraded component library, the highest-leverage hygiene fixes, motion primitives, and real (web + iOS + Android) haptics.
+
+**Architecture:** Deliver the entire visual identity through the _central theme layer_ only — `src/lib/theme.css` (the `@juspay/svelte-ui-components` CSS-variable mappings) plus the `:root` token block and global classes in `src/app.css`. Components reference central tokens (`var(--accent)`); they never hardcode a look. Upgrade the library first so the central press/focus theming hooks exist, then re-theme, then layer motion + haptics on top.
+
+**Tech Stack:** SvelteKit (adapter-node) · Svelte 5 runes · TypeScript (strict) · `@juspay/svelte-ui-components` 2.87.0 · pnpm · `node:test` test runner · native iOS (Swift/WKWebView) + Android (Kotlin/WebView) wrappers · chrome-devtools MCP for screenshot verification.
+
+## Global Constraints
+
+_Every task implicitly inherits this section. Values are verbatim from the spec (`docs/superpowers/specs/2026-07-08-native-feel-foundation-design.md`)._
+
+- **Centralize the look.** Visual/identity changes go through `src/lib/theme.css` + `src/app.css` `:root`/global classes ONLY. **No per-component `.svelte` style forks for theming** — components only reference central tokens (e.g. `var(--accent)`).
+- **Library floor:** `@juspay/svelte-ui-components` at **2.87.0** (up from `^2.18.0`). Upgrade + regression-verify FIRST.
+- **Accent = Amber Phosphor** `#f5b14c` (fg on amber `#0c0d0b`, hover `#ffc266`, dim `rgba(245,177,76,.14)`, line `rgba(245,177,76,.32)`). **Green `--ds-green-700` = live/success ONLY. Blue `--ds-blue-700` = info ONLY.**
+- **Bolder tokens:** `--text-base` 14→**16px**; `--radius-lg` 8→**14px**; `--radius-xl` 12→**18px**; page-title tracking `--tracking-tighter`→`--tracking-tight`. One committed card elevation.
+- **Native haptics this slice:** iOS (`UIImpactFeedbackGenerator`/`UINotificationFeedbackGenerator`/`UISelectionFeedbackGenerator`) + Android (`Vibrator`/`VibrationEffect`).
+- **Types:** all types live in `src/lib/types/`, imported via the `$lib/types` barrel; unions are hand-written and re-exported from `index.ts`. Named exports only; no `export default`; no `any`.
+- **Definition of done requires:** `pnpm build` clean + full screenshot regression + every feature exercised end-to-end.
+
+## Approach note — TDD vs. verification protocol
+
+This is a theming slice, so the test discipline adapts by task type (both are mandatory gates):
+
+- **Logic tasks** (the `haptic()` function, the `HapticKind` type, token grep-guards) use real TDD: failing test first → minimal impl → passing run → commit.
+- **Visual/CSS/theme tasks** (which cannot be xUnit-tested) use a concrete **verification protocol** instead of a unit test: a grep-guard command with expected output where applicable, a `pnpm build` check, and a specific **screenshot checklist** (which screen, what to look for) captured via the chrome-devtools MCP against the local dev server.
+
+## Execution ordering
+
+Strictly sequential across units: **Unit E (upgrade + regression) must fully pass before any theming.** Then **A** (tokens) → **B** (hygiene/bolder) → **C** (motion) → **D** (haptics). Within the shared files (`src/app.css` `:root`, `src/lib/theme.css`, `src/routes/+layout.svelte`) later units make additive edits to distinct blocks; keep to this order to avoid churn.
+
+---
+
+## Unit E — Library upgrade (@juspay/svelte-ui-components 2.18.0 → 2.87.0) + screenshot regression protocol
+
+### Task 1: Capture pre-upgrade screenshot baseline for every library-consuming screen
+
+**Files:**
+
+- Test: `test-screenshots/native-feel-unit-e/pre-upgrade/*.png` (new directory)
+
+**Interfaces:**
+
+- Consumes: none (read-only capture against the running dev server)
+- Produces: `test-screenshots/native-feel-unit-e/pre-upgrade/*.png` — the baseline the post-upgrade task diffs against
+
+- [ ] **Step 1: Confirm the dev server is up and enumerate every screen that renders a library component**
+
+Grep confirms which routes/components pull from `@juspay/svelte-ui-components` (already run during drafting):
+
+```bash
+grep -rl "@juspay/svelte-ui-components" /Users/sachinsharma/Developer/Personal/shooter/src
+```
+
+Expected output (19 files — this is the exhaustive set the screenshot pass must cover, directly or via a shared component they render):
+
+```
+src/app.css
+src/lib/modules/client/activity/ActivityFeed.svelte
+src/lib/modules/client/dashboard/DashboardCard.svelte
+src/lib/modules/client/terminal/ChatView.svelte
+src/lib/modules/client/terminal/CommandPalette.svelte
+src/lib/modules/client/terminal/ConnectionStatus.svelte
+src/lib/modules/client/terminal/LaunchSheet.svelte
+src/lib/modules/client/terminal/QuickKeys.svelte
+src/lib/modules/client/terminal/ShareGate.svelte
+src/lib/modules/client/terminal/ShareSheet.svelte
+src/lib/modules/client/terminal/ShortcutsHelp.svelte
+src/lib/theme.css
+src/routes/+error.svelte
+src/routes/+layout.svelte
+src/routes/+page.svelte
+src/routes/config/+page.svelte
+src/routes/neurolink/+page.svelte
+src/routes/project/+page.svelte
+src/routes/session/[id]/+page.svelte
+src/routes/sos/[id]/+page.svelte
+src/routes/sos/+page.svelte
+src/routes/terminals/[id]/+page.svelte
+src/routes/terminals/+page.svelte
+```
+
+Confirm the dev server (already running at task-drafting time) is still reachable before capturing:
+
+```bash
+curl -s http://localhost:54006/api/health
+```
+
+Expected output: `{"status":"healthy",...}` (HTTP 200). If it is not running, start it in the background:
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm dev
+```
+
+Expected: log line `Local: http://localhost:54006` and `Dev tunnel:` (or `--no-tunnel` equivalent) within ~15s, then it idles serving requests.
+
+- [ ] **Step 2: Create the baseline screenshot directory**
+
+```bash
+mkdir -p /Users/sachinsharma/Developer/Personal/shooter/test-screenshots/native-feel-unit-e/pre-upgrade
+```
+
+Expected output: no output, directory exists (`ls` shows it empty).
+
+- [ ] **Step 3: Capture one screenshot per screen using the chrome-devtools MCP tools against the dev server**
+
+This repo has no Playwright/Puppeteer script — screenshots are captured interactively via the `chrome-devtools-mcp` MCP tools (per the global CLAUDE.md "Chrome DevTools MCP" setup), pointed at the local dev server instead of production. For each row below: `navigate_page` to the URL, `take_snapshot` to get element refs if a click/state-change is needed, then `take_screenshot` and save to the given filename under `test-screenshots/native-feel-unit-e/pre-upgrade/`. Emulate an iPhone-sized viewport (390x844) via `resize_page` before capturing so this is a phone-first regression check, not a desktop one.
+
+Checklist (14 screenshots — every screen/sub-state that renders a library component):
+
+```
+[ ] 01-dashboard.png          → navigate http://localhost:54006/            (Dashboard: DashboardCard, EmptyState/Card via +page.svelte)
+[ ] 02-activity.png           → navigate http://localhost:54006/activity    (ActivityFeed: Pill/Tag/EmptyState)
+[ ] 03-terminals-list.png     → navigate http://localhost:54006/terminals   (list: Card/ListItem/Button, or EmptyState if none)
+[ ] 04-terminals-launchsheet.png → on /terminals, tap the "+"/launch trigger to open LaunchSheet (Sheet/Choicebox/Button)
+[ ] 05-terminal-raw-tab.png   → launch (or open existing) a terminal at /terminals/[id], "Raw" tab active (ChatView/Tabs/Icon)
+[ ] 06-terminal-chat-tab.png  → same terminal, switch to "Chat" tab (ChatView message rendering)
+[ ] 07-terminal-quickkeys.png → same terminal, quick-keys bar visible at bottom (QuickKeys: Button/Pill row)
+[ ] 08-terminal-sharesheet.png → tap the share/export action to open ShareSheet (Sheet/Button)
+[ ] 09-terminal-shortcuts.png → open ShortcutsHelp overlay (Modal/Card) if reachable via a visible control
+[ ] 10-project.png            → navigate http://localhost:54006/project     (project dashboard: Card/Tabs)
+[ ] 11-session-detail.png     → navigate http://localhost:54006/session/[id] for an existing session id (ChatView reused)
+[ ] 12-config.png             → navigate http://localhost:54006/config      (Input/Toggle-equivalent/Button/Select)
+[ ] 13-sos.png                → navigate http://localhost:54006/sos         (list) and, if any SOS item exists, /sos/[id]
+[ ] 14-neurolink.png          → navigate http://localhost:54006/neurolink   (provider config UI: Select/Input/Card)
+```
+
+Example tool sequence for row 01 (repeat this pattern, swapping URL/filename, for every row):
+
+```
+mcp__plugin_chrome-devtools-mcp_chrome-devtools__resize_page(width=390, height=844)
+mcp__plugin_chrome-devtools-mcp_chrome-devtools__navigate_page(url="http://localhost:54006/")
+mcp__plugin_chrome-devtools-mcp_chrome-devtools__take_screenshot(filePath="/Users/sachinsharma/Developer/Personal/shooter/test-screenshots/native-feel-unit-e/pre-upgrade/01-dashboard.png")
+```
+
+Expected: 14 PNG files exist under `test-screenshots/native-feel-unit-e/pre-upgrade/`, each showing the current (2.18.0) rendering — Vercel-blue accents, 14px base text, 8px/12px radii, flat card treatment. Verify with:
+
+```bash
+ls /Users/sachinsharma/Developer/Personal/shooter/test-screenshots/native-feel-unit-e/pre-upgrade/ | wc -l
+```
+
+Expected output: `14` (or fewer only if a screen genuinely has no reachable state in dev, e.g. no SOS item — note any skipped row explicitly rather than silently omitting it).
+
+- [ ] **Step 4: Commit the baseline**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter
+git add test-screenshots/native-feel-unit-e/pre-upgrade/
+git commit -m "test(native-feel): capture pre-upgrade screenshot baseline for svelte-ui-components 2.18.0"
+```
+
+Expected output: `[feat/native-feel-foundation <sha>] test(native-feel): capture pre-upgrade screenshot baseline for svelte-ui-components 2.18.0` with 14 files changed.
+
+---
+
+### Task 2: Bump @juspay/svelte-ui-components 2.18.0 → 2.87.0 and verify the build
+
+**Files:**
+
+- Modify: `package.json:119`
+- Modify: `pnpm-lock.yaml` (regenerated by `pnpm install`)
+
+**Interfaces:**
+
+- Consumes: none
+- Produces: `@juspay/svelte-ui-components@2.87.0` installed in `node_modules` — the version every later theming unit (A/B/C/D) builds its `theme.css` changes against, including the new central hooks `--button-active-transform`, `--button-active-background`, `--button-hover-transform`, `--button-focus-visible-box-shadow`
+
+- [ ] **Step 1: Bump the version pin in package.json**
+
+Current code (`package.json:118-119`, read via `Read` tool):
+
+```json
+  "dependencies": {
+    "@juspay/svelte-ui-components": "^2.18.0",
+```
+
+New code:
+
+```json
+  "dependencies": {
+    "@juspay/svelte-ui-components": "2.87.0",
+```
+
+- [ ] **Step 2: Update the lockfile**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm install
+```
+
+Expected output: pnpm resolves and installs `@juspay/svelte-ui-components@2.87.0`, ends with something like `Done in Xs` and no `ERR_PNPM_*` lines. Confirm the lockfile actually moved:
+
+```bash
+grep -n "'@juspay/svelte-ui-components'" pnpm-lock.yaml | head -5
+```
+
+Expected output (version string present, replacing the old `2.18.0` entries):
+
+```
+      '@juspay/svelte-ui-components':
+  '@juspay/svelte-ui-components@2.87.0':
+  '@juspay/svelte-ui-components@2.87.0(svelte@5.55.7(@typescript-eslint/types@8.57.2))(type-decoder@2.3.1)':
+```
+
+And confirm no stale `2.18.0` reference remains:
+
+```bash
+grep -c "@juspay/svelte-ui-components@2.18.0" /Users/sachinsharma/Developer/Personal/shooter/pnpm-lock.yaml
+```
+
+Expected output: `0`
+
+- [ ] **Step 3: Confirm the installed package version on disk**
+
+```bash
+node -p "require('/Users/sachinsharma/Developer/Personal/shooter/node_modules/@juspay/svelte-ui-components/package.json').version"
+```
+
+Expected output: `2.87.0`
+
+- [ ] **Step 4: Type-check and lint (catches prop/type drift across the ~15 components in use before the build step)**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm check
+```
+
+Expected output: ends with `svelte-check found 0 errors and 0 warnings` (or equivalent zero-error summary) and no TypeScript diagnostic output from the trailing `tsc --noEmit --strict`. If prop names/types shifted (e.g. a renamed `Sheet`/`Choicebox` prop), this step surfaces it as a compile error at the exact call site — fix the call site's usage to match the new signature (not a theme change, so it does not violate the central-theming constraint) before continuing.
+
+- [ ] **Step 5: Production build**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm build
+```
+
+Expected output: Vite build completes (`✓ built in Xs`), `postbuild` copies `pty-holder.cjs`, and:
+
+```bash
+ls /Users/sachinsharma/Developer/Personal/shooter/build/handler.js /Users/sachinsharma/Developer/Personal/shooter/build/pty-holder.cjs
+```
+
+Expected output: both files listed, no "No such file or directory" error.
+
+- [ ] **Step 6: Run the existing test suite as a non-regression smoke check**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm test
+```
+
+Expected output: every `tests/*.test.cjs` invocation prints its own pass summary (e.g. `✓ all N tests passed` per file) and the command exits `0`. None of these tests exercise the UI library directly, so this step's purpose is confirming the dependency bump didn't break module resolution or the server-side build graph — it is not a substitute for the screenshot regression in the next task.
+
+- [ ] **Step 7: Restart the dev server on the new build so the screenshot task in the next task hits 2.87.0**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm dev
+```
+
+Expected: same startup log as before (`Local: http://localhost:54006`), now serving the rebuilt app against `@juspay/svelte-ui-components@2.87.0`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter
+git add package.json pnpm-lock.yaml
+git commit -m "chore(deps): bump @juspay/svelte-ui-components 2.18.0 -> 2.87.0
+
+Unlocks central press/focus theming hooks (--button-active-transform,
+--button-active-background, --button-hover-transform,
+--button-focus-visible-box-shadow) needed for the native-feel re-theme.
+Same major (2.x) — pnpm check/build/test clean; visual regression
+verified separately via before/after screenshots."
+```
+
+Expected output: `[feat/native-feel-foundation <sha>] chore(deps): bump @juspay/svelte-ui-components 2.18.0 -> 2.87.0` with 2 files changed.
+
+---
+
+### Task 3: Post-upgrade screenshot regression + feature exercise on 2.87.0
+
+**Files:**
+
+- Test: `test-screenshots/native-feel-unit-e/post-upgrade/*.png` (new directory)
+
+**Interfaces:**
+
+- Consumes: `test-screenshots/native-feel-unit-e/pre-upgrade/*.png` (produced by Task "Capture pre-upgrade screenshot baseline")
+- Produces: sign-off that `@juspay/svelte-ui-components@2.87.0` is a safe base — the gate later theming units (Unit A token re-base, Unit B website-tell fixes, Unit C motion, Unit D haptics) depend on before touching `theme.css`/`app.css`
+
+- [ ] **Step 1: Re-capture the identical 14-screen checklist against the upgraded build**
+
+```bash
+mkdir -p /Users/sachinsharma/Developer/Personal/shooter/test-screenshots/native-feel-unit-e/post-upgrade
+```
+
+Repeat exactly the same 14 rows and tool-call pattern as the pre-upgrade task (same URLs, same viewport `390x844`, same interactions to reach each state), saving into `post-upgrade/` with matching filenames:
+
+```
+01-dashboard.png
+02-activity.png
+03-terminals-list.png
+04-terminals-launchsheet.png
+05-terminal-raw-tab.png
+06-terminal-chat-tab.png
+07-terminal-quickkeys.png
+08-terminal-sharesheet.png
+09-terminal-shortcuts.png
+10-project.png
+11-session-detail.png
+12-config.png
+13-sos.png
+14-neurolink.png
+```
+
+Expected:
+
+```bash
+diff <(ls /Users/sachinsharma/Developer/Personal/shooter/test-screenshots/native-feel-unit-e/pre-upgrade/) <(ls /Users/sachinsharma/Developer/Personal/shooter/test-screenshots/native-feel-unit-e/post-upgrade/)
+```
+
+Expected output: empty (identical filename sets — same screens covered both passes).
+
+- [ ] **Step 2: Visually diff each pair and log any regression**
+
+For each of the 14 filenames, open the pre/post pair side by side (read both PNGs with the `Read` tool, which renders images) and confirm: no layout shift, no missing/broken icons, no changed button/pill/card shapes, no console errors introduced. This slice makes **no theme changes yet** (that's Units A–D), so pre/post should be visually near-identical except for incidental upstream fixes in 2.19–2.87 (e.g. a padding or focus-ring tweak inside the library's own default CSS). Record any such diff:
+
+```bash
+touch /Users/sachinsharma/Developer/Personal/shooter/test-screenshots/native-feel-unit-e/REGRESSIONS.md
+```
+
+If a regression is found, write one bullet per issue into that file (screen name, what changed, whether it's cosmetic-acceptable-upstream-drift or a real break) — do not silently proceed past a real break; fix the call site (prop/slot usage) before continuing to Unit A.
+
+- [ ] **Step 3: Manually exercise every feature end-to-end on the upgraded library (per Constraint 5 / spec's "Feature exercise" checklist)**
+
+Drive each of these via the chrome-devtools MCP tools (`click`, `fill`, `press_key`) against `http://localhost:54006`, confirming no functional regression from the bump:
+
+```
+[ ] Launch a terminal from /terminals (LaunchSheet: pick a project/command, submit) — new terminal appears in the list
+[ ] Attach to the launched terminal at /terminals/[id] — PTY output streams live in the Raw tab
+[ ] Switch Raw <-> Chat tabs — content renders in both without error
+[ ] Tap 2-3 QuickKeys buttons (e.g. Ctrl-C, Tab, arrow) — keystroke reaches the PTY (visible effect in Raw tab)
+[ ] Type a line of input and press Enter — command executes, output appears
+[ ] Kill the terminal — status flips to killed/removed, list updates
+[ ] Open /session/[id] for an existing session — messages render via ChatView
+[ ] Open /config, change one field (e.g. a toggle/select), Save — success toast/state, value persists on reload
+[ ] Generate the QR code on /config (or wherever qr-config renders) — QR image renders
+[ ] Load / (Dashboard) with at least one terminal card present — DashboardCard renders correct status
+[ ] Load /activity — ActivityFeed renders entries (or EmptyState if none) without console errors
+```
+
+Expected: every row completes with the described visible effect and zero uncaught console errors (check via `mcp__plugin_chrome-devtools-mcp_chrome-devtools__list_console_messages` after the pass — expect no new `error`-level entries attributable to the app's own code, i.e. ignore unrelated network noise from e.g. missing FCM config).
+
+- [ ] **Step 4: Final build + lint gate**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm quality:all
+```
+
+Expected output: `pnpm run lint`, `pnpm run format:check`, and `pnpm run check` each report zero errors/warnings, command exits `0`.
+
+- [ ] **Step 5: Commit the post-upgrade regression evidence**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter
+git add test-screenshots/native-feel-unit-e/post-upgrade/
+git status --short test-screenshots/native-feel-unit-e/REGRESSIONS.md
+```
+
+If `REGRESSIONS.md` was created in Step 2 (non-empty), add it too; otherwise it stays untracked/empty and is skipped:
+
+```bash
+git add test-screenshots/native-feel-unit-e/REGRESSIONS.md 2>/dev/null || true
+git commit -m "test(native-feel): post-upgrade screenshot regression + feature exercise for svelte-ui-components 2.87.0
+
+Verified all 14 library-consuming screens against the pre-upgrade
+baseline and manually exercised terminal launch/attach/kill, quick
+keys, session view, config save, and QR generation. No functional
+regressions from 2.18.0 -> 2.87.0; safe base for the Unit A/B/C/D
+central re-theme."
+```
+
+Expected output: `[feat/native-feel-foundation <sha>] test(native-feel): post-upgrade screenshot regression + feature exercise for svelte-ui-components 2.87.0` with the post-upgrade PNGs (and `REGRESSIONS.md` if non-empty) listed as new files.
+
+## Unit A — Central token re-base (amber accent split from status)
+
+### Task 4: Add central accent + status token layer to app.css :root
+
+**Files:**
+
+- Modify: `src/app.css:117-120`
+
+**Interfaces:**
+
+- Consumes: none
+- Produces: `--accent`, `--accent-hover`, `--accent-fg`, `--accent-dim`, `--accent-line`, `--status-live`, `--status-success`, `--status-info`, `--status-danger` — new CSS custom properties on `:root`, consumed by every later step in this unit and by Units B/C/D.
+
+- [ ] **Step 1: Insert the accent + status token block at the end of the `:root` block**
+
+Current (`src/app.css:106-120`):
+
+```css
+  /* Border Radius */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-full: 9999px;
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 200ms ease;
+
+  /* Layout */
+  --max-width: 1100px;
+  --header-height: 64px;
+}
+```
+
+New:
+
+```css
+  /* Border Radius */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-full: 9999px;
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 200ms ease;
+
+  /* Layout */
+  --max-width: 1100px;
+  --header-height: 64px;
+
+  /* Brand accent — Amber Phosphor. The ONLY hue for actions/active/selected/focus. */
+  --ds-amber-accent: #f5b14c;
+  --ds-amber-accent-hover: #ffc266;
+  --ds-amber-accent-fg: #0c0d0b;
+  --ds-amber-accent-dim: rgba(245, 177, 76, 0.14);
+  --ds-amber-accent-line: rgba(245, 177, 76, 0.32);
+  --accent: var(--ds-amber-accent);
+  --accent-hover: var(--ds-amber-accent-hover);
+  --accent-fg: var(--ds-amber-accent-fg);
+  --accent-dim: var(--ds-amber-accent-dim);
+  --accent-line: var(--ds-amber-accent-line);
+
+  /* Status — semantic and separate from accent. Never repurpose these for actions. */
+  --status-live: var(--ds-green-700);
+  --status-success: var(--ds-green-700);
+  --status-info: var(--ds-blue-700);
+  --status-danger: var(--ds-red-700);
+}
+```
+
+- [ ] **Step 2: Verify the tokens exist**
+
+```bash
+grep -n -- "--accent:\|--accent-hover:\|--accent-fg:\|--accent-dim:\|--accent-line:\|--status-live:\|--status-success:\|--status-info:\|--status-danger:" src/app.css
+```
+
+Expected output (9 lines, inside `:root`):
+
+```
+83:  --accent: var(--ds-amber-accent);
+84:  --accent-hover: var(--ds-amber-accent-hover);
+85:  --accent-fg: var(--ds-amber-accent-fg);
+86:  --accent-dim: var(--ds-amber-accent-dim);
+87:  --accent-line: var(--ds-amber-accent-line);
+90:  --status-live: var(--ds-green-700);
+91:  --status-success: var(--ds-green-700);
+92:  --status-info: var(--ds-blue-700);
+93:  --status-danger: var(--ds-red-700);
+```
+
+(exact line numbers will shift by a few lines depending on final placement — what matters is all 9 declarations exist once, inside the same `:root` block as `--ds-green-700`/`--ds-blue-700`/`--ds-red-700`).
+
+- [ ] **Step 3: Build check**
+
+```bash
+pnpm build
+```
+
+Expected: exits 0, no CSS/Vite errors (a new custom-property block cannot break the build, but this confirms no stray syntax error like a missing `;` or brace).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app.css
+git commit -m "feat(theme): add central amber accent and status token layer"
+```
+
+---
+
+### Task 5: Rewire theme.css library variable mappings to central accent tokens
+
+**Files:**
+
+- Modify: `src/lib/theme.css:12-23` (Button block)
+- Modify: `src/lib/theme.css:37` (Input block)
+- Modify: `src/lib/theme.css:110` (Tabs block)
+- Modify: `src/lib/theme.css:189,190,198,199` (Choicebox block)
+
+**Interfaces:**
+
+- Consumes: `--accent`, `--accent-hover`, `--accent-fg`, `--accent-dim`, `--accent-line` (produced by "Add central accent + status token layer" task, `src/app.css`)
+- Produces: none (rewires existing library-consumed CSS variable names — `--button-color`, `--button-text-color`, `--button-hover-color`, `--button-hover-text-color`, `--button-active-background`, `--input-focus-border`, `--tabs-indicator-color`, `--choicebox-selected-border-color`, `--choicebox-selected-background`, `--choicebox-indicator-selected-color`, `--choicebox-focus-ring` — read by `@juspay/svelte-ui-components` `Button`/`Input`/`Tabs`/`Choicebox`)
+
+- [ ] **Step 1: Rewire the Button block**
+
+Current (`src/lib/theme.css:12-23`):
+
+```css
+/* ===== Button ===== */
+--button-font-family: var(--font-sans);
+--button-font-size: var(--text-sm);
+--button-font-weight: 500;
+--button-color: var(--ds-blue-700);
+--button-text-color: #fff;
+--button-padding: 8px 16px;
+--button-border-radius: var(--radius-md);
+--button-border: 1px solid transparent;
+--button-hover-color: var(--ds-blue-900);
+--button-hover-text-color: #fff;
+--button-content-gap: 8px;
+```
+
+New:
+
+```css
+/* ===== Button ===== */
+--button-font-family: var(--font-sans);
+--button-font-size: var(--text-sm);
+--button-font-weight: 500;
+--button-color: var(--accent);
+--button-text-color: var(--accent-fg);
+--button-padding: 8px 16px;
+--button-border-radius: var(--radius-md);
+--button-border: 1px solid transparent;
+--button-hover-color: var(--accent-hover);
+--button-hover-text-color: var(--accent-fg);
+--button-active-background: var(--accent-hover);
+--button-content-gap: 8px;
+```
+
+Note: `--button-hover-text-color` is switched from `#fff` to `var(--accent-fg)` (not literally listed in the design table, but required — the fill stays amber-family on hover, and white text on a light amber (`#ffc266`) hover fill fails contrast; `--accent-fg` (`#0c0d0b`) is the color designed for text-on-amber). `--button-active-background` is a new declaration — the hook doesn't exist pre-upgrade (Unit E lands `2.87.0`), but declaring an unused custom property is inert until the upgrade ships, and this way the mapping is already correct the moment Unit E lands.
+
+- [ ] **Step 2: Rewire the Input focus border**
+
+Current (`src/lib/theme.css:37`):
+
+```css
+--input-focus-border: 1px solid var(--ds-blue-700);
+```
+
+New:
+
+```css
+--input-focus-border: 1px solid var(--accent);
+```
+
+- [ ] **Step 3: Rewire the Tabs indicator**
+
+Current (`src/lib/theme.css:110`):
+
+```css
+--tabs-indicator-color: var(--ds-blue-700);
+```
+
+New:
+
+```css
+--tabs-indicator-color: var(--accent);
+```
+
+- [ ] **Step 4: Rewire the Choicebox selection + focus ring**
+
+Current (`src/lib/theme.css:181-199`):
+
+```css
+/* ===== Choicebox ===== */
+--choicebox-background: var(--ds-gray-100);
+--choicebox-border: 2px solid var(--border);
+--choicebox-border-radius: var(--radius-lg);
+--choicebox-padding: 16px;
+--choicebox-gap: 12px;
+--choicebox-hover-border-color: var(--border-hover);
+--choicebox-hover-background: var(--ds-gray-200);
+--choicebox-selected-border-color: var(--ds-blue-700);
+--choicebox-selected-background: var(--ds-blue-100);
+--choicebox-title-color: var(--text-primary);
+--choicebox-title-font-size: var(--text-base);
+--choicebox-title-font-weight: 500;
+--choicebox-title-font-family: var(--font-sans);
+--choicebox-description-color: var(--text-tertiary);
+--choicebox-description-font-size: var(--text-sm);
+--choicebox-indicator-border: 2px solid var(--ds-gray-500);
+--choicebox-indicator-selected-color: var(--ds-blue-700);
+--choicebox-focus-ring: 0 0 0 3px rgba(0, 112, 243, 0.2);
+```
+
+New:
+
+```css
+/* ===== Choicebox ===== */
+--choicebox-background: var(--ds-gray-100);
+--choicebox-border: 2px solid var(--border);
+--choicebox-border-radius: var(--radius-lg);
+--choicebox-padding: 16px;
+--choicebox-gap: 12px;
+--choicebox-hover-border-color: var(--border-hover);
+--choicebox-hover-background: var(--ds-gray-200);
+--choicebox-selected-border-color: var(--accent);
+--choicebox-selected-background: var(--accent-dim);
+--choicebox-title-color: var(--text-primary);
+--choicebox-title-font-size: var(--text-base);
+--choicebox-title-font-weight: 500;
+--choicebox-title-font-family: var(--font-sans);
+--choicebox-description-color: var(--text-tertiary);
+--choicebox-description-font-size: var(--text-sm);
+--choicebox-indicator-border: 2px solid var(--ds-gray-500);
+--choicebox-indicator-selected-color: var(--accent);
+--choicebox-focus-ring: 0 0 0 3px var(--accent-line);
+```
+
+Note: `--choicebox-focus-ring` is not in the design doc's literal 3-variable table, but it sits three lines below `--choicebox-indicator-selected-color` in the same block and was still hardcoded to `rgba(0, 112, 243, 0.2)` (Vercel blue) — leaving it would put a blue keyboard-focus ring on a now-amber-selected choicebox, directly contradicting the "selected choicebox amber" verification checklist item and the unit's own grep-guard ("no ... selection color still resolves to --ds-blue-700" — this is a literal rgba, not a `var(--ds-blue-700)` reference, so the guard's grep for the token name won't catch it, but the intent — no blue left in the choicebox selection path — requires fixing it here too). `--accent-line` (`rgba(245, 177, 76, 0.32)`) is the token purpose-built for this kind of ring.
+
+- [ ] **Step 5: Verify no button/input/tabs/choicebox variable in theme.css still resolves to blue**
+
+```bash
+grep -n -- "ds-blue-700\|0, 112, 243" src/lib/theme.css
+```
+
+Expected output: empty (no matches).
+
+- [ ] **Step 6: Build check**
+
+```bash
+pnpm build
+```
+
+Expected: exits 0, no CSS errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/theme.css
+git commit -m "feat(theme): rewire button, input, tabs and choicebox to the accent token"
+```
+
+---
+
+### Task 6: Rewire central app.css focus/selection state and remove the neurolink per-component fork
+
+**Files:**
+
+- Modify: `src/app.css:638-644` (`.btn:focus-visible, .input:focus-visible, .nav-link:focus-visible`)
+- Modify: `src/app.css:657-661` (`::selection`)
+- Modify: `src/routes/neurolink/+page.svelte:321-328` (`.input-bar :global(.input-prompt)`)
+
+**Interfaces:**
+
+- Consumes: `--accent`, `--accent-fg` (produced by "Add central accent + status token layer" task)
+- Produces: none
+
+- [ ] **Step 1: Rewire the generic focus-visible outline**
+
+Current (`src/app.css:638-644`):
+
+```css
+/* Focus States */
+.btn:focus-visible,
+.input:focus-visible,
+.nav-link:focus-visible {
+  outline: 2px solid var(--ds-blue-700);
+  outline-offset: 2px;
+}
+```
+
+New:
+
+```css
+/* Focus States */
+.btn:focus-visible,
+.input:focus-visible,
+.nav-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+```
+
+- [ ] **Step 2: Rewire the text-selection highlight**
+
+Current (`src/app.css:657-661`):
+
+```css
+/* Selection */
+::selection {
+  background: var(--ds-blue-700);
+  color: #fff;
+}
+```
+
+New:
+
+```css
+/* Selection */
+::selection {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+```
+
+- [ ] **Step 3: Remove the neurolink page's per-component `--input-focus-border` fork**
+
+This is a direct violation of Constraint 1 ("no per-component `.svelte` style forks for theming") on the exact variable centralized in the previous task — left in place, it silently overrides the new central amber focus border back to hardcoded blue on `/neurolink`, and would make the unit's own grep-guard fail.
+
+Current (`src/routes/neurolink/+page.svelte:321-328`):
+
+```css
+.input-bar :global(.input-prompt) {
+  flex: 1;
+  --input-font-family: var(--font-mono);
+  --input-background: var(--component-bg);
+  --input-border: 1px solid var(--border-hover);
+  --input-focus-border: 1px solid var(--ds-blue-700);
+  --input-container-margin: 0;
+}
+```
+
+New (delete the fork — the component now inherits the centrally-rewired `--input-focus-border: 1px solid var(--accent)` from `theme.css`):
+
+```css
+.input-bar :global(.input-prompt) {
+  flex: 1;
+  --input-font-family: var(--font-mono);
+  --input-background: var(--component-bg);
+  --input-border: 1px solid var(--border-hover);
+  --input-container-margin: 0;
+}
+```
+
+- [ ] **Step 4: Verify no button/tab/input/selection color resolves to blue anywhere touched by this unit**
+
+```bash
+grep -rn -- "ds-blue-700" src/app.css src/lib/theme.css src/routes/+layout.svelte src/lib/modules/client/terminal/LaunchSheet.svelte src/routes/neurolink/+page.svelte
+```
+
+Expected output (only the primitive definition and unrelated informational-text/status usages remain — none in a button/tab/input/selection/focus context):
+
+```
+src/app.css:27:  --ds-blue-700: #0070f3;
+src/routes/neurolink/+page.svelte:228:    color: var(--ds-blue-700);
+src/routes/neurolink/+page.svelte:301:    color: var(--ds-blue-700);
+```
+
+(Those two neurolink hits are the page `<h1>` title color and `.log-entry.user` chat-role text color — decorative/informational text, not a button/tab/input/selection/focus surface, and out of this unit's scope.)
+
+- [ ] **Step 5: Build check**
+
+```bash
+pnpm build
+```
+
+Expected: exits 0, no CSS/Svelte errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app.css src/routes/neurolink/+page.svelte
+git commit -m "fix(theme): rewire global focus/selection to accent and drop neurolink input-focus fork"
+```
+
+---
+
+### Task 7: Point layout active-tab and gear focus outline at the accent token
+
+**Files:**
+
+- Modify: `src/routes/+layout.svelte:178-181`
+- Modify: `src/routes/+layout.svelte:233-235`
+
+**Interfaces:**
+
+- Consumes: `--accent` (produced by "Add central accent + status token layer" task)
+- Produces: none
+
+- [ ] **Step 1: Rewire the gear-button focus outline**
+
+Current (`src/routes/+layout.svelte:178-181`):
+
+```svelte
+  :global(.btn-gear:focus-visible) {
+    outline: 2px solid var(--ds-green-700);
+    outline-offset: 2px;
+  }
+```
+
+New:
+
+```svelte
+  :global(.btn-gear:focus-visible) {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+```
+
+- [ ] **Step 2: Rewire the active bottom-tab color**
+
+Current (`src/routes/+layout.svelte:233-235`):
+
+```svelte
+  .tab-item.active {
+    color: var(--ds-green-700);
+  }
+```
+
+New:
+
+```svelte
+  .tab-item.active {
+    color: var(--accent);
+  }
+```
+
+- [ ] **Step 3: Verify no green/blue action color remains in +layout.svelte**
+
+```bash
+grep -n -- "ds-green-700\|ds-blue-700" src/routes/+layout.svelte
+```
+
+Expected output: empty (no matches) — green is no longer used for the active tab or focus ring, only `var(--accent)` remains for those two spots.
+
+- [ ] **Step 4: Build check**
+
+```bash
+pnpm build
+```
+
+Expected: exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/routes/+layout.svelte
+git commit -m "fix(nav): rewire active tab and gear focus ring to the accent token"
+```
+
+---
+
+### Task 8: Point LaunchSheet's launch button at the accent token
+
+**Files:**
+
+- Modify: `src/lib/modules/client/terminal/LaunchSheet.svelte:261-270`
+
+**Interfaces:**
+
+- Consumes: `--accent`, `--accent-hover` (produced by "Add central accent + status token layer" task)
+- Produces: none
+
+- [ ] **Step 1: Rewire the launch button**
+
+Current (`src/lib/modules/client/terminal/LaunchSheet.svelte:261-270`):
+
+```svelte
+  :global(.btn-launch) {
+    --button-color: var(--ds-green-700);
+    --button-text-color: #fff;
+    --button-hover-color: var(--ds-green-900);
+    --button-hover-text-color: #fff;
+    --button-border-radius: var(--radius-lg);
+    --button-height: 48px;
+    --button-width: 100%;
+    margin-top: var(--space-2);
+  }
+```
+
+New:
+
+```svelte
+  :global(.btn-launch) {
+    --button-color: var(--accent);
+    --button-text-color: var(--accent-fg);
+    --button-hover-color: var(--accent-hover);
+    --button-hover-text-color: var(--accent-fg);
+    --button-border-radius: var(--radius-lg);
+    --button-height: 48px;
+    --button-width: 100%;
+    margin-top: var(--space-2);
+  }
+```
+
+- [ ] **Step 2: Unit-level grep-guard sign-off — no button/tab/input/selection color resolves to `--ds-blue-700` anywhere in the app**
+
+```bash
+grep -rn -- "ds-blue-700" src --include="*.css" --include="*.svelte" \
+  | grep -viE "app.css:27|dashboardcard.svelte:(29|33|184|232|233|234|235)|autopilotpanel.svelte:(380|533)|activityfeed.svelte:252|neurolink/\+page.svelte:(228|271|301)"
+```
+
+Expected output: empty (no matches). The allowlisted survivors are all status/info semantics or focus rings on components explicitly deferred to Unit B's press/focus centralization (`DashboardCard.svelte`'s `.card:focus-visible` at line 184 and status-pill/border colors, `AutopilotPanel.svelte`'s status text/outline, `ActivityFeed.svelte`'s `.type` label, and neurolink's page-title/chat-role text) — none of them are a button, tab, input, or selection surface, and all remain intentionally blue = info per the design doc.
+
+- [ ] **Step 3: Screenshot verification checklist (Constraint 5 — capture and inspect each)**
+
+1. `/` (Dashboard) — no primary/CTA button visible here by default; confirm connection-status dot is still **green** (unchanged) and no blue accents appear.
+2. `/terminals` → tap "New Terminal" (opens `LaunchSheet`) — the **"Launch Terminal"** button fill is **amber** (`#F5B14C`), button text is dark (`--accent-fg`), no blue or green.
+3. `/terminals` — bottom tab bar: navigate between Projects/Terminals/SOS — the **active tab label is amber**, inactive tabs stay muted gray; tapping the gear icon and tabbing to it with a keyboard shows an **amber focus ring**, not green.
+4. `/config` (or any screen with a text `Input`) — click into a text field — the focus border ring is **amber**, not blue.
+5. `/config` or any screen rendering a `Choicebox` (e.g. provider/preset selection) — select an option — the selected choicebox border/background tint is **amber**, and tabbing to it shows an amber focus ring (not blue).
+6. `/neurolink` — click into the chat input — focus border is **amber** (confirms the removed per-component fork now inherits the central token); the page `<h1>` title and `.log-entry.user` text remain their existing blue (unaffected, out of scope).
+7. Select some body text anywhere in the app (e.g. a chat message) — the text-selection highlight is **amber** with dark text, not blue-with-white.
+8. `/terminals/[id]` — confirm the "live"/connected status pill/dot is still **green**, unaffected by the re-theme.
+
+- [ ] **Step 4: Final build check**
+
+```bash
+pnpm build
+```
+
+Expected: exits 0, clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/modules/client/terminal/LaunchSheet.svelte
+git commit -m "fix(terminal): rewire launch button to the accent token"
+```
+
+## UNIT B — Website tells + bolder look (central)
+
+### Task 9: Format-detection — stop paths/dates rendering as fake blue links
+
+**Files:**
+
+- Modify: `src/app.html:7-9`
+- Modify: `ios/Shooter/Shooter/ContentView.swift:448-451`
+
+**Interfaces:**
+
+- Consumes: none
+- Produces: none (pure hygiene fix; no other unit depends on this)
+
+- [ ] **Step 1: Add the format-detection meta tag**
+
+Current (`src/app.html:7-9`):
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="theme-color" content="#0a0a0a" />
+<link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />
+```
+
+New:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="theme-color" content="#0a0a0a" />
+<meta name="format-detection" content="telephone=no, date=no, address=no, email=no" />
+<link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />
+```
+
+- [ ] **Step 2: Disable WKWebView's native data detectors (iOS)**
+
+Current (`ios/Shooter/Shooter/ContentView.swift:448-451`):
+
+```swift
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.allowsInlineMediaPlayback = true
+
+        let prefs = WKWebpagePreferences()
+```
+
+New:
+
+```swift
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.allowsInlineMediaPlayback = true
+        // Match the web meta[name=format-detection] behavior natively: plain text
+        // (session paths, timestamps, IDs) should never auto-link as tel/date/address/email.
+        if #available(iOS 14.5, *) {
+            config.dataDetectorTypes = []
+        }
+
+        let prefs = WKWebpagePreferences()
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -n "format-detection" /Users/sachinsharma/Developer/Personal/shooter/src/app.html
+# Expected: one match — the new <meta name="format-detection" .../> line
+
+grep -n "dataDetectorTypes" /Users/sachinsharma/Developer/Personal/shooter/ios/Shooter/Shooter/ContentView.swift
+# Expected: one match — config.dataDetectorTypes = []
+
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm build
+# Expected: clean build, no errors
+```
+
+Screenshot checklist (iOS Safari or the PWA, not desktop Chrome — format-detection is a WebKit behavior): open `/` and `/project`, look at the project `fullPath` subtitle text (e.g. a path containing digits that could read as a phone number) — confirm it renders as plain grey monospace text, not an underlined blue tappable link. If an iOS device/simulator isn't available in this environment, note it as unverified in the PR description and re-check on first TestFlight/simulator build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter
+git add src/app.html ios/Shooter/Shooter/ContentView.swift
+git commit -m "fix(webview): disable phone/date/address auto-linking on web and iOS"
+```
+
+---
+
+### Task 10: Header clears the notch (safe-area-inset-top)
+
+**Files:**
+
+- Modify: `src/app.css:154-162`
+
+**Interfaces:**
+
+- Consumes: none
+- Produces: none
+
+- [ ] **Step 1: Grow the header by the top safe-area inset**
+
+Current (`src/app.css:154-162`):
+
+```css
+/* Header */
+.header {
+  height: var(--header-height);
+  background: var(--background);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+```
+
+New:
+
+```css
+/* Header */
+.header {
+  height: calc(var(--header-height) + env(safe-area-inset-top, 0px));
+  padding-top: env(safe-area-inset-top, 0px);
+  background: var(--background);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+```
+
+This mirrors the existing bottom-inset pattern already used at `src/app.css:1833` (`.chat-input-bar`) and `src/routes/+layout.svelte:191,200` (`.main`/`.bottom-tabs`). `.header-content` (`src/app.css:164-172`) already has `height: 100%` and doesn't need editing — with the global `box-sizing: border-box` reset (`src/app.css:128`), `.header`'s content-box height stays `var(--header-height)` after the inset padding is applied, so `.header-content` continues to fill exactly one `--header-height` worth of space, positioned below the notch.
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -n "safe-area-inset-top" /Users/sachinsharma/Developer/Personal/shooter/src/app.css
+# Expected: two matches on the same .header rule (height calc + padding-top)
+
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm build
+# Expected: clean build
+```
+
+Screenshot checklist: add the site to the iOS home screen (or use Safari's device-frame simulator / Chrome DevTools device toolbar with a notched device like iPhone 14 Pro) and open `/`. Confirm the logo + status badge + gear icon sit fully below the status bar/notch, not overlapped by it. Also check a non-notched viewport (desktop Chrome, no safe-area) — header height must be visually unchanged there (`env()` resolves to `0px`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter
+git add src/app.css
+git commit -m "fix(header): respect safe-area-inset-top under the iPhone notch"
+```
+
+---
+
+### Task 11: Central press + focus-visible feedback for tappables
+
+**Files:**
+
+- Modify: `src/lib/theme.css:11-23` (Button section)
+- Modify: `src/app.css:663-680` (insert new central rule after the scrollbar block)
+
+**Interfaces:**
+
+- Consumes: `--accent` (optional — falls back to the committed amber literal `#f5b14c` if Unit A hasn't landed `--accent` yet, so this task doesn't hard-depend on Unit A's execution order)
+- Produces: `--button-active-transform`, `--button-focus-visible-box-shadow` (theme.css custom properties). **Dependency note:** at the currently-installed library version (`2.18.0`), `Button.svelte`'s `<style>` already reads `--button-active-transform` in a `button:active { transform: var(--button-active-transform); }` rule (verified in `node_modules/@juspay/svelte-ui-components/dist/Button/Button.svelte:131-133`), so the press-scale ships immediately. It has **no** `:focus-visible` rule at all yet — `--button-focus-visible-box-shadow` is inert until Unit E lands the `2.87.0` upgrade that adds that hook. This task only sets the central variable; Unit E's upgrade is what makes the focus ring render.
+
+- [ ] **Step 1: Add press/focus vars to the Button section of theme.css**
+
+Current (`src/lib/theme.css:11-24`):
+
+```css
+:root {
+  /* ===== Button ===== */
+  --button-font-family: var(--font-sans);
+  --button-font-size: var(--text-sm);
+  --button-font-weight: 500;
+  --button-color: var(--ds-blue-700);
+  --button-text-color: #fff;
+  --button-padding: 8px 16px;
+  --button-border-radius: var(--radius-md);
+  --button-border: 1px solid transparent;
+  --button-hover-color: var(--ds-blue-900);
+  --button-hover-text-color: #fff;
+  --button-content-gap: 8px;
+
+  /* ===== Input ===== */
+```
+
+New:
+
+```css
+:root {
+  /* ===== Button ===== */
+  --button-font-family: var(--font-sans);
+  --button-font-size: var(--text-sm);
+  --button-font-weight: 500;
+  --button-color: var(--ds-blue-700);
+  --button-text-color: #fff;
+  --button-padding: 8px 16px;
+  --button-border-radius: var(--radius-md);
+  --button-border: 1px solid transparent;
+  --button-hover-color: var(--ds-blue-900);
+  --button-hover-text-color: #fff;
+  --button-content-gap: 8px;
+  /* Press/focus feedback — central hooks read by Button.svelte (:active today;
+     :focus-visible ships once @juspay/svelte-ui-components is upgraded to 2.87.0). */
+  --button-active-transform: scale(0.97);
+  --button-focus-visible-box-shadow: 0 0 0 2px var(--accent, #f5b14c);
+
+  /* ===== Input ===== */
+```
+
+- [ ] **Step 2: Add the one central `:active` rule for the three custom app-shell tappables**
+
+Current (`src/app.css:673-681`):
+
+```css
+::-webkit-scrollbar-thumb {
+  background: var(--ds-gray-400);
+  border-radius: var(--radius-full);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--ds-gray-500);
+}
+
+/* ============================================
+   Session Cards
+   ============================================ */
+```
+
+New:
+
+```css
+::-webkit-scrollbar-thumb {
+  background: var(--ds-gray-400);
+  border-radius: var(--radius-full);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--ds-gray-500);
+}
+
+/* Touch press feedback — central rule for the custom (non-library) app-shell
+   tappables. Library tappables (Button) get press feedback via the theme.css
+   vars above; .session-card/.terminal-card/.tab-item are plain elements. */
+@media (hover: none) {
+  .session-card:active,
+  .terminal-card:active,
+  .tab-item:active {
+    transform: scale(0.978);
+    transition: transform 60ms ease;
+  }
+}
+
+/* ============================================
+   Session Cards
+   ============================================ */
+```
+
+`.session-card` is defined at `src/app.css:686`; `.terminal-card` is scoped inside `src/routes/terminals/+page.svelte:401` and `.tab-item` inside `src/routes/+layout.svelte:212` — both are plain (unscoped-conflicting) class names with no existing `:active` rule, so this global, unscoped `app.css` rule reaches them without needing any per-component edit.
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -n "button-active-transform\|button-focus-visible-box-shadow" /Users/sachinsharma/Developer/Personal/shooter/src/lib/theme.css
+# Expected: two matches in the Button section
+
+grep -n "@media (hover: none)" /Users/sachinsharma/Developer/Personal/shooter/src/app.css
+# Expected: at least one match — the new press-feedback block (plus any pre-existing ones from later tasks)
+
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm build
+# Expected: clean build
+```
+
+Screenshot checklist (use Chrome DevTools device-toolbar touch emulation or a real phone — `:active`/`hover:none` won't trigger with a mouse): tap-and-hold on a primary `Button` (e.g. Settings page "Save" or Dashboard launch button) — button should depress via `scale(0.97)`. Tap-and-hold a session card on `/project`, a terminal card on `/terminals`, and a bottom tab on any screen — each should visibly compress (`scale(0.978)`) on press and spring back on release. The focus-visible amber ring will **not** yet be visible (blocked on Unit E) — tab to a button with a keyboard and confirm no visual regression (no broken/invalid outline), just note the ring itself is pending.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter
+git add src/lib/theme.css src/app.css
+git commit -m "feat(theme): centralize press and focus-visible feedback for tappables"
+```
+
+---
+
+### Task 12: One committed card elevation (central `.card`/`.list`/`.list-item` + library `Card` vars)
+
+**Files:**
+
+- Modify: `src/app.css:355-361` (`.card`)
+- Modify: `src/app.css:479-497` (`.list`, `.list-item`)
+- Modify: `src/lib/theme.css:49-51` (insert new `Card` var section)
+
+**Interfaces:**
+
+- Consumes: `--radius-lg` (central token, currently `8px`, bumped to `14px` by the "bolder tokens" task later in this unit — either ordering is safe since this task only ever references the token, never a literal)
+- Produces: `--card-background`, `--card-border`, `--card-border-radius`, `--card-overflow`, `--card-header-padding`, `--card-header-border-bottom`, `--card-title-font-size`, `--card-title-font-weight`, `--card-title-color`, `--card-description-font-size`, `--card-description-color`, `--card-description-opacity`, `--card-description-margin-top`, `--card-content-padding` (theme.css custom properties, consumed by the library `Card` component's own scoped styles, e.g. `Card.svelte`'s `background: var(--card-background, inherit)`)
+
+The library `Card` component (`@juspay/svelte-ui-components`, used on `/config` for "Setup Guide", "Registered Devices", "AI Providers", "Danger Zone", etc. — `src/routes/config/+page.svelte:16,430,457,529,545,596,625`) currently has **zero** `--card-*` vars set anywhere in `theme.css`, so it falls back to its own hardcoded defaults — including `border: var(--card-border, 1px solid currentColor)`, which resolves `currentColor` to `--text-primary` (near-white) and renders a stark, out-of-system light border. This is the single biggest contributor to the "flat card vs. gradient-card split" the spec calls out.
+
+- [ ] **Step 1: Give `.card` and `.list`/`.list-item` the same elevation as `.session-card`**
+
+Current (`src/app.css:355-361`):
+
+```css
+/* Cards */
+.card {
+  background: var(--component-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+```
+
+New:
+
+```css
+/* Cards */
+.card {
+  background: linear-gradient(135deg, rgba(20, 20, 20, 0.9) 0%, rgba(28, 28, 32, 0.9) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+}
+```
+
+Current (`src/app.css:479-493`):
+
+```css
+/* List */
+.list {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.list-item {
+  display: flex;
+  align-items: center;
+  padding: var(--space-4) var(--space-5);
+  background: var(--component-bg);
+  border-bottom: 1px solid var(--ds-gray-alpha-200);
+  transition: background var(--transition-fast);
+}
+```
+
+New:
+
+```css
+/* List */
+.list {
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+}
+
+.list-item {
+  display: flex;
+  align-items: center;
+  padding: var(--space-4) var(--space-5);
+  background: linear-gradient(135deg, rgba(20, 20, 20, 0.9) 0%, rgba(28, 28, 32, 0.9) 100%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  transition: background var(--transition-fast);
+}
+```
+
+- [ ] **Step 2: Theme the library `Card` component to match**
+
+Current (`src/lib/theme.css:49-51`):
+
+```css
+--input-container-margin: 0 0 var(--space-5) 0;
+
+/* ===== Banner (replaces Alert) ===== */
+```
+
+New:
+
+```css
+--input-container-margin: 0 0 var(--space-5) 0;
+
+/* ===== Card ===== */
+--card-background: linear-gradient(135deg, rgba(20, 20, 20, 0.9) 0%, rgba(28, 28, 32, 0.9) 100%);
+--card-border: 1px solid rgba(255, 255, 255, 0.06);
+--card-border-radius: var(--radius-lg);
+--card-overflow: hidden;
+--card-header-padding: var(--space-4) var(--space-5) 0;
+--card-header-border-bottom: none;
+--card-title-font-size: var(--text-sm);
+--card-title-font-weight: 500;
+--card-title-color: var(--text-primary);
+--card-description-font-size: var(--text-sm);
+--card-description-color: var(--text-tertiary);
+--card-description-opacity: 1;
+--card-description-margin-top: var(--space-1);
+--card-content-padding: var(--space-5);
+
+/* ===== Banner (replaces Alert) ===== */
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -n "linear-gradient(135deg, rgba(20, 20, 20" /Users/sachinsharma/Developer/Personal/shooter/src/app.css /Users/sachinsharma/Developer/Personal/shooter/src/lib/theme.css
+# Expected: 3 matches — app.css .card, app.css .list-item, theme.css --card-background
+
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm build
+# Expected: clean build
+```
+
+Screenshot checklist: `/config` — every `Card` ("Setup Guide", "Registered Devices", "AI Providers", "Danger Zone") should now render the same dark gradient + subtle 1px hairline + soft drop shadow as a session card on `/project`, with **no** stray bright/white border. `/` (Dashboard) — `DashboardCard` (`class="card"`, `src/lib/modules/client/dashboard/DashboardCard.svelte:88`) should pick up the new box-shadow (its own scoped `<style>` block sets `background`/`border`/`border-left` but never sets `box-shadow`, so the central shadow shows through even though the scoped rule wins on background/border — see Open Issues). `/project` and `/` session cards should look visually identical in depth to the newly-updated `.card`/`Card` surfaces.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter
+git add src/app.css src/lib/theme.css
+git commit -m "feat(theme): unify card elevation across app.css and the library Card"
+```
+
+---
+
+### Task 13: Hide the desktop scrollbar chrome on touch devices
+
+**Files:**
+
+- Modify: `src/app.css:663-680`
+
+**Interfaces:**
+
+- Consumes: none
+- Produces: none
+
+- [ ] **Step 1: Zero out the WebKit scrollbar under touch**
+
+Current (`src/app.css:663-680`):
+
+```css
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--ds-gray-400);
+  border-radius: var(--radius-full);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--ds-gray-500);
+}
+```
+
+New:
+
+```css
+/* Scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--ds-gray-400);
+  border-radius: var(--radius-full);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--ds-gray-500);
+}
+
+/* Touch devices: no persistent desktop-style scrollbar track/thumb */
+@media (hover: none) {
+  ::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+}
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -n "hover: none" /Users/sachinsharma/Developer/Personal/shooter/src/app.css
+# Expected: this rule plus the .session-card/.terminal-card/.tab-item press-feedback rule from the earlier task — 2 matches total once both tasks have landed
+
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm build
+# Expected: clean build
+```
+
+Screenshot checklist: with Chrome DevTools' device toolbar (touch emulation on) or a real phone, scroll a long list — `/terminals` (many cards) and `/session/[id]` chat view — confirm no visible scrollbar track/thumb. Then check a normal desktop Chrome window (mouse, `hover: hover`) on the same screens — the 8px gray scrollbar must still render exactly as before (no regression for desktop users).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter
+git add src/app.css
+git commit -m "fix(scroll): hide desktop scrollbar chrome on touch devices"
+```
+
+---
+
+### Task 14: Replace glyph back-arrows with the Icon component
+
+**Files:**
+
+- Create: `src/lib/assets/icons/arrow-left.svg`
+- Modify: `src/app.css:848-858` (remove dead `.session-chevron`)
+- Modify: `src/app.css:868-891` (remove dead `.session-back-btn`)
+- Modify: `src/routes/session/[id]/+page.svelte:11-16,573-575,580-581`
+- Modify: `src/routes/project/+page.svelte:6-8,245-249,257`
+- Modify: `src/routes/config/+page.svelte:9-12,421`
+- Modify: `src/routes/terminals/[id]/+page.svelte:16-17,791-794`
+
+**Interfaces:**
+
+- Consumes: `Icon` from `@juspay/svelte-ui-components` (already imported in `project/+page.svelte`, `config/+page.svelte`, `terminals/[id]/+page.svelte`; newly imported in `session/[id]/+page.svelte`), `.icon-14` class (`src/lib/theme.css:569-574`)
+- Produces: none
+
+`grep -rn "session-chevron\|session-back-btn"` across `src/routes` and `src/lib` returns **zero** matches — these two CSS classes are dead leftovers from a pre-library-migration UI (confirmed via `git log -p --follow -- src/app.css`, introduced in commit `dc719e7 feat: migrate UI to @juspay/svelte-ui-components` and never referenced by any template since). The live glyph tells today are the six `← Back` / `&#8592;` / `&larr;` literal-arrow instances inside `.back-link` across 4 route files — those are what this task actually swaps for the `Icon` component; the dead CSS is removed as part of the same "no stray glyph-arrow CSS" cleanup.
+
+- [ ] **Step 1: Add the shared arrow-left icon asset**
+
+Create `src/lib/assets/icons/arrow-left.svg` (matches the existing Feather-style stroke icons, e.g. `src/lib/assets/icons/refresh.svg`):
+
+```svg
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="19" y1="12" x2="5" y2="12"/>
+  <polyline points="12 19 5 12 12 5"/>
+</svg>
+```
+
+- [ ] **Step 2: Remove the dead `.session-chevron` and `.session-back-btn` CSS**
+
+Current (`src/app.css:848-858`):
+
+```css
+.session-duration {
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #737373);
+}
+
+.session-chevron {
+  color: var(--text-tertiary, #737373);
+  font-size: 1.2rem;
+  align-self: center;
+}
+
+/* ============================================
+   Session Detail Page
+   ============================================ */
+```
+
+New:
+
+```css
+.session-duration {
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #737373);
+}
+
+/* ============================================
+   Session Detail Page
+   ============================================ */
+```
+
+Current (`src/app.css:869-892`):
+
+```css
+
+.session-back-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-secondary, #141414);
+  border: 1px solid var(--border, #2a2a2a);
+  color: var(--text-secondary, #a3a3a3);
+  cursor: pointer;
+  transition: all var(--transition-fast, 150ms);
+  text-decoration: none;
+  font-size: 1.1rem;
+}
+
+.session-back-btn:hover {
+  background: var(--bg-tertiary, #1a1a1a);
+  color: var(--text-primary, #fafafa);
+  border-color: var(--gray-600, #525252);
+}
+
+.session-info-bar {
+```
+
+New:
+
+```css
+
+.session-info-bar {
+```
+
+- [ ] **Step 3: `src/routes/session/[id]/+page.svelte` — add imports, swap both back-links**
+
+Current (lines 11-16):
+
+```svelte
+import {browser} from '$app/environment'; import {page} from '$app/state'; import {(getCached,
+setCache,
+sourceToCommand)} from '$lib/modules/client/common'; import ChatView from '$lib/modules/client/terminal/ChatView.svelte';
+import {Button} from '@juspay/svelte-ui-components'; import {onMount} from 'svelte';
+```
+
+New:
+
+```svelte
+import {browser} from '$app/environment'; import {page} from '$app/state'; import ArrowLeftSvg from '$lib/assets/icons/arrow-left.svg?raw';
+import {(getCached, setCache, sourceToCommand)} from '$lib/modules/client/common'; import ChatView from
+'$lib/modules/client/terminal/ChatView.svelte'; import {(Button, Icon)} from '@juspay/svelte-ui-components';
+import {onMount} from 'svelte';
+```
+
+Current (lines 573-575):
+
+```svelte
+<div class="session-back-row">
+  <a href={projectId ? `/project?id=${projectId}` : '/'} class="back-link">← Back</a>
+</div>
+```
+
+New:
+
+```svelte
+<div class="session-back-row">
+  <a href={projectId ? `/project?id=${projectId}` : '/'} class="back-link">
+    <Icon svg={ArrowLeftSvg} classes="icon-14" />
+    Back
+  </a>
+</div>
+```
+
+Current (lines 580-581):
+
+```svelte
+      <div class="session-header-row">
+        <a href={projectId ? `/project?id=${projectId}` : '/'} class="back-link">← Back</a>
+```
+
+New:
+
+```svelte
+      <div class="session-header-row">
+        <a href={projectId ? `/project?id=${projectId}` : '/'} class="back-link">
+          <Icon svg={ArrowLeftSvg} classes="icon-14" />
+          Back
+        </a>
+```
+
+- [ ] **Step 4: `src/routes/project/+page.svelte` — add import, swap both back-links**
+
+Current (lines 6-8):
+
+```svelte
+import AlertTriangleSvg from '$lib/assets/icons/alert-triangle.svg?raw'; import BellSvg from
+'$lib/assets/icons/bell.svg?raw'; import RefreshSvg from '$lib/assets/icons/refresh.svg?raw';
+```
+
+New:
+
+```svelte
+import AlertTriangleSvg from '$lib/assets/icons/alert-triangle.svg?raw'; import ArrowLeftSvg from
+'$lib/assets/icons/arrow-left.svg?raw'; import BellSvg from '$lib/assets/icons/bell.svg?raw'; import
+RefreshSvg from '$lib/assets/icons/refresh.svg?raw';
+```
+
+(`Icon` is already imported at `src/routes/project/+page.svelte:18` — `import { Banner, Button, EmptyState, Icon, Pill, Shimmer } from '@juspay/svelte-ui-components';`.)
+
+Current (lines 245-249):
+
+```svelte
+<div class="project-back-row">
+  <a href="/" class="back-link">
+    <span class="back-arrow">&larr;</span>
+    Back to Projects
+  </a>
+</div>
+```
+
+New:
+
+```svelte
+<div class="project-back-row">
+  <a href="/" class="back-link">
+    <Icon svg={ArrowLeftSvg} classes="icon-14" />
+    Back to Projects
+  </a>
+</div>
+```
+
+Current (line 257):
+
+```svelte
+<a href="/" class="back-link">&#8592; Back to Projects</a>
+```
+
+New:
+
+```svelte
+<a href="/" class="back-link">
+  <Icon svg={ArrowLeftSvg} classes="icon-14" />
+  Back to Projects
+</a>
+```
+
+- [ ] **Step 5: `src/routes/config/+page.svelte` — add import, swap the back-link**
+
+Current (lines 9-12):
+
+```svelte
+import AlertTriangleSvg from '$lib/assets/icons/alert-triangle.svg?raw'; import CheckCircleSvg from
+'$lib/assets/icons/check-circle.svg?raw'; import PlaySvg from '$lib/assets/icons/play.svg?raw';
+import XCircleSvg from '$lib/assets/icons/x-circle.svg?raw';
+```
+
+New:
+
+```svelte
+import AlertTriangleSvg from '$lib/assets/icons/alert-triangle.svg?raw'; import ArrowLeftSvg from
+'$lib/assets/icons/arrow-left.svg?raw'; import CheckCircleSvg from
+'$lib/assets/icons/check-circle.svg?raw'; import PlaySvg from '$lib/assets/icons/play.svg?raw';
+import XCircleSvg from '$lib/assets/icons/x-circle.svg?raw';
+```
+
+(`Icon` is already imported at `src/routes/config/+page.svelte:16` — `import { Banner, Button, Card, Icon, Input, Stepper } from '@juspay/svelte-ui-components';`.)
+
+Current (line 421):
+
+```svelte
+<a href="/" class="back-link">← Back to Projects</a>
+```
+
+New:
+
+```svelte
+<a href="/" class="back-link">
+  <Icon svg={ArrowLeftSvg} classes="icon-14" />
+  Back to Projects
+</a>
+```
+
+- [ ] **Step 6: `src/routes/terminals/[id]/+page.svelte` — add import, swap the back-link**
+
+Current (lines 16-17):
+
+```svelte
+import AlertTriangleSvg from '$lib/assets/icons/alert-triangle.svg?raw'; import {AI_COMMANDS} from '$lib/modules/client/common';
+```
+
+New:
+
+```svelte
+import AlertTriangleSvg from '$lib/assets/icons/alert-triangle.svg?raw'; import ArrowLeftSvg from
+'$lib/assets/icons/arrow-left.svg?raw'; import {AI_COMMANDS} from '$lib/modules/client/common';
+```
+
+(`Icon` is already imported at `src/routes/terminals/[id]/+page.svelte:29` inside the multi-line `@juspay/svelte-ui-components` import.)
+
+Current (lines 791-794):
+
+```svelte
+<a href="/terminals" class="back-link">
+  <span class="back-arrow">&larr;</span>
+  Terminals
+</a>
+```
+
+New:
+
+```svelte
+<a href="/terminals" class="back-link">
+  <Icon svg={ArrowLeftSvg} classes="icon-14" />
+  Terminals
+</a>
+```
+
+- [ ] **Step 7: Verify**
+
+```bash
+grep -rn "session-chevron\|session-back-btn" /Users/sachinsharma/Developer/Personal/shooter/src
+# Expected: no matches
+
+grep -rln "back-arrow\|&larr;\|&#8592;\|← Back" /Users/sachinsharma/Developer/Personal/shooter/src/routes
+# Expected: no matches — every glyph arrow has been swapped for <Icon>
+
+cd /Users/sachinsharma/Developer/Personal/shooter
+pnpm lint:fix
+# Expected: exits 0; perfectionist auto-fixes any residual import-order nits from the manual edits above
+
+pnpm build
+# Expected: clean build
+```
+
+Screenshot checklist: `/session/[id]` (error state and normal header), `/project` (not-found state and normal header), `/config` (top-of-page back link), `/terminals/[id]` (error state) — every back-link now shows a stroke-based left-arrow icon at the same visual weight/size as the nav-bar icons (`icon-26` on the bottom tabs vs. `icon-14` inline here — both are the same Feather-style stroke, just scaled), not a serif/default-font `←` glyph.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter
+git add src/lib/assets/icons/arrow-left.svg src/app.css src/routes/session/\[id\]/+page.svelte src/routes/project/+page.svelte src/routes/config/+page.svelte src/routes/terminals/\[id\]/+page.svelte
+git commit -m "refactor(nav): replace glyph back-arrows with the Icon component"
+```
+
+---
+
+### Task 15: Bolder base type scale and radii (central tokens, mirrored into theme.css)
+
+**Files:**
+
+- Modify: `src/app.css:73,109-110,247` (`:root` tokens + `.page-title`)
+- Modify: `src/lib/theme.css:19,30,139` (button/input/select radius mirror)
+
+**Interfaces:**
+
+- Consumes: none
+- Produces: `--text-base` (16px), `--radius-lg` (14px), `--radius-xl` (18px) — consumed transitively by every existing `var(--text-base)`/`var(--radius-lg)`/`var(--radius-xl)` reference across `app.css` and `theme.css` (e.g. `--choicebox-border-radius`, `--toast-border-radius`, `--modal-border-radius`, `--card-border-radius` all already reference `var(--radius-lg)`/`var(--radius-xl)` and pick up the bump with no further edits)
+
+- [ ] **Step 1: Bump the base type size and large radii in `:root`**
+
+Current (`src/app.css:70-78`):
+
+```css
+/* Font Sizes - Geist Typography Scale */
+--text-xs: 12px;
+--text-sm: 13px;
+--text-base: 14px;
+--text-md: 15px;
+--text-lg: 16px;
+--text-xl: 20px;
+--text-2xl: 24px;
+--text-3xl: 32px;
+```
+
+New:
+
+```css
+/* Font Sizes - Geist Typography Scale */
+--text-xs: 12px;
+--text-sm: 13px;
+--text-base: 16px;
+--text-md: 15px;
+--text-lg: 16px;
+--text-xl: 20px;
+--text-2xl: 24px;
+--text-3xl: 32px;
+```
+
+Current (`src/app.css:106-111`):
+
+```css
+/* Border Radius */
+--radius-sm: 4px;
+--radius-md: 6px;
+--radius-lg: 8px;
+--radius-xl: 12px;
+--radius-full: 9999px;
+```
+
+New:
+
+```css
+/* Border Radius */
+--radius-sm: 4px;
+--radius-md: 6px;
+--radius-lg: 14px;
+--radius-xl: 18px;
+--radius-full: 9999px;
+```
+
+- [ ] **Step 2: Soften the page-title tracking to match the bolder scale**
+
+Current (`src/app.css:244-251`):
+
+```css
+.page-title {
+  font-size: var(--text-2xl);
+  font-weight: 600;
+  letter-spacing: var(--tracking-tighter);
+  color: var(--text-primary);
+  line-height: var(--leading-tight);
+  margin-bottom: var(--space-2);
+}
+```
+
+New:
+
+```css
+.page-title {
+  font-size: var(--text-2xl);
+  font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+  color: var(--text-primary);
+  line-height: var(--leading-tight);
+  margin-bottom: var(--space-2);
+}
+```
+
+- [ ] **Step 3: Mirror the radius bump into the library's button/input/select vars**
+
+These three currently pin to `--radius-md` (6px, unchanged by this bump) instead of `--radius-lg`, so they'd otherwise be left behind by the "bolder" system:
+
+Current (`src/lib/theme.css:19`):
+
+```css
+--button-border-radius: var(--radius-md);
+```
+
+New:
+
+```css
+--button-border-radius: var(--radius-lg);
+```
+
+Current (`src/lib/theme.css:30`):
+
+```css
+--input-radius: var(--radius-md);
+```
+
+New:
+
+```css
+--input-radius: var(--radius-lg);
+```
+
+Current (`src/lib/theme.css:139`):
+
+```css
+--select-radius: var(--radius-md);
+```
+
+New:
+
+```css
+--select-radius: var(--radius-lg);
+```
+
+No change needed for `--choicebox-border-radius` (`theme.css:184`, already `var(--radius-lg)`), `--toast-border-radius` (`theme.css:204`, already `var(--radius-lg)`), `--modal-border-radius` (`theme.css:220`, already `var(--radius-xl)`), `--card-border-radius` (added by the elevation task, already `var(--radius-lg)`), or `--pill-border-radius`/`--badge-border-radius` (already `var(--radius-full)`, maximally rounded) — they all cascade automatically from the `:root` bump.
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -n "text-base: 14px\|radius-lg: 8px\|radius-xl: 12px" /Users/sachinsharma/Developer/Personal/shooter/src/app.css
+# Expected: no matches (old values gone)
+
+grep -n "text-base: 16px\|radius-lg: 14px\|radius-xl: 18px" /Users/sachinsharma/Developer/Personal/shooter/src/app.css
+# Expected: 3 matches — the new values
+
+grep -n "button-border-radius: var(--radius-lg)\|input-radius: var(--radius-lg)\|select-radius: var(--radius-lg)" /Users/sachinsharma/Developer/Personal/shooter/src/lib/theme.css
+# Expected: 3 matches
+
+cd /Users/sachinsharma/Developer/Personal/shooter && pnpm build
+# Expected: clean build
+```
+
+Screenshot checklist (16px-base overflow check — per Constraint 3/5, screenshot **every** screen, but pay closest attention to the three places that read `var(--text-base)` directly): `/config` (the `session-info`-style dense rows, all `Input` fields, and the "Registered Devices" list — confirm no wrapped/clipped labels), `/terminals/[id]` topbar (`font-size: var(--text-base)` at `src/routes/terminals/[id]/+page.svelte:1035`) and `/session/[id]` header (`src/routes/session/[id]/+page.svelte:651`) — confirm the title/subtitle row doesn't overflow or force a second line unexpectedly, `/terminals` list (`src/routes/terminals/+page.svelte:459`). `QuickKeys` (`src/lib/modules/client/terminal/QuickKeys.svelte:57`) explicitly overrides `--button-font-size: var(--text-xs)` so it is **not** expected to change size — confirm it indeed looks untouched. Also confirm every button/input/select corner now reads visibly rounder (14px) across `/`, `/project`, `/config`, and that `Choicebox` options on `/config`'s AI-provider picker don't clip their selected-state ring at the new radius. If any specific row clips, tune that row's own CSS centrally (do not revert the global token).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/sachinsharma/Developer/Personal/shooter
+git add src/app.css src/lib/theme.css
+git commit -m "feat(theme): bolder 16px base type and larger radii, mirrored into the library"
+```
+
+## Unit C — Motion primitives (list FLIP + view-transition route hook)
+
+### Task 16: Shared reduced-motion primitive (`prefersReducedMotion` / `resolveMotionDuration`)
+
+**Files:**
+
+- Create: `src/lib/modules/client/common/motion.ts`
+- Test: `tests/motion.test.cjs`
+- Modify: `src/lib/modules/client/common/index.ts:1-10`
+- Modify: `package.json:79`
+
+**Interfaces:**
+
+- Consumes: none
+- Produces: `prefersReducedMotion(): boolean` and `resolveMotionDuration(baseMs: number, reducedMotion: boolean): number`, both exported from `$lib/modules/client/common` — consumed by the "DashboardView FLIP" and "onNavigate view-transition hook" tasks below.
+
+- [ ] **Step 1: Write the failing test first**
+
+Create `tests/motion.test.cjs` (mirrors the existing `tests/decide-injection.test.cjs` pattern: `tsx/cjs` register + a hand-rolled `runTest`/`assertEqual` runner, no framework):
+
+```js
+'use strict';
+
+require('tsx/cjs');
+
+const path = require('path');
+const mod = require(
+  path.join(__dirname, '..', 'src', 'lib', 'modules', 'client', 'common', 'motion.ts')
+);
+const { prefersReducedMotion, resolveMotionDuration } = mod;
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(
+      `${label || 'assertEqual'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+    );
+  }
+}
+
+runTest('resolveMotionDuration returns 0 when reduced motion is requested', () => {
+  assertEqual(resolveMotionDuration(220, true), 0, 'reduced');
+});
+
+runTest('resolveMotionDuration returns the base duration when motion is allowed', () => {
+  assertEqual(resolveMotionDuration(220, false), 220, 'allowed');
+});
+
+runTest('resolveMotionDuration passes through a zero base unchanged', () => {
+  assertEqual(resolveMotionDuration(0, false), 0, 'zero base');
+});
+
+runTest('prefersReducedMotion returns false when window is unavailable (SSR/Node)', () => {
+  assertEqual(typeof window, 'undefined', 'no window in this test process');
+  assertEqual(prefersReducedMotion(), false, 'ssr fallback');
+});
+
+runTest('prefersReducedMotion reflects matchMedia(prefers-reduced-motion: reduce).matches', () => {
+  global.window = {
+    matchMedia: (query) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+    }),
+  };
+  try {
+    assertEqual(prefersReducedMotion(), true, 'matches true');
+  } finally {
+    delete global.window;
+  }
+});
+
+runTest('prefersReducedMotion returns false when the media query does not match', () => {
+  global.window = {
+    matchMedia: () => ({ matches: false }),
+  };
+  try {
+    assertEqual(prefersReducedMotion(), false, 'matches false');
+  } finally {
+    delete global.window;
+  }
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);
+```
+
+Run it against the not-yet-created module:
+
+```bash
+node tests/motion.test.cjs
+```
+
+Expected output (FAIL — module doesn't exist yet):
+
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/sachinsharma/Developer/Personal/shooter/src/lib/modules/client/common/motion.ts'
+```
+
+(process exits non-zero before any `PASS`/`FAIL` lines print, since the `require()` at the top of the file throws.)
+
+- [ ] **Step 2: Implement the minimal primitive**
+
+Create `src/lib/modules/client/common/motion.ts`:
+
+```ts
+/**
+ * Reduced-motion-aware duration primitive shared by every animation entry
+ * point (list FLIP, view-transition route hook, future motion work). Centralizing
+ * the `prefers-reduced-motion` read here means every consumer honors the OS
+ * accessibility setting identically instead of re-implementing the check.
+ */
+
+/** True when the OS/browser requests reduced motion. Always false during SSR (no `window`). */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/** Resolves an animation duration to 0 when reduced motion is requested, else the base duration. */
+export function resolveMotionDuration(baseMs: number, reducedMotion: boolean): number {
+  return reducedMotion ? 0 : baseMs;
+}
+```
+
+- [ ] **Step 3: Re-run the test — expect PASS**
+
+```bash
+node tests/motion.test.cjs
+```
+
+Expected output:
+
+```
+  PASS  resolveMotionDuration returns 0 when reduced motion is requested
+  PASS  resolveMotionDuration returns the base duration when motion is allowed
+  PASS  resolveMotionDuration passes through a zero base unchanged
+  PASS  prefersReducedMotion returns false when window is unavailable (SSR/Node)
+  PASS  prefersReducedMotion reflects matchMedia(prefers-reduced-motion: reduce).matches
+  PASS  prefersReducedMotion returns false when the media query does not match
+
+6 passed, 0 failed
+```
+
+Exit code `0`.
+
+- [ ] **Step 4: Export from the client/common barrel**
+
+Current `src/lib/modules/client/common/index.ts`:
+
+```ts
+// Shared client utilities
+export { clearCache, getCached, setCache } from './cache';
+export { getApiKey, isShooterConfig } from './config-guard';
+export { toErrorMessage } from './error';
+export { renderMarkdown } from './markdown';
+export { hasScanner, isNativeBridge, scanQR } from './native-bridge';
+export { startPresenceReporting } from './presence';
+export { AI_COMMANDS, sourceLabel, sourceToCommand } from './provider';
+export { formatRelativeTime } from './time';
+export { getToolDescription } from './tool-title';
+```
+
+Replace with:
+
+```ts
+// Shared client utilities
+export { clearCache, getCached, setCache } from './cache';
+export { getApiKey, isShooterConfig } from './config-guard';
+export { toErrorMessage } from './error';
+export { renderMarkdown } from './markdown';
+export { prefersReducedMotion, resolveMotionDuration } from './motion';
+export { hasScanner, isNativeBridge, scanQR } from './native-bridge';
+export { startPresenceReporting } from './presence';
+export { AI_COMMANDS, sourceLabel, sourceToCommand } from './provider';
+export { formatRelativeTime } from './time';
+export { getToolDescription } from './tool-title';
+```
+
+- [ ] **Step 5: Wire the new test into the `pnpm test` chain**
+
+Current `package.json:79` (single line, truncated here — full line ends `... && node tests/summary-store.test.cjs"`):
+
+```json
+    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/service-manager.test.cjs && node tests/plan-mode-routing.test.cjs && node tests/dynamic-options-extraction.test.cjs && node tests/next-step-consensus.test.cjs && node tests/summaries-route.test.cjs && node tests/litellm-client.test.cjs && node tests/decide-injection.test.cjs && node tests/presence-store.test.cjs && node tests/autopilot-context.test.cjs && node tests/apns-payload.test.cjs && node tests/agent-launch.test.cjs && node tests/codex-parser.test.cjs && node tests/provider-readers.test.cjs && node tests/generic-watcher.test.cjs && node tests/sos-coordinator.test.cjs && node tests/sos-policy.test.cjs && node tests/pty-input.test.cjs && node tests/share-store.test.cjs && node tests/seq-ring.test.cjs && node tests/terminal-emulator.test.cjs && node tests/resize-authority.test.cjs && node tests/device-token-resolution.test.cjs && node tests/pty-holder-integration.cjs && node tests/device-token-store.test.cjs && node tests/device-format.test.cjs && node tests/classify-apns-reason.test.cjs && node tests/fcm-classify.test.cjs && node tests/notify-fanout.test.cjs && node tests/device-registry-prune.test.cjs && node tests/summary-store.test.cjs",
+```
+
+Replace the trailing segment `&& node tests/summary-store.test.cjs"` with `&& node tests/summary-store.test.cjs && node tests/motion.test.cjs"` (append the new test at the end of the chain, everything else unchanged):
+
+```json
+    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/service-manager.test.cjs && node tests/plan-mode-routing.test.cjs && node tests/dynamic-options-extraction.test.cjs && node tests/next-step-consensus.test.cjs && node tests/summaries-route.test.cjs && node tests/litellm-client.test.cjs && node tests/decide-injection.test.cjs && node tests/presence-store.test.cjs && node tests/autopilot-context.test.cjs && node tests/apns-payload.test.cjs && node tests/agent-launch.test.cjs && node tests/codex-parser.test.cjs && node tests/provider-readers.test.cjs && node tests/generic-watcher.test.cjs && node tests/sos-coordinator.test.cjs && node tests/sos-policy.test.cjs && node tests/pty-input.test.cjs && node tests/share-store.test.cjs && node tests/seq-ring.test.cjs && node tests/terminal-emulator.test.cjs && node tests/resize-authority.test.cjs && node tests/device-token-resolution.test.cjs && node tests/pty-holder-integration.cjs && node tests/device-token-store.test.cjs && node tests/device-format.test.cjs && node tests/classify-apns-reason.test.cjs && node tests/fcm-classify.test.cjs && node tests/notify-fanout.test.cjs && node tests/device-registry-prune.test.cjs && node tests/summary-store.test.cjs && node tests/motion.test.cjs",
+```
+
+- [ ] **Step 6: Type-check**
+
+```bash
+pnpm check
+```
+
+Expected: exits 0, no errors referencing `motion.ts` or `common/index.ts`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/modules/client/common/motion.ts src/lib/modules/client/common/index.ts tests/motion.test.cjs package.json
+git commit -m "feat(motion): add reduced-motion-aware duration primitive"
+```
+
+---
+
+### Task 17: FLIP-animate DashboardView's keyed card lists
+
+**Files:**
+
+- Modify: `src/lib/modules/client/dashboard/DashboardView.svelte:1-48`
+
+**Interfaces:**
+
+- Consumes: `prefersReducedMotion(): boolean`, `resolveMotionDuration(baseMs: number, reducedMotion: boolean): number` from `$lib/modules/client/common` (previous task)
+- Produces: none (leaf visual behavior)
+
+- [ ] **Step 1: Add the flip import + reduced-motion-guarded duration**
+
+Current `src/lib/modules/client/dashboard/DashboardView.svelte:1-20`:
+
+```svelte
+<script lang="ts">
+  import type { DashboardCard } from '$lib/types';
+
+  import DashboardCardComponent from './DashboardCard.svelte';
+
+  const {
+    cards,
+    onCardClick,
+  }: {
+    cards: DashboardCard[];
+    onCardClick?: (card: DashboardCard) => void;
+  } = $props();
+
+  const runningCards = $derived(cards.filter((c) => c.status === 'running'));
+  const otherCards = $derived(cards.filter((c) => c.status !== 'running'));
+
+  function handleClick(card: DashboardCard): void {
+    onCardClick?.(card);
+  }
+</script>
+```
+
+Replace with:
+
+```svelte
+<script lang="ts">
+  import type { DashboardCard } from '$lib/types';
+
+  import { prefersReducedMotion, resolveMotionDuration } from '$lib/modules/client/common';
+  import { flip } from 'svelte/animate';
+
+  import DashboardCardComponent from './DashboardCard.svelte';
+
+  const {
+    cards,
+    onCardClick,
+  }: {
+    cards: DashboardCard[];
+    onCardClick?: (card: DashboardCard) => void;
+  } = $props();
+
+  const runningCards = $derived(cards.filter((c) => c.status === 'running'));
+  const otherCards = $derived(cards.filter((c) => c.status !== 'running'));
+
+  // Computed once — a fixed FLIP duration, not a live media-query subscription.
+  // Keeps card-reorder animation and the OS reduced-motion setting in lockstep.
+  const flipDuration = resolveMotionDuration(220, prefersReducedMotion());
+
+  function handleClick(card: DashboardCard): void {
+    onCardClick?.(card);
+  }
+</script>
+```
+
+- [ ] **Step 2: Wrap each keyed card in a real element carrying `animate:flip`**
+
+`animate:` can only target a regular DOM element that is the direct child of a keyed `{#each}` block — not a component tag — so each `<DashboardCardComponent>` needs a thin wrapper `<div>`.
+
+Current `src/lib/modules/client/dashboard/DashboardView.svelte:22-34` (the "Active" section):
+
+```svelte
+{#if runningCards.length > 0}
+  <div class="section">
+    <h3 class="section-label">Active</h3>
+    {#each runningCards as card (card.terminalId)}
+      <DashboardCardComponent
+        {card}
+        onclick={(): void => {
+          handleClick(card);
+        }}
+      />
+    {/each}
+  </div>
+{/if}
+```
+
+Replace with:
+
+```svelte
+{#if runningCards.length > 0}
+  <div class="section">
+    <h3 class="section-label">Active</h3>
+    {#each runningCards as card (card.terminalId)}
+      <div class="card-flip" animate:flip={{ duration: flipDuration }}>
+        <DashboardCardComponent
+          {card}
+          onclick={(): void => {
+            handleClick(card);
+          }}
+        />
+      </div>
+    {/each}
+  </div>
+{/if}
+```
+
+Current `src/lib/modules/client/dashboard/DashboardView.svelte:36-48` (the "Recent" section):
+
+```svelte
+{#if otherCards.length > 0}
+  <div class="section">
+    <h3 class="section-label">Recent</h3>
+    {#each otherCards as card (card.terminalId)}
+      <DashboardCardComponent
+        {card}
+        onclick={(): void => {
+          handleClick(card);
+        }}
+      />
+    {/each}
+  </div>
+{/if}
+```
+
+Replace with:
+
+```svelte
+{#if otherCards.length > 0}
+  <div class="section">
+    <h3 class="section-label">Recent</h3>
+    {#each otherCards as card (card.terminalId)}
+      <div class="card-flip" animate:flip={{ duration: flipDuration }}>
+        <DashboardCardComponent
+          {card}
+          onclick={(): void => {
+            handleClick(card);
+          }}
+        />
+      </div>
+    {/each}
+  </div>
+{/if}
+```
+
+No new CSS is needed for `.card-flip` — a bare `<div>` is `display: block` by default, which is layout-identical to the `<DashboardCardComponent>` it replaces as the direct flex child of `.section`, so the FLIP wrapper introduces no visual shift.
+
+- [ ] **Step 3: Verify — grep guard**
+
+```bash
+grep -c "animate:flip" src/lib/modules/client/dashboard/DashboardView.svelte
+```
+
+Expected output: `2` (one per `{#each}` block).
+
+```bash
+grep -c "svelte/animate" src/lib/modules/client/dashboard/DashboardView.svelte
+```
+
+Expected output: `1`.
+
+- [ ] **Step 4: Verify — build + type-check**
+
+```bash
+pnpm build
+```
+
+Expected: build succeeds, no Svelte compiler errors (in particular no "AnimateDirective can only be used on elements" error, since `animate:flip` sits on the wrapper `<div>`, not on `<DashboardCardComponent>`).
+
+```bash
+pnpm check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 5: Screenshot/video verification checklist**
+
+Run the app (`pnpm dev` or via the `run` skill) and open `/` (Dashboard):
+
+1. With ≥2 terminals running: trigger a reorder that changes `cards` order (e.g. a card transitions `running` → `other`, or a new active session bumps another card down). Confirm the remaining cards **glide/slide** into their new position over ~220ms rather than snapping instantly.
+2. Take a screenshot mid-transition (or a short screen recording) showing a card visibly mid-translate, not just before/after stills.
+3. Enable OS-level "Reduce Motion" (macOS: System Settings → Accessibility → Display → Reduce Motion; or emulate via `mcp__plugin_chrome-devtools-mcp_chrome-devtools__emulate` with `reducedMotion: 'reduce'` if testing in Chrome DevTools), repeat the same reorder trigger, and confirm cards **snap instantly** with no glide (duration resolves to `0`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/modules/client/dashboard/DashboardView.svelte
+git commit -m "feat(dashboard): FLIP-animate card reordering, reduced-motion-guarded"
+```
+
+---
+
+### Task 18: `onNavigate` view-transition hook for route changes
+
+**Files:**
+
+- Modify: `src/routes/+layout.svelte:1-15,63-89`
+- Modify: `src/app.css:647-662`
+
+**Interfaces:**
+
+- Consumes: `prefersReducedMotion(): boolean` from `$lib/modules/client/common` (first task); `onNavigate` from `$app/navigation` (SvelteKit, confirmed present at `node_modules/@sveltejs/kit/types/index.d.ts:3159`); `document.startViewTransition` (typed in this repo's TS DOM lib at `node_modules/typescript/lib/lib.dom.d.ts:10378`, unconditional — feature-detected at runtime via `typeof`, not via a TS optional-chain).
+- Produces: none (leaf navigation behavior)
+
+- [ ] **Step 1: Import `onNavigate` and the reduced-motion primitive**
+
+Current `src/routes/+layout.svelte:1-15`:
+
+```svelte
+<script lang="ts">
+  import type { LayoutData } from '$lib/types';
+
+  import '../app.css';
+  import '$lib/theme.css';
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import BellSvg from '$lib/assets/icons/bell.svg?raw';
+  import DashboardSvg from '$lib/assets/icons/dashboard.svg?raw';
+  import SettingsSvg from '$lib/assets/icons/settings.svg?raw';
+  import TerminalSvg from '$lib/assets/icons/terminal.svg?raw';
+  import ToolSvg from '$lib/assets/icons/tool.svg?raw';
+  import { Button, Icon, Pill } from '@juspay/svelte-ui-components';
+  import { onMount, type Snippet } from 'svelte';
+```
+
+Replace with:
+
+```svelte
+<script lang="ts">
+  import type { LayoutData } from '$lib/types';
+
+  import '../app.css';
+  import '$lib/theme.css';
+  import { browser } from '$app/environment';
+  import { goto, onNavigate } from '$app/navigation';
+  import { page } from '$app/stores';
+  import BellSvg from '$lib/assets/icons/bell.svg?raw';
+  import DashboardSvg from '$lib/assets/icons/dashboard.svg?raw';
+  import SettingsSvg from '$lib/assets/icons/settings.svg?raw';
+  import TerminalSvg from '$lib/assets/icons/terminal.svg?raw';
+  import ToolSvg from '$lib/assets/icons/tool.svg?raw';
+  import { prefersReducedMotion } from '$lib/modules/client/common';
+  import { Button, Icon, Pill } from '@juspay/svelte-ui-components';
+  import { onMount, type Snippet } from 'svelte';
+```
+
+- [ ] **Step 2: Add the `onNavigate` hook, guarded by reduced-motion + feature detection**
+
+Current `src/routes/+layout.svelte:63-89`:
+
+```svelte
+  onMount(() => {
+    void checkSystemStatus();
+    const interval = setInterval(() => {
+      void checkSystemStatus();
+    }, 30000);
+    return (): void => {
+      clearInterval(interval);
+    };
+  });
+
+  async function checkSystemStatus(): Promise<void> {
+    try {
+      const response = await fetch('/api/health');
+      if (!response.ok) {
+        systemStatus = 'error';
+        return;
+      }
+      const data = (await response.json()) as { status?: string };
+      systemStatus =
+        data.status === 'healthy' || data.status === 'degraded' || data.status === 'error'
+          ? data.status
+          : 'unknown';
+    } catch {
+      systemStatus = 'error';
+    }
+  }
+</script>
+```
+
+Replace with:
+
+```svelte
+  onMount(() => {
+    void checkSystemStatus();
+    const interval = setInterval(() => {
+      void checkSystemStatus();
+    }, 30000);
+    return (): void => {
+      clearInterval(interval);
+    };
+  });
+
+  // Progressive enhancement: cross-fade/slide between routes via the View
+  // Transitions API when the browser supports it and the user has not asked
+  // for reduced motion. Falls through to SvelteKit's normal instant swap
+  // everywhere else (Safari < 18, Firefox, reduced-motion).
+  onNavigate((navigation) => {
+    if (prefersReducedMotion() || typeof document.startViewTransition !== 'function') {
+      return;
+    }
+
+    return new Promise((resolve) => {
+      document.startViewTransition(async () => {
+        resolve();
+        await navigation.complete;
+      });
+    });
+  });
+
+  async function checkSystemStatus(): Promise<void> {
+    try {
+      const response = await fetch('/api/health');
+      if (!response.ok) {
+        systemStatus = 'error';
+        return;
+      }
+      const data = (await response.json()) as { status?: string };
+      systemStatus =
+        data.status === 'healthy' || data.status === 'degraded' || data.status === 'error'
+          ? data.status
+          : 'unknown';
+    } catch {
+      systemStatus = 'error';
+    }
+  }
+</script>
+```
+
+- [ ] **Step 3: Add the central `::view-transition` slide/cross-fade, gated by `prefers-reduced-motion: no-preference`**
+
+Current `src/app.css:647-662`:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Selection */
+::selection {
+  background: var(--ds-blue-700);
+  color: #fff;
+}
+```
+
+Replace with:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Page transitions (View Transitions API) — see +layout.svelte's onNavigate
+   hook. Browsers without support (or with reduced motion requested) fall
+   through to SvelteKit's normal instant route swap. */
+@keyframes shooter-view-fade-out {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes shooter-view-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  ::view-transition-old(root) {
+    animation: shooter-view-fade-out 150ms ease both;
+  }
+
+  ::view-transition-new(root) {
+    animation: shooter-view-slide-in 220ms ease both;
+  }
+}
+
+/* Selection */
+::selection {
+  background: var(--ds-blue-700);
+  color: #fff;
+}
+```
+
+- [ ] **Step 4: Verify — grep guard**
+
+```bash
+grep -c "startViewTransition" src/routes/+layout.svelte
+```
+
+Expected output: `2` (the `typeof` feature-detect check + the `document.startViewTransition(` call).
+
+```bash
+grep -c "::view-transition-" src/app.css
+```
+
+Expected output: `2` (`::view-transition-old(root)` + `::view-transition-new(root)`).
+
+```bash
+grep -n "prefers-reduced-motion: no-preference" src/app.css
+```
+
+Expected output: one match, the `@media` line wrapping the two `::view-transition-*` rules.
+
+- [ ] **Step 5: Verify — build + type-check**
+
+```bash
+pnpm build
+```
+
+Expected: build succeeds (Vite/esbuild accept `::view-transition-old`/`::view-transition-new` as plain unrecognized-but-valid CSS pseudo-elements; no PostCSS/lint failure).
+
+```bash
+pnpm check
+```
+
+Expected: exits 0 — `document.startViewTransition` type-checks against `lib.dom.d.ts`, `navigation.complete` is `Promise<void>` per `@sveltejs/kit`'s `Navigation` type, and the callback's return type (`Promise<void> | undefined`) satisfies `onNavigate`'s `MaybePromise<(() => void) | void>` signature.
+
+- [ ] **Step 6: Screenshot/video verification checklist**
+
+Run the app in a browser that supports the View Transitions API (Chrome/Edge; use `mcp__plugin_chrome-devtools-mcp_chrome-devtools__navigate_page` + `take_screenshot`, or a manual screen recording):
+
+1. From `/` (Dashboard), tap the Terminals tab. Confirm the outgoing view cross-fades out (~150ms) while the incoming view slides up + fades in (~220ms) — record a short clip since a still screenshot can't show the transition itself.
+2. Repeat between `/terminals` → `/activity` → `/config` to confirm the transition fires on every bottom-tab navigation, not just one route pair.
+3. In DevTools, confirm no console errors during navigation (a rejected `navigation.complete` on a cancelled nav should not throw unhandled — check the console tab is clean after a few rapid taps).
+4. Emulate `prefers-reduced-motion: reduce` (`mcp__plugin_chrome-devtools-mcp_chrome-devtools__emulate` with `reducedMotion: 'reduce'`, or macOS Reduce Motion), repeat the same navigations, and confirm routes swap **instantly** with no slide/cross-fade (the `onNavigate` hook returns early via `prefersReducedMotion()`, and even if it didn't, the `::view-transition-*` rules are inert outside `no-preference`).
+5. In a browser without View Transitions support (Firefox, or Safari < 18), confirm navigation still works normally (instant swap, no error) — the `typeof document.startViewTransition !== 'function'` guard falls through cleanly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/routes/+layout.svelte src/app.css
+git commit -m "feat(nav): cross-fade/slide route transitions via View Transitions API"
+```
+
+## Unit D — Haptics full vertical (web + iOS + Android)
+
+### Task 19: HapticKind type — central types module + barrel
+
+**Files:**
+
+- Create: `src/lib/types/haptics.ts`
+- Modify: `src/lib/types/index.ts:13-14`
+
+**Interfaces:**
+
+- Consumes: none
+- Produces: `HapticKind` union type, imported everywhere via `import type { HapticKind } from '$lib/types'`
+
+- [ ] **Step 1: Create the hand-written union type**
+
+`src/lib/types/haptics.ts` does not exist yet. Create it:
+
+```ts
+// Haptic feedback kinds for the web haptic() bridge. A string-literal union —
+// not expressible in the type-crafter YAML schema — mirrored by iOS
+// (UIImpactFeedbackGenerator/UINotificationFeedbackGenerator/UISelectionFeedbackGenerator)
+// and Android (VibrationEffect) native implementations.
+export type HapticKind =
+  | 'light'
+  | 'medium'
+  | 'heavy'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'selection';
+```
+
+- [ ] **Step 2: Re-export from the barrel**
+
+Current `src/lib/types/index.ts:13-15`:
+
+```ts
+export type * from './gemini';
+export * from './generated';
+export type * from './neurolink';
+```
+
+Replace with:
+
+```ts
+export type * from './gemini';
+export * from './generated';
+export type * from './haptics';
+export type * from './neurolink';
+```
+
+- [ ] **Step 3: Verify — grep guard + typecheck the new module in isolation**
+
+```bash
+grep -n "haptics" src/lib/types/index.ts
+```
+
+Expected output:
+
+```
+15:export type * from './haptics';
+```
+
+```bash
+node -e "require('tsx/cjs'); const m = require('./src/lib/types/haptics.ts'); console.log('module loads, no runtime export (type-only):', Object.keys(m));"
+```
+
+Expected output (type-only module, erased at runtime — this just proves the file parses/loads cleanly through the project's TS toolchain):
+
+```
+module loads, no runtime export (type-only): []
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/types/haptics.ts src/lib/types/index.ts
+git commit -m "feat(types): add HapticKind union for native/web haptic bridge"
+```
+
+---
+
+### Task 20: haptic() web API — TDD (native-bridge.ts)
+
+**Files:**
+
+- Modify: `src/app.d.ts:1-29`
+- Modify: `src/lib/modules/client/common/native-bridge.ts:1-59`
+- Create: `tests/native-bridge.test.cjs`
+- Modify: `package.json:79`
+
+**Interfaces:**
+
+- Consumes: `HapticKind` from `$lib/types` (Task 19); `window.ShooterBridge`/`window.ShooterNativeBridge` ambient globals from `src/app.d.ts`
+- Produces: `export function haptic(kind: HapticKind = 'light'): void` from `native-bridge.ts`, consumed by Task 21 (`+layout.svelte`, `QuickKeys.svelte`)
+
+- [ ] **Step 1: Extend the ambient bridge type to declare `haptic`**
+
+Current `src/app.d.ts` (full file, 29 lines):
+
+```ts
+// See https://svelte.dev/docs/kit/types#app.d.ts
+
+declare global {
+  interface ShooterBridge {
+    getApnsToken?: () => string;
+    getConfig?: () => string;
+    getDeviceId?: () => string;
+    getDeviceName?: () => string;
+    getEnvironment?: () => string;
+    getFcmToken?: () => string;
+    getPlatform?: () => string;
+    saveConfig?: (config: string) => void;
+    scanner?: ShooterBridgeScanner;
+  }
+
+  interface ShooterBridgeScanner {
+    scan: () => Promise<string>;
+  }
+
+  // Window must use interface — TypeScript requires it for declaration merging
+  interface Window {
+    handleNativeResponse?: (callbackId: string, response: string) => void;
+    ShooterBridge?: ShooterBridge;
+    ShooterNativeBridge?: ShooterBridge;
+  }
+}
+
+export {};
+```
+
+Edit: add `haptic?: (kind: string) => void;` to the `ShooterBridge` interface (both `window.ShooterBridge` (iOS) and `window.ShooterNativeBridge` (Android) type-alias to this same interface, so one field covers both platforms). `string` (not `HapticKind`) matches this file's existing convention — every other bridge field is a bare primitive; `app.d.ts` is exempt from the project's "types live in `src/lib/types/`" ESLint rule (`eslint.config.js` `ignores: ['src/lib/types/**', 'src/app.d.ts']`) precisely so it can stay a self-contained ambient declaration, and `HapticKind` values are assignable into a `string`-typed parameter regardless:
+
+```ts
+// See https://svelte.dev/docs/kit/types#app.d.ts
+
+declare global {
+  interface ShooterBridge {
+    getApnsToken?: () => string;
+    getConfig?: () => string;
+    getDeviceId?: () => string;
+    getDeviceName?: () => string;
+    getEnvironment?: () => string;
+    getFcmToken?: () => string;
+    getPlatform?: () => string;
+    haptic?: (kind: string) => void;
+    saveConfig?: (config: string) => void;
+    scanner?: ShooterBridgeScanner;
+  }
+
+  interface ShooterBridgeScanner {
+    scan: () => Promise<string>;
+  }
+
+  // Window must use interface — TypeScript requires it for declaration merging
+  interface Window {
+    handleNativeResponse?: (callbackId: string, response: string) => void;
+    ShooterBridge?: ShooterBridge;
+    ShooterNativeBridge?: ShooterBridge;
+  }
+}
+
+export {};
+```
+
+- [ ] **Step 2: Write the failing test first**
+
+Create `tests/native-bridge.test.cjs` (same hand-rolled node-test style as `tests/device-format.test.cjs` — this repo has no vitest; `pnpm test` chains `node tests/*.test.cjs` files, confirmed by reading `package.json:79`). Node 24 ships a built-in `navigator` global getter, so the test must override it with `Object.defineProperty` (a plain `global.navigator = {}` throws `TypeError: Cannot set property navigator of #<Object> which has only a getter` — verified):
+
+```js
+/**
+ * Unit tests for src/lib/modules/client/common/native-bridge.ts — haptic()
+ *
+ * haptic() resolution order: window.ShooterBridge.haptic (iOS) →
+ * window.ShooterNativeBridge.haptic (Android) → navigator.vibrate (web) →
+ * no-op. Must be SSR/desktop-safe and never throw.
+ *
+ * Loads the real TS module via tsx/cjs. window/navigator are faked as
+ * globals before the require (the module reads them at call time, not at
+ * import time, so each test can reassign them freely).
+ */
+
+'use strict';
+
+const path = require('path');
+
+require('tsx/cjs');
+
+function setWindow(value) {
+  global.window = value;
+}
+
+// Node 24 defines a built-in `navigator` global getter (configurable, but
+// not a plain writable property) — must use defineProperty, not assignment.
+function setNavigator(value) {
+  Object.defineProperty(global, 'navigator', { configurable: true, value, writable: true });
+}
+
+setWindow({});
+setNavigator({});
+
+const { haptic } = require(
+  path.join(__dirname, '..', 'src', 'lib', 'modules', 'client', 'common', 'native-bridge.ts')
+);
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(`${label}: expected ${e}, got ${a}`);
+  }
+}
+
+console.log('\nnative-bridge haptic() unit tests\n');
+
+runTest('Test 1: prefers window.ShooterBridge.haptic (iOS) when present', () => {
+  const calls = [];
+  setWindow({ ShooterBridge: { haptic: (kind) => calls.push(kind) } });
+  setNavigator({
+    vibrate: () => {
+      throw new Error('navigator.vibrate should not be called when ShooterBridge.haptic exists');
+    },
+  });
+  haptic('selection');
+  assertEqual(calls, ['selection'], 'ShooterBridge.haptic called with kind');
+});
+
+runTest(
+  'Test 2: falls back to window.ShooterNativeBridge.haptic (Android) when ShooterBridge lacks it',
+  () => {
+    const calls = [];
+    setWindow({ ShooterNativeBridge: { haptic: (kind) => calls.push(kind) } });
+    setNavigator({
+      vibrate: () => {
+        throw new Error(
+          'navigator.vibrate should not be called when ShooterNativeBridge.haptic exists'
+        );
+      },
+    });
+    haptic('heavy');
+    assertEqual(calls, ['heavy'], 'ShooterNativeBridge.haptic called with kind');
+  }
+);
+
+runTest('Test 3: falls back to navigator.vibrate when neither native bridge is present', () => {
+  const calls = [];
+  setWindow({});
+  setNavigator({ vibrate: (ms) => calls.push(ms) });
+  haptic('light');
+  assertEqual(calls, [10], 'navigator.vibrate called with mapped ms for "light"');
+});
+
+runTest('Test 4: default kind is "light" when called with no argument', () => {
+  const calls = [];
+  setWindow({});
+  setNavigator({ vibrate: (ms) => calls.push(ms) });
+  haptic();
+  assertEqual(calls, [10], 'navigator.vibrate called with the light duration by default');
+});
+
+runTest('Test 5: silent no-op when window is undefined (SSR)', () => {
+  const original = global.window;
+  setWindow(undefined);
+  try {
+    haptic('error'); // must not throw
+  } finally {
+    setWindow(original);
+  }
+});
+
+runTest(
+  'Test 6: silent no-op when neither bridge nor navigator.vibrate exist (desktop browser)',
+  () => {
+    setWindow({});
+    setNavigator({});
+    haptic('medium'); // must not throw
+  }
+);
+
+runTest('Test 7: never throws even if the native bridge itself throws', () => {
+  setWindow({
+    ShooterBridge: {
+      haptic: () => {
+        throw new Error('native crash');
+      },
+    },
+  });
+  setNavigator({ vibrate: () => {} });
+  haptic('warning'); // must not throw
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total\n`);
+
+process.exit(failed > 0 ? 1 : 0);
+```
+
+Run it now, before `haptic` exists — expect a real failure:
+
+```bash
+node tests/native-bridge.test.cjs
+```
+
+Expected output (RED — verified by running this exact require against the current file, which has no `haptic` export):
+
+```
+native-bridge haptic() unit tests
+
+  FAIL  Test 1: prefers window.ShooterBridge.haptic (iOS) when present
+        haptic is not a function
+  FAIL  Test 2: falls back to window.ShooterNativeBridge.haptic (Android) when ShooterBridge lacks it
+        haptic is not a function
+  FAIL  Test 3: falls back to navigator.vibrate when neither native bridge is present
+        haptic is not a function
+  FAIL  Test 4: default kind is "light" when called with no argument
+        haptic is not a function
+  FAIL  Test 5: silent no-op when window is undefined (SSR)
+        haptic is not a function
+  FAIL  Test 6: silent no-op when neither bridge nor navigator.vibrate exist (desktop browser)
+        haptic is not a function
+  FAIL  Test 7: never throws even if the native bridge itself throws
+        haptic is not a function
+
+Results: 0 passed, 7 failed, 7 total
+```
+
+- [ ] **Step 3: Implement `haptic()` — minimal code to pass**
+
+Current `src/lib/modules/client/common/native-bridge.ts` (full file, 59 lines) — quoting the two edit points:
+
+Top of file (lines 1-11):
+
+```ts
+/**
+ * Native bridge utilities for detecting and communicating with
+ * the ShooterBridge injected by native WebView wrappers (iOS/Android).
+ *
+ * The native side injects window.ShooterBridge at documentStart with its own
+ * callback-ID system (window.ShooterBridge._callbacks + window.handleNativeResponse).
+ * This module MUST NOT override handleNativeResponse — the native version handles
+ * resolving scanner/picker promises using its own callback registry.
+ */
+
+/** True when the native bridge exposes a QR scanner */
+export function hasScanner(): boolean {
+```
+
+Replace with (adds the type import):
+
+```ts
+/**
+ * Native bridge utilities for detecting and communicating with
+ * the ShooterBridge injected by native WebView wrappers (iOS/Android).
+ *
+ * The native side injects window.ShooterBridge at documentStart with its own
+ * callback-ID system (window.ShooterBridge._callbacks + window.handleNativeResponse).
+ * This module MUST NOT override handleNativeResponse — the native version handles
+ * resolving scanner/picker promises using its own callback registry.
+ */
+
+import type { HapticKind } from '$lib/types';
+
+/** True when the native bridge exposes a QR scanner */
+export function hasScanner(): boolean {
+```
+
+End of file (lines 41-59, unchanged content) — append the haptic implementation after it:
+
+```ts
+/** Get the scanner.scan function from whichever bridge exists */
+function getScanFn(): (() => Promise<string>) | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  // Check iOS bridge first, then Android.
+  // Capture the scanner object (not the bare function) to preserve `this` binding
+  // when the native side implements scan() as a method on the scanner object.
+  const iosScanner = window.ShooterBridge?.scanner;
+  if (iosScanner && typeof iosScanner.scan === 'function') {
+    return () => iosScanner.scan();
+  }
+  const androidScanner = window.ShooterNativeBridge?.scanner;
+  if (androidScanner && typeof androidScanner.scan === 'function') {
+    return () => androidScanner.scan();
+  }
+  return null;
+}
+
+/** navigator.vibrate() fallback durations (ms) per haptic kind, for browsers/PWA with no native bridge. */
+const VIBRATION_MS: Record<HapticKind, number> = {
+  error: 40,
+  heavy: 30,
+  light: 10,
+  medium: 20,
+  selection: 5,
+  success: 15,
+  warning: 25,
+};
+
+/**
+ * Fire a haptic tick.
+ * Resolution order: window.ShooterBridge.haptic (iOS) → window.ShooterNativeBridge.haptic
+ * (Android) → navigator.vibrate (web/PWA) → no-op. SSR/desktop-safe — never throws.
+ */
+export function haptic(kind: HapticKind = 'light'): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    if (typeof window.ShooterBridge?.haptic === 'function') {
+      window.ShooterBridge.haptic(kind);
+      return;
+    }
+    if (typeof window.ShooterNativeBridge?.haptic === 'function') {
+      window.ShooterNativeBridge.haptic(kind);
+      return;
+    }
+    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+      navigator.vibrate(VIBRATION_MS[kind]);
+    }
+  } catch {
+    // Haptics are best-effort — never let a native-bridge exception surface to callers.
+  }
+}
+```
+
+- [ ] **Step 4: Run the test again — expect GREEN**
+
+```bash
+node tests/native-bridge.test.cjs
+```
+
+Expected output (verified against an equivalent implementation in a scratch harness using the identical resolution logic and the same `Object.defineProperty` navigator trick):
+
+```
+native-bridge haptic() unit tests
+
+  PASS  Test 1: prefers window.ShooterBridge.haptic (iOS) when present
+  PASS  Test 2: falls back to window.ShooterNativeBridge.haptic (Android) when ShooterBridge lacks it
+  PASS  Test 3: falls back to navigator.vibrate when neither native bridge is present
+  PASS  Test 4: default kind is "light" when called with no argument
+  PASS  Test 5: silent no-op when window is undefined (SSR)
+  PASS  Test 6: silent no-op when neither bridge nor navigator.vibrate exist (desktop browser)
+  PASS  Test 7: never throws even if the native bridge itself throws
+
+Results: 7 passed, 0 failed, 7 total
+```
+
+- [ ] **Step 5: Wire into the `pnpm test` chain and the common barrel**
+
+Current `package.json:79` (excerpt, end of the chain):
+
+```
+... && node tests/notify-fanout.test.cjs && node tests/device-registry-prune.test.cjs && node tests/summary-store.test.cjs",
+```
+
+Replace with:
+
+```
+... && node tests/notify-fanout.test.cjs && node tests/device-registry-prune.test.cjs && node tests/summary-store.test.cjs && node tests/native-bridge.test.cjs",
+```
+
+Current `src/lib/modules/client/common/index.ts` (full file):
+
+```ts
+// Shared client utilities
+export { clearCache, getCached, setCache } from './cache';
+export { getApiKey, isShooterConfig } from './config-guard';
+export { toErrorMessage } from './error';
+export { renderMarkdown } from './markdown';
+export { hasScanner, isNativeBridge, scanQR } from './native-bridge';
+export { startPresenceReporting } from './presence';
+export { AI_COMMANDS, sourceLabel, sourceToCommand } from './provider';
+export { formatRelativeTime } from './time';
+export { getToolDescription } from './tool-title';
+```
+
+Replace the native-bridge export line (natural-alphabetical order, `perfectionist` sorts `haptic` before `hasScanner`):
+
+```ts
+export { haptic, hasScanner, isNativeBridge, scanQR } from './native-bridge';
+```
+
+- [ ] **Step 6: Full regression run + build**
+
+```bash
+pnpm test
+```
+
+Expected: all suites pass, ending with the new one (verified baseline `pnpm test` — 30+ suites — passes clean before this change; the new suite adds 7 more passing tests with no other suite touched).
+
+```bash
+pnpm build
+```
+
+Expected: `vite build` completes with no TypeScript errors (confirms `$lib/types` import resolves inside `native-bridge.ts` and `app.d.ts`'s `haptic` field type-checks).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app.d.ts src/lib/modules/client/common/native-bridge.ts src/lib/modules/client/common/index.ts tests/native-bridge.test.cjs package.json
+git commit -m "feat(haptics): add haptic() web API with native-bridge → vibrate → no-op resolution"
+```
+
+---
+
+### Task 21: Wire haptic() into tab switch and quick-key press
+
+**Files:**
+
+- Modify: `src/routes/+layout.svelte:1-17,126-155`
+- Modify: `src/lib/modules/client/terminal/QuickKeys.svelte:1-29`
+
+**Interfaces:**
+
+- Consumes: `haptic` from `$lib/modules/client/common` (Task 20)
+- Produces: none (leaf call sites)
+
+- [ ] **Step 1: `+layout.svelte` — import haptic and fire it on every bottom-tab tap**
+
+Current `src/routes/+layout.svelte:1-17`:
+
+```svelte
+<script lang="ts">
+  import type { LayoutData } from '$lib/types';
+
+  import '../app.css';
+  import '$lib/theme.css';
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import BellSvg from '$lib/assets/icons/bell.svg?raw';
+  import DashboardSvg from '$lib/assets/icons/dashboard.svg?raw';
+  import SettingsSvg from '$lib/assets/icons/settings.svg?raw';
+  import TerminalSvg from '$lib/assets/icons/terminal.svg?raw';
+  import ToolSvg from '$lib/assets/icons/tool.svg?raw';
+  import { Button, Icon, Pill } from '@juspay/svelte-ui-components';
+  import { onMount, type Snippet } from 'svelte';
+
+  const { children, data }: { children: Snippet; data: LayoutData } = $props();
+```
+
+Replace with (adds the `haptic` import from the common module barrel):
+
+```svelte
+<script lang="ts">
+  import type { LayoutData } from '$lib/types';
+
+  import '../app.css';
+  import '$lib/theme.css';
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import BellSvg from '$lib/assets/icons/bell.svg?raw';
+  import DashboardSvg from '$lib/assets/icons/dashboard.svg?raw';
+  import SettingsSvg from '$lib/assets/icons/settings.svg?raw';
+  import TerminalSvg from '$lib/assets/icons/terminal.svg?raw';
+  import ToolSvg from '$lib/assets/icons/tool.svg?raw';
+  import { haptic } from '$lib/modules/client/common';
+  import { Button, Icon, Pill } from '@juspay/svelte-ui-components';
+  import { onMount, type Snippet } from 'svelte';
+
+  const { children, data }: { children: Snippet; data: LayoutData } = $props();
+```
+
+Current `src/routes/+layout.svelte:123-157` (the bottom tab bar):
+
+```svelte
+  <!-- Bottom tab bar: Dashboard + Activity + Terminals -->
+  <nav class="bottom-tabs">
+    <div class="bottom-tabs-inner">
+      <a
+        href="/"
+        class="tab-item"
+        class:active={$page.url.pathname === '/' ||
+          $page.url.pathname.startsWith('/project') ||
+          $page.url.pathname.startsWith('/session')}
+      >
+        <Icon svg={DashboardSvg} classes="icon-26" />
+        <span>Dashboard</span>
+      </a>
+      <a
+        href="/activity"
+        class="tab-item"
+        class:active={$page.url.pathname.startsWith('/activity')}
+      >
+        <Icon svg={BellSvg} classes="icon-26" />
+        <span>Activity</span>
+      </a>
+      <a
+        href="/terminals"
+        class="tab-item"
+        class:active={$page.url.pathname.startsWith('/terminals')}
+      >
+        <Icon svg={TerminalSvg} classes="icon-26" />
+        <span>Terminals</span>
+      </a>
+      <a href="/sos" class="tab-item" class:active={$page.url.pathname.startsWith('/sos')}>
+        <Icon svg={ToolSvg} classes="icon-26" />
+        <span>SoS</span>
+      </a>
+    </div>
+  </nav>
+</div>
+```
+
+Replace with (each tab anchor gets `onclick={(): void => haptic('light')}` — fires on the tap that starts the navigation, does not prevent the `href` navigation since it's a plain `<a>`):
+
+```svelte
+  <!-- Bottom tab bar: Dashboard + Activity + Terminals -->
+  <nav class="bottom-tabs">
+    <div class="bottom-tabs-inner">
+      <a
+        href="/"
+        class="tab-item"
+        class:active={$page.url.pathname === '/' ||
+          $page.url.pathname.startsWith('/project') ||
+          $page.url.pathname.startsWith('/session')}
+        onclick={(): void => haptic('light')}
+      >
+        <Icon svg={DashboardSvg} classes="icon-26" />
+        <span>Dashboard</span>
+      </a>
+      <a
+        href="/activity"
+        class="tab-item"
+        class:active={$page.url.pathname.startsWith('/activity')}
+        onclick={(): void => haptic('light')}
+      >
+        <Icon svg={BellSvg} classes="icon-26" />
+        <span>Activity</span>
+      </a>
+      <a
+        href="/terminals"
+        class="tab-item"
+        class:active={$page.url.pathname.startsWith('/terminals')}
+        onclick={(): void => haptic('light')}
+      >
+        <Icon svg={TerminalSvg} classes="icon-26" />
+        <span>Terminals</span>
+      </a>
+      <a
+        href="/sos"
+        class="tab-item"
+        class:active={$page.url.pathname.startsWith('/sos')}
+        onclick={(): void => haptic('light')}
+      >
+        <Icon svg={ToolSvg} classes="icon-26" />
+        <span>SoS</span>
+      </a>
+    </div>
+  </nav>
+</div>
+```
+
+- [ ] **Step 2: `QuickKeys.svelte` — fire haptic on every quick-key press**
+
+Current `src/lib/modules/client/terminal/QuickKeys.svelte:1-29`:
+
+```svelte
+<script lang="ts">
+  import type { QuickKey, QuickKeysProps } from '$lib/types';
+
+  import { Button } from '@juspay/svelte-ui-components';
+
+  const { onKey }: QuickKeysProps = $props();
+
+  const keys: QuickKey[] = [
+    { escape: '\x03', label: 'Ctrl+C' },
+    { escape: '\t', label: 'Tab' },
+    { escape: '\x1b[A', label: '↑' },
+    { escape: '\x1b[B', label: '↓' },
+    { escape: '\x1b', label: 'Esc' },
+    { escape: '\x04', label: 'Ctrl+D' },
+    { escape: '\x1a', label: 'Ctrl+Z' },
+  ];
+</script>
+
+<div class="quick-keys" role="toolbar" aria-label="Quick terminal keys">
+  {#each keys as k (k.label)}
+    <Button
+      classes="btn-quick-key"
+      onclick={(): void => {
+        onKey(k.escape);
+      }}
+      text={k.label}
+    />
+  {/each}
+</div>
+```
+
+Replace with:
+
+```svelte
+<script lang="ts">
+  import type { QuickKey, QuickKeysProps } from '$lib/types';
+
+  import { haptic } from '$lib/modules/client/common';
+  import { Button } from '@juspay/svelte-ui-components';
+
+  const { onKey }: QuickKeysProps = $props();
+
+  const keys: QuickKey[] = [
+    { escape: '\x03', label: 'Ctrl+C' },
+    { escape: '\t', label: 'Tab' },
+    { escape: '\x1b[A', label: '↑' },
+    { escape: '\x1b[B', label: '↓' },
+    { escape: '\x1b', label: 'Esc' },
+    { escape: '\x04', label: 'Ctrl+D' },
+    { escape: '\x1a', label: 'Ctrl+Z' },
+  ];
+</script>
+
+<div class="quick-keys" role="toolbar" aria-label="Quick terminal keys">
+  {#each keys as k (k.label)}
+    <Button
+      classes="btn-quick-key"
+      onclick={(): void => {
+        haptic('light');
+        onKey(k.escape);
+      }}
+      text={k.label}
+    />
+  {/each}
+</div>
+```
+
+- [ ] **Step 3: Verify — grep guard, build, screenshot/feature checklist**
+
+```bash
+grep -n "haptic(" src/routes/+layout.svelte src/lib/modules/client/terminal/QuickKeys.svelte
+```
+
+Expected output: 5 matches total — 4 in `+layout.svelte` (one per tab anchor) + 1 in `QuickKeys.svelte`.
+
+```bash
+pnpm build
+```
+
+Expected: clean build (no unresolved import / type errors from the new `haptic` usages).
+
+Manual checklist (desktop browser, since native haptics need a device — see Tasks 4/5 for on-device verification):
+
+1. Open `/` in a desktop browser with devtools console open — click each of the 4 bottom tabs (Dashboard, Activity, Terminals, SoS). Confirm no console errors and navigation still works normally (haptic() is a silent no-op on desktop, per Task 20 Test 6).
+2. Open a terminal at `/terminals/[id]`, tap several quick keys (Ctrl+C, Tab, arrows, Esc). Confirm keys are still sent to the PTY (no regression) and no console errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/routes/+layout.svelte src/lib/modules/client/terminal/QuickKeys.svelte
+git commit -m "feat(haptics): fire haptic() on bottom-tab switch and quick-key press"
+```
+
+---
+
+### Task 22: iOS native haptics — UIImpactFeedbackGenerator / UINotificationFeedbackGenerator / UISelectionFeedbackGenerator
+
+**Files:**
+
+- Modify: `ios/Shooter/Shooter/ContentView.swift:368-471,533-567`
+
+**Interfaces:**
+
+- Consumes: none (native-side implementation of the `window.ShooterBridge.haptic(kind)` contract established in Task 20's `app.d.ts`)
+- Produces: `window.ShooterBridge.haptic(kind: string): void` — resolved first by `haptic()` in `native-bridge.ts` on-device
+
+- [ ] **Step 1: Add `haptic` to the injected JS bridge**
+
+Current `ios/Shooter/Shooter/ContentView.swift:385-395` (inside `bridgeScript()`):
+
+```swift
+        window.ShooterBridge.getConfig = function() { return JSON.stringify(this._config); };
+        window.ShooterBridge.getFcmToken = function() { return this._config.fcmToken || ''; };
+        window.ShooterBridge.getApnsToken = function() { return this._config.apnsToken || ''; };
+        window.ShooterBridge.getDeviceId = function() { return this._config.deviceId || ''; };
+        window.ShooterBridge.getDeviceName = function() { return this._config.deviceName || ''; };
+        window.ShooterBridge.getEnvironment = function() { return this._config.appEnv || ''; };
+        window.ShooterBridge.getPlatform = function() { return 'ios'; };
+        window.ShooterBridge.saveConfig = function(json) {
+            window.webkit.messageHandlers.shooterBridge.postMessage(json);
+        };
+
+        // Generic native callback infrastructure — reusable for scanner, image picker, etc.
+```
+
+Replace with (adds `haptic` as a fire-and-forget synchronous call — no Promise/callback needed):
+
+```swift
+        window.ShooterBridge.getConfig = function() { return JSON.stringify(this._config); };
+        window.ShooterBridge.getFcmToken = function() { return this._config.fcmToken || ''; };
+        window.ShooterBridge.getApnsToken = function() { return this._config.apnsToken || ''; };
+        window.ShooterBridge.getDeviceId = function() { return this._config.deviceId || ''; };
+        window.ShooterBridge.getDeviceName = function() { return this._config.deviceName || ''; };
+        window.ShooterBridge.getEnvironment = function() { return this._config.appEnv || ''; };
+        window.ShooterBridge.getPlatform = function() { return 'ios'; };
+        window.ShooterBridge.saveConfig = function(json) {
+            window.webkit.messageHandlers.shooterBridge.postMessage(json);
+        };
+        window.ShooterBridge.haptic = function(kind) {
+            window.webkit.messageHandlers.shooterHaptic.postMessage(kind || 'light');
+        };
+
+        // Generic native callback infrastructure — reusable for scanner, image picker, etc.
+```
+
+- [ ] **Step 2: Register the new message handler**
+
+Current `ios/Shooter/Shooter/ContentView.swift:465-471`:
+
+```swift
+        // Handle saveConfig calls from JavaScript
+        config.userContentController.add(context.coordinator, name: "shooterBridge")
+        // Handle native feature requests (scanner, future: image picker, etc.)
+        config.userContentController.add(context.coordinator, name: "requestScanner")
+        // Phone-resident agent: durable file persistence + on-device decide step
+        config.userContentController.add(context.coordinator, name: "shooterFiles")
+        config.userContentController.add(context.coordinator, name: "shooterAgentDecide")
+```
+
+Replace with:
+
+```swift
+        // Handle saveConfig calls from JavaScript
+        config.userContentController.add(context.coordinator, name: "shooterBridge")
+        // Handle native feature requests (scanner, future: image picker, etc.)
+        config.userContentController.add(context.coordinator, name: "requestScanner")
+        // Phone-resident agent: durable file persistence + on-device decide step
+        config.userContentController.add(context.coordinator, name: "shooterFiles")
+        config.userContentController.add(context.coordinator, name: "shooterAgentDecide")
+        // Native haptic feedback ticks
+        config.userContentController.add(context.coordinator, name: "shooterHaptic")
+```
+
+- [ ] **Step 3: Dispatch the new message name + implement the handler**
+
+Current `ios/Shooter/Shooter/ContentView.swift:533-567`:
+
+```swift
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            switch message.name {
+            case "shooterBridge":
+                handleSaveConfig(message)
+            case "requestScanner":
+                handleRequestScanner(message)
+            case "shooterFiles":
+                handleFiles(message)
+            case "shooterAgentDecide":
+                handleAgentDecide(message)
+            default:
+                break
+            }
+        }
+
+        // MARK: - saveConfig handler
+
+        private func handleSaveConfig(_ message: WKScriptMessage) {
+            guard let jsonString = message.body as? String,
+                  let data = jsonString.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return }
+
+            if let serverUrl = obj["serverUrl"] as? String {
+                UserDefaults.standard.set(serverUrl, forKey: "serverUrl")
+            }
+            if let apiKey = obj["apiKey"] as? String {
+                KeychainHelper.save(key: "apiKey", value: apiKey)
+            }
+            print("[ShooterBridge] saveConfig: serverUrl=\(obj["serverUrl"] ?? "nil"), apiKey=\((obj["apiKey"] as? String)?.isEmpty == false ? "(set)" : "(empty)")")
+        }
+
+        // MARK: - QR Scanner handler
+```
+
+Replace with (adds the `shooterHaptic` case to the dispatch switch, plus the handler mapping `kind` string → the three feedback-generator types, dispatched on the main thread since `UIFeedbackGenerator` subclasses must be triggered on the main thread):
+
+```swift
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            switch message.name {
+            case "shooterBridge":
+                handleSaveConfig(message)
+            case "requestScanner":
+                handleRequestScanner(message)
+            case "shooterFiles":
+                handleFiles(message)
+            case "shooterAgentDecide":
+                handleAgentDecide(message)
+            case "shooterHaptic":
+                handleHaptic(message)
+            default:
+                break
+            }
+        }
+
+        // MARK: - saveConfig handler
+
+        private func handleSaveConfig(_ message: WKScriptMessage) {
+            guard let jsonString = message.body as? String,
+                  let data = jsonString.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return }
+
+            if let serverUrl = obj["serverUrl"] as? String {
+                UserDefaults.standard.set(serverUrl, forKey: "serverUrl")
+            }
+            if let apiKey = obj["apiKey"] as? String {
+                KeychainHelper.save(key: "apiKey", value: apiKey)
+            }
+            print("[ShooterBridge] saveConfig: serverUrl=\(obj["serverUrl"] ?? "nil"), apiKey=\((obj["apiKey"] as? String)?.isEmpty == false ? "(set)" : "(empty)")")
+        }
+
+        // MARK: - Haptic feedback handler
+
+        /// Maps a web-side HapticKind string to the matching UIKit feedback generator.
+        /// Impact generators for light/medium/heavy taps, notification generator for
+        /// success/warning/error outcomes, selection generator for picker-style changes.
+        private func handleHaptic(_ message: WKScriptMessage) {
+            guard let kind = message.body as? String else { return }
+            DispatchQueue.main.async {
+                switch kind {
+                case "light":
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                case "medium":
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                case "heavy":
+                    UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+                case "success":
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                case "warning":
+                    UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                case "error":
+                    UINotificationFeedbackGenerator().notificationOccurred(.error)
+                case "selection":
+                    UISelectionFeedbackGenerator().selectionChanged()
+                default:
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                }
+            }
+        }
+
+        // MARK: - QR Scanner handler
+```
+
+- [ ] **Step 4: Verify — build + device checklist**
+
+```bash
+cd ios/Shooter && xcodebuild -project Shooter.xcodeproj -scheme Shooter -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build
+```
+
+Expected: `** BUILD SUCCEEDED **` (this exact command was run against the pre-change tree and succeeded — confirms the project/scheme names and build invocation are correct; re-run after the edit to confirm no compile regressions from the new `handleHaptic` code).
+
+```bash
+grep -n "shooterHaptic\|handleHaptic\|window.ShooterBridge.haptic" ios/Shooter/Shooter/ContentView.swift
+```
+
+Expected: 4 matches — the JS assignment, the `userContentController.add(...)` registration, the switch `case`, and the `private func handleHaptic` declaration.
+
+Device/simulator checklist (per Constraint 5 — physical haptics require a real iPhone; the simulator will not buzz but exercises the message-passing path without crashing):
+
+1. Run the app on a physical iPhone (Xcode → Run, device selected). Load the dashboard.
+2. Tap each bottom tab (Dashboard/Activity/Terminals/SoS) — confirm a light physical tick on every tap (fired from Task 21's `haptic('light')` call, resolved here via `window.ShooterBridge.haptic`).
+3. Open a terminal, tap a quick key — confirm the same light tick.
+4. Confirm no crash/console error in Xcode's device console when tapping rapidly (generator objects are allocated per-call, which is the Apple-recommended pattern for infrequent, ad-hoc feedback).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ios/Shooter/Shooter/ContentView.swift
+git commit -m "feat(ios): implement native haptic feedback for window.ShooterBridge.haptic"
+```
+
+---
+
+### Task 23: Android native haptics — Vibrator / VibrationEffect
+
+**Files:**
+
+- Modify: `android/app/src/main/kotlin/com/shooter/android/MainActivity.kt:1-25,327-339`
+- Modify: `android/app/src/main/AndroidManifest.xml:1-6`
+
+**Interfaces:**
+
+- Consumes: none (native-side implementation of the `window.ShooterBridge.haptic(kind)` contract — on Android, `window.ShooterBridge` is the raw `@JavascriptInterface`-annotated Kotlin object added via `webView.addJavascriptInterface(ShooterBridge(), "ShooterBridge")` at `MainActivity.kt:125`, so `haptic` is added directly to it, no JS shim needed)
+- Produces: `window.ShooterBridge.haptic(kind: string): void` — resolved first by `haptic()` in `native-bridge.ts` on-device
+
+- [ ] **Step 1: Declare the VIBRATE permission**
+
+Current `android/app/src/main/AndroidManifest.xml:1-6` (confirmed by reading the file — `VIBRATE` is currently absent):
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.CAMERA" />
+```
+
+Replace with:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.VIBRATE" />
+```
+
+- [ ] **Step 2: Import Vibrator/VibrationEffect**
+
+Current `android/app/src/main/kotlin/com/shooter/android/MainActivity.kt:1-24`:
+
+```kotlin
+package com.shooter.android
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.graphics.Color
+import android.os.Bundle
+import android.util.Log
+import android.view.Menu
+import android.view.MenuItem
+import android.webkit.JavascriptInterface
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.google.android.gms.common.moduleinstall.ModuleInstall
+import com.google.android.gms.common.moduleinstall.ModuleInstallRequest
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
+import org.json.JSONObject
+```
+
+Replace with (adds `Vibrator`/`VibrationEffect`, natural-sorted into the existing `android.os.*` group):
+
+```kotlin
+package com.shooter.android
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.graphics.Color
+import android.os.Bundle
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.util.Log
+import android.view.Menu
+import android.view.MenuItem
+import android.webkit.JavascriptInterface
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.google.android.gms.common.moduleinstall.ModuleInstall
+import com.google.android.gms.common.moduleinstall.ModuleInstallRequest
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
+import org.json.JSONObject
+```
+
+- [ ] **Step 3: Add `haptic()` to the `ShooterBridge` inner class**
+
+Current `android/app/src/main/kotlin/com/shooter/android/MainActivity.kt:327-339` (end of the `ShooterBridge` inner class):
+
+```kotlin
+        @JavascriptInterface
+        fun getFcmToken(): String {
+            val token = AppPreferences(this@MainActivity).fcmToken ?: ""
+            android.util.Log.d(TAG, "ShooterBridge.getFcmToken() → ${token.take(10)}...")
+            return token
+        }
+
+        @JavascriptInterface
+        fun getPlatform(): String {
+            android.util.Log.d(TAG, "ShooterBridge.getPlatform() → android")
+            return "android"
+        }
+    }
+```
+
+Replace with (mirrors the web `VIBRATION_MS` durations from Task 20; runs on the UI thread via `runOnUiThread` — matching the existing `openSettings` bridge method's pattern at `MainActivity.kt:117-122` — since `@JavascriptInterface` methods are invoked on a WebView worker thread, not the UI thread):
+
+```kotlin
+        @JavascriptInterface
+        fun getFcmToken(): String {
+            val token = AppPreferences(this@MainActivity).fcmToken ?: ""
+            android.util.Log.d(TAG, "ShooterBridge.getFcmToken() → ${token.take(10)}...")
+            return token
+        }
+
+        @JavascriptInterface
+        fun getPlatform(): String {
+            android.util.Log.d(TAG, "ShooterBridge.getPlatform() → android")
+            return "android"
+        }
+
+        @JavascriptInterface
+        fun haptic(kind: String) {
+            this@MainActivity.runOnUiThread {
+                val vibrator = this@MainActivity.getSystemService(Vibrator::class.java) ?: return@runOnUiThread
+                if (!vibrator.hasVibrator()) return@runOnUiThread
+                val durationMs = when (kind) {
+                    "light" -> 10L
+                    "medium" -> 20L
+                    "heavy" -> 30L
+                    "success" -> 15L
+                    "warning" -> 25L
+                    "error" -> 40L
+                    "selection" -> 5L
+                    else -> 10L
+                }
+                vibrator.vibrate(VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE))
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Verify — compile + device checklist**
+
+```bash
+cd android && ./gradlew :app:compileDebugKotlin --console=plain
+```
+
+Expected: `BUILD SUCCESSFUL` (this exact command was run against the pre-change tree and succeeded in ~23s — confirms the module/task name; re-run after the edit to confirm the new `Vibrator`/`VibrationEffect` code compiles).
+
+```bash
+grep -n "VIBRATE\|fun haptic" android/app/src/main/AndroidManifest.xml android/app/src/main/kotlin/com/shooter/android/MainActivity.kt
+```
+
+Expected: 2 matches — the manifest permission line and the `fun haptic(kind: String)` declaration.
+
+Device checklist (per Constraint 5 — the emulator can simulate vibration in logs but won't physically buzz; use a real device):
+
+1. Run the app on a physical Android device (`./gradlew installDebug` or Android Studio Run). Load the dashboard.
+2. Tap each bottom tab (Dashboard/Activity/Terminals/SoS) — confirm a light physical buzz on every tap (fired from Task 21's `haptic('light')`, resolved here via `window.ShooterBridge.haptic`, since Android's `window.ShooterBridge` is this same `@JavascriptInterface` object per `MainActivity.kt:125`).
+3. Open a terminal, tap a quick key — confirm the same light buzz.
+4. Toggle system-wide "Vibration & haptics" off in Android Settings and confirm the app respects it (device-level `Vibrator` calls are automatically suppressed by the OS when the user has disabled haptics — no app-side check needed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add android/app/src/main/kotlin/com/shooter/android/MainActivity.kt android/app/src/main/AndroidManifest.xml
+git commit -m "feat(android): implement native haptic feedback via Vibrator/VibrationEffect"
+```
+
+---
+
+## Assumptions & open issues (reconcile during execution)
+
+**Unit E — Library upgrade:**
+
+- package.json currently pins @juspay/svelte-ui-components with a caret range ("^2.18.0"). The spec's Constraint 2 states the target as a bare version string ("2.87.0", not "^2.87.0"), so I pinned it exact (no caret) to lock the base for the rest of the program and make regressions attributable to a deliberate, reproducible bump. If the team prefers to keep caret-range style consistent with the rest of dependencies, change `"2.87.0"` to `"^2.87.0"` in Task 1 Step 1 and rerun `pnpm install`.
+- Verified `pnpm dev` is ALREADY RUNNING on http://localhost:54006 (confirmed via `curl http://localhost:54006/api/health` -> 200/healthy) at task-drafting time, using ~/.shooter-dev as SHOOTER_HOME. The executing agent should confirm it's still up (or start it with `pnpm dev` in a background shell) before the screenshot steps; the tasks assume port 54006 is reachable and do not include falling back to killing/restarting it since it's a shared dev instance.
+- No project-specific `verify` skill or Playwright/Puppeteer script exists in this repo — screenshot capture must go through the `chrome-devtools-mcp` MCP tools (per the global CLAUDE.md's 'Chrome DevTools MCP — debug-Chrome setup' section), pointed at http://localhost:54006 rather than a real device/site. I did not have permission/need to actually drive the MCP browser myself while drafting this unit (read-only exploration only), so the exact DOM selectors for the LaunchSheet/QuickKeys/ShareSheet trigger elements referenced in Task 3's checklist are described by visible text/aria-role, not verified live in a screenshot — the executing agent should adjust selectors via `take_snapshot` if they've drifted.
+- For screens requiring state that may not exist in the dev environment (a running terminal, an existing session, SOS/neurolink data), Task 3's checklist instructs launching one via the LaunchSheet flow (mirroring the existing `test-screenshots/02-launchsheet-open.png` .. `09-claude-terminal.png` naming convention already in the repo) rather than assuming fixture data is present.
+- The repo's `pnpm test` command runs the Node.js `node:test`-based suite (tests/\*.test.cjs) — there is no vitest in this repo despite the general instructions mentioning it; none of these existing tests touch the UI library or theme layer, so Task 2's test run is a non-regression smoke check, not a targeted test for this change.
+
+**Unit A — Central token re-base:**
+
+- DashboardCard.svelte:184 and AutopilotPanel.svelte:380 have per-component `.card:focus-visible { outline: 2px solid var(--ds-blue-700, #0070f3); }` style forks — left untouched in this unit because Unit B (design doc) explicitly owns centralizing press/focus feedback via `--button-focus-visible-box-shadow` and the Card/ListItem/Pill equivalents; flagging so Unit B's grep-guard doesn't miss these two.
+- DashboardCard.svelte:33 (borderColor for 'running' non-active cards) and AutopilotPanel.svelte:533 use --ds-blue-700 as an intentional 'info' status color per the design doc's green=live/blue=info split — confirmed correct, left unchanged, not a bug.
+- ActivityFeed.svelte:252 (.type label color) and neurolink/+page.svelte:228,271,301 (page title, pill, chat-role text) use --ds-blue-700 as decorative/informational text color, not an action/selection surface — left unchanged as out of this unit's literal scope (button/tab/input/selection only); flagging in case product wants these swept into the accent system in a later pass.
+- --button-active-background is a newly-declared CSS variable that only takes effect once Unit E (library upgrade to @juspay/svelte-ui-components 2.87.0) lands and the Button component actually reads that hook — until then it's an inert unused custom property, confirmed harmless but worth the assembler knowing the dependency direction (Unit A can land before or after Unit E without breaking, but the visual effect of --button-active-background is dormant until Unit E ships).
+- The exact line numbers cited for the new app.css :root token block (Step 2 grep expectations in the first task) assume no other unit lands conflicting edits to the same :root block first; if Unit B's radius/text-base bump (also in app.css :root) lands before this unit, line numbers will shift but the property names and values are unaffected.
+
+**UNIT B — Website tells + bolder look:**
+
+- Unit E dependency: `--button-focus-visible-box-shadow` (press/focus task) and any Unit A color mapping onto `--button-active-background` will not visibly render until @juspay/svelte-ui-components is bumped to 2.87.0 — confirmed by reading the installed 2.18.0 Button.svelte, which has `:active { transform: var(--button-active-transform) }` already but no `:focus-visible` rule at all. This unit ships the central var regardless (forward-compatible); the assembler should sequence Unit E before/alongside this unit's press/focus and Unit A's amber-mapping tasks so the screenshot verification of the focus ring isn't a false negative.
+- Unit A dependency (soft): the focus-visible box-shadow references `var(--accent, #f5b14c)` with an inline fallback matching the spec's committed amber value, so this unit's press/focus task is independently mergeable regardless of whether Unit A has landed `--accent` in app.css yet. Once Unit A lands, the fallback becomes redundant but harmless.
+- DashboardCard.svelte (`src/lib/modules/client/dashboard/DashboardCard.svelte:146-172`) has its own scoped `.card` style block (background/border/border-left/border-radius) that wins over the central `app.css` `.card` rule for those specific properties (Svelte scoping raises selector specificity). The new central box-shadow still shows through (DashboardCard's scoped block never sets box-shadow), so the elevation task's shadow lands everywhere, but the background gradient specifically will only visually apply to plain (non-DashboardCard) `.card` usages and the library `Card` component (which reads `--card-background` via `var()`, not hardcoded). A true single-source elevation for DashboardCard would require editing that component's scoped `<style>` block, which is out of this CENTRAL-ONLY unit's mandate (owner constraint 1) — flagging for a follow-up slice or an explicit owner call to relax the constraint for this one dead-code-adjacent spot.
+- `.list`/`.list-item` (elevation task) and the library `ListItem` component (press/focus task's 'Card/ListItem/Pill equivalents') are confirmed dead/unused in the current codebase — verified via repo-wide grep, zero `<ListItem>` or `class="list-item"` usages in any .svelte template (only the unrelated TS type names `DeviceListItem`/`TerminalListItem` share the substring). Their CSS/theme vars were still updated for consistency/future-readiness per the spec's explicit instruction, but there is nothing to screenshot-verify for them today.
+- Task ordering within this unit: the 'bolder tokens' task and the 'card elevation' task both touch theme.css but in disjoint line ranges (Button/Input/Select radius mirror vs. new Card section) — safe to land in either order. The 'press/focus' task's theme.css insertion (end of Button section) and the 'bolder tokens' task's edit to `--button-border-radius` (start of Button section) are also disjoint lines in the same block — verified no textual overlap.
+- iOS Swift change (`config.dataDetectorTypes = []`) could not be compiled/verified in this sandboxed environment (no Xcode toolchain invoked) — verification is code-review-level only; recommend an actual `xcodebuild` or Xcode-preview pass before merging if a maintainer has the toolchain available.
+- The `Icon`-swap task removes six literal glyph-arrow occurrences across 4 route files (not just the 2 dead classes named in the original spec bullet) — flagging the scope expansion explicitly since `.session-chevron`/`.session-back-btn` turned out to be 100% dead CSS with no template usage (confirmed via `git log -p --follow -- src/app.css`), while the actual live 'glyph chevron' tells were the `.back-link` `← Back` / `&larr;` / `&#8592;` instances the spec didn't name by class.
+
+**Unit C — Motion primitives:**
+
+- Did not execute any of the edits myself (Write/Edit/Bash) — this is a planning/drafting handoff; the assembler or a follow-up agent must actually apply the diffs and run the verification commands.
+- The View-Transitions ::view-transition-old(root)/::view-transition-new(root) rule targets the default unnamed root transition group (no per-element view-transition-name assignment) — this is the simplest central rule per the spec's 'default ::view-transition slide/cross-fade' wording; if a later slice wants per-route or per-element named transitions, that CSS will need view-transition-name assignments on specific elements, which is out of scope here.
+- package.json's pnpm test script runs the FULL existing chain (30+ node test files, including ones that spin up better-sqlite3/node-pty); running it after appending motion.test.cjs will take noticeably longer than the isolated node tests/motion.test.cjs check — flagged as optional/final in Task A rather than mandatory per-step.
+- Did not verify in a live browser that Svelte 5's animate: directive compiles cleanly on a <div> wrapping a component (only confirmed via reading the Svelte compiler source that AnimateDirective is only wired for RegularElement, not Component) — Task B's Step 4 pnpm build check is the first real compiler verification of this.
+- Assumed DashboardCardComponent's rendered root element has no CSS that depends on being a direct flex child with specific margin auto-collapsing behavior; the wrapper <div> should be layout-transparent but this is asserted from reading DashboardView.svelte's <style> block only, not from rendering DashboardCard.svelte's own <style> block (not fully read).
+
+**Unit D — Haptics full vertical:**
+
+- Native (iOS/Android) haptic verification steps require a physical device — I could not execute those device checklists in this environment; I did verify both native projects build cleanly at baseline (xcodebuild BUILD SUCCEEDED, ./gradlew :app:compileDebugKotlin BUILD SUCCESSFUL) and validated the exact haptic() resolution logic + the Object.defineProperty(navigator) test trick against a scratch harness using tsx/cjs (matches the actual native-bridge.ts implementation), but did not apply any of these edits to the actual repo files — this is a task draft only, per the assignment ('Draft tasks... Read the real files first, then draft the task section(s)'), so all repo files are unmodified and the task list is ready for an executor agent.
+- Chose kind='light' for both tab-switch and quick-key taps; the design spec explicitly says 'light' for tab-item (line 115 of the design doc) but doesn't specify a kind for quick-key press beyond 'called on quick-key press' — light was chosen for consistency with frequent, low-weight taps; flag if the assembler wants a different kind (e.g. 'selection') for quick keys.
+- app.d.ts's ShooterBridge.haptic field is typed as plain `string` rather than the new `HapticKind` (to match every other field in that ambient/ignored-from-type-governance file and avoid coupling the global ambient declaration to the app's central type barrel) — HapticKind values are assignable into it at every call site, so this is purely a style choice or the assembler may prefer to import HapticKind there instead for tighter typing.
+- Did not touch primary-button haptic (mentioned in the full design spec's Unit D but not in this UNIT D assignment's explicit call-site list, which only names bottom-tab switch and quick-key press) — left out of scope per the assignment text; flag if primary-button press should also be wired in this slice.
+- The pnpm test chain edit (package.json:79) inserts the new test file at the very end of the existing chain; did not reorder alphabetically since the existing chain is not alphabetically sorted (it appears roughly chronological by feature), matching existing convention.

--- a/docs/superpowers/specs/2026-07-08-native-feel-foundation-design.md
+++ b/docs/superpowers/specs/2026-07-08-native-feel-foundation-design.md
@@ -1,0 +1,181 @@
+# Native-Feel Foundation — Design Spec (Slice 1)
+
+**Date:** 2026-07-08
+**Status:** Approved (with owner amendments — see Constraints)
+**Branch:** `feat/native-feel-foundation`
+**Program:** "Make Shooter feel native" — Slice 1 of 6
+
+---
+
+## Why this exists
+
+Shooter is a phone-first companion for Claude Code (buzz → glance → one-tap decide; drive Claude from your thumb), but the UI is **Vercel's Geist desktop-dashboard design system with a mobile breakpoint bolted on** — the stylesheet header at `src/app.css:1` literally reads `/* Geist Design System - Dark Mode */`. An 8-agent audit of the live codebase found the single generative decision ("make the dashboard responsive" instead of "build a phone app") recurs at six layers: visual tokens, navigation chrome, touch feedback, input handling, motion, and notification delivery. The result reads as "a website in a browser," not "an app you want to open."
+
+**Design lineage (visual decisions already made with the owner):**
+
+- Diagnosis + directions brief: `https://claude.ai/code/artifact/180b4b8b-1c80-4a02-9881-43ea08e9906a` — local: `/private/tmp/claude-501/-Users-sachinsharma-Developer-Personal-shooter/6a21287b-35f5-4e73-a397-050fa8d62f26/scratchpad/shooter-native-brief.html`
+- Accent picker: `https://claude.ai/code/artifact/bfd73562-9200-4287-a68e-d157722d05a6` — local: `/private/tmp/claude-501/-Users-sachinsharma-Developer-Personal-shooter/6a21287b-35f5-4e73-a397-050fa8d62f26/scratchpad/shooter-accent-picker.html`
+
+**Locked decisions:**
+
+| Decision          | Choice                                                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Overall direction | **Native shell + terminal soul** — iOS-native chrome for list/settings/nav screens, full-bleed Terminal-First treatment for session screens |
+| Distribution      | **PWA/Safari stays first-class** → real Web Push is in scope (later slice)                                                                  |
+| Accent            | **Amber Phosphor `#F5B14C`** — warm retro-terminal identity, distinct from the AI-default palette, separated from the "live" status green   |
+
+## Constraints (owner-mandated for this slice)
+
+1. **Centralize the look.** All visual/identity changes (amber accent, type scale, radius, elevation, press/focus feedback) are delivered through the **central theme layer** — `src/lib/theme.css` (the `@juspay/svelte-ui-components` CSS-variable mappings) plus the `:root` token block and global classes in `src/app.css`. **No per-component `.svelte` style forks for theming** — components only _reference_ central tokens (e.g. `--accent`); they never hardcode a look. (Functional, non-look fixes — `format-detection` meta, safe-area, native haptics — land in their natural homes.)
+2. **Upgrade the component library.** `@juspay/svelte-ui-components` `^2.18.0` → **`2.87.0`** (latest). This is a prerequisite: the newer version exposes the central theming hooks we need — `--button-active-transform`, `--button-active-background`, `--button-hover-transform`, `--button-focus-visible-box-shadow` (press/hover/focus effects "without `:global()`") — so press-states and focus rings can be centralized instead of scattered.
+3. **Bolder look** (owner chose the bolder option): commit to **16px base text**, the larger radii, and a single committed card treatment — but achieved centrally per constraint 1.
+4. **Native haptics in this slice** (not deferred): ship the iOS (`UIImpactFeedbackGenerator`/`UINotificationFeedbackGenerator`) and Android (`Vibrator`/`HapticFeedbackConstants`) implementations so taps physically buzz on device now.
+5. **Screenshot verification + test every feature.** Verification is not optional: capture before/after screenshots of every screen and exercise all features (especially post-upgrade regression) before the slice is considered done.
+
+## The program (context — not all in this slice)
+
+| #     | Slice                                                                                                            | Effort | Depends on |
+| ----- | ---------------------------------------------------------------------------------------------------------------- | ------ | ---------- |
+| **1** | **Foundation** (this spec)                                                                                       | S–M    | —          |
+| 2     | Native nav shell (`Toolbar`-based per-screen nav bar, grouped inset lists, thumb-zone actions, page transitions) | L      | 1          |
+| 3     | Terminal core loop (live keystroke streaming, immersive session, accessory key-row + Clips, keyboard-avoidance)  | L      | 1          |
+| 4     | Motion & haptics depth (sliding tab indicator, swipe-to-delete, skeletons, connection-state animation)           | M      | 1          |
+| 5     | Onboarding + Web Push (service worker + Web Push, QR fix, rehearse-permission, grouped Settings via `Toggle`)    | L      | 1          |
+| 6     | Ambient status (Live Activity / Dynamic Island, widget, real lock-screen labels)                                 | L      | 5          |
+
+Each slice is its own spec → plan → PR. This document specs **Slice 1 only** and establishes the token, motion, and haptic primitives every later slice builds on.
+
+---
+
+## Slice 1 — Goal
+
+Ship the cheapest, highest-leverage changes that (a) stop the app looking like a website and (b) lay the amber token, motion, and haptic foundation — all through the central theme layer, on the upgraded library. Cross-app hygiene only: **no navigation-architecture rebuild** (Slice 2) and **no terminal input rework** (Slice 3). After this slice the app should already feel meaningfully "less webby" on a phone.
+
+**In scope:** library upgrade; central token re-base (amber accent + accent/status split); the "website tells" fixes; centralized press/focus feedback; motion primitives (list FLIP + page-transition helper); native + web haptics.
+
+**Explicitly out of scope (deferred):** per-screen nav bars & grouped inset lists (Slice 2); the terminal symbol key-row, live keystroke streaming, immersive full-bleed session (Slice 3); Web Push / service worker (Slice 5); swipe-to-delete, sliding tab indicator, skeleton redesign (Slice 4). Named here so the boundary is unambiguous.
+
+---
+
+## Design
+
+### Unit E — Library upgrade (prerequisite, do first)
+
+**Change.** Bump `@juspay/svelte-ui-components` `^2.18.0` → `2.87.0` in `package.json`; update the lockfile with the repo's package manager (`pnpm`). This unlocks the central press/focus theming hooks (Constraint 2) and newer components used by later slices (`Toolbar`, `Toggle`).
+
+**Risk.** 69 minor versions — same major (2.x), so no intended breaking changes, but prop/DOM/default drift is possible across the ~15 components in use (`Button`, `Pill`, `Input`, `Card`, `ListItem`, `Icon`, `Sheet`, `Modal`, `Toast`, `EmptyState`, `Choicebox`, `Shimmer`, `Tabs`, `Menu`, `Select`).
+
+**Verification (mandatory, per Constraint 5).** After upgrade: `pnpm build` clean; then screenshot + exercise **every** screen that renders a library component — `/` (Dashboard), `/activity`, `/terminals`, `/terminals/[id]` (raw + chat tabs, quick keys, launch sheet, share sheet), `/project`, `/session/[id]`, `/config`, `/sos`, `/neurolink`. Diff against pre-upgrade screenshots; fix any visual/behavioral regressions before proceeding to the theme work.
+
+### Unit A — Token re-base (amber accent, split from status) — central only
+
+**Problem.** One hue does triple duty. `--ds-green-700` is used both as **status** (live/success) and as **accent** (active tab `+layout.svelte:234`, focus ring `+layout.svelte:179`); the de-facto **primary-action** color is Vercel blue `--ds-blue-700 #0070f3` (`theme.css:16` `--button-color`, `:37` `--input-focus-border`, `:110` `--tabs-indicator-color`, `:189–198` choicebox-selected). Nothing reads as _this app's_ color.
+
+**Change — central token layer (`src/app.css` `:root`).** Add the amber accent + explicit status tokens (primitives untouched):
+
+```css
+/* Brand accent — Amber Phosphor. The ONLY hue for actions/active/selected/focus. */
+--ds-amber-accent: #f5b14c;
+--ds-amber-accent-hover: #ffc266;
+--ds-amber-accent-fg: #0c0d0b; /* text/icon on an amber fill */
+--ds-amber-accent-dim: rgba(245, 177, 76, 0.14);
+--ds-amber-accent-line: rgba(245, 177, 76, 0.32);
+--accent: var(--ds-amber-accent);
+--accent-hover: var(--ds-amber-accent-hover);
+--accent-fg: var(--ds-amber-accent-fg);
+--accent-dim: var(--ds-amber-accent-dim);
+--accent-line: var(--ds-amber-accent-line);
+/* Status — semantic and separate. */
+--status-live: var(--ds-green-700);
+--status-success: var(--ds-green-700);
+--status-info: var(--ds-blue-700);
+--status-danger: var(--ds-red-700);
+```
+
+**Change — central theme mappings (`src/lib/theme.css`).** Point the library's action/active/selected/focus variables at `--accent`:
+
+| Library variable (theme.css)                                                                                   | New value                                |
+| -------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `--button-color`, `--button-hover-color`, `--button-active-background`                                         | `--accent` / `--accent-hover`            |
+| `--button-text-color` (on filled primary)                                                                      | `--accent-fg`                            |
+| `--input-focus-border`                                                                                         | `1px solid var(--accent)`                |
+| `--tabs-indicator-color`                                                                                       | `--accent`                               |
+| `--choicebox-selected-border-color`, `--choicebox-selected-background`, `--choicebox-indicator-selected-color` | `--accent` / `--accent-dim` / `--accent` |
+
+**Change — token references in the two app-shell/CTA spots** (reference the central token, do not hardcode a look): `+layout.svelte` `.tab-item.active` color and focus outline → `var(--accent)`; `LaunchSheet.svelte` launch-button `--button-color`/`--button-hover-color` → `var(--accent)`/`var(--accent-hover)`.
+
+**Leave green/blue as status** (unchanged): `ConnectionStatus.svelte:43,62`, `ActivityFeed.svelte:176,195,266`, `AutopilotPanel.svelte:338,359,360`, live pills/dots (`DashboardCard.svelte:224–227,338`, `session/[id]:675`), success/info toasts & banners.
+
+**Verify.** Every primary button, active tab, focused field, and selected choice renders amber; every live/connected/success signal stays green; blue only means info. Grep guard: no button/tab/input/selection color still resolves to `--ds-blue-700`.
+
+### Unit B — Website tells (hygiene + bolder look)
+
+1. **Fake blue path links.** Add to `src/app.html` `<head>`: `<meta name="format-detection" content="telephone=no, date=no, address=no, email=no" />`. If the iOS `WKWebView` is configured in `ios/`, also set `dataDetectorTypes = []`. _Verify:_ paths on `/` and `/project` are plain text.
+2. **Header under the notch.** `src/app.css:155` `.header`: add `padding-top: env(safe-area-inset-top, 0px)` and grow height to `calc(var(--header-height) + env(safe-area-inset-top, 0px))`. Mirrors the bottom-inset pattern already at `app.css:1833`, `+layout.svelte:191,200`. _Verify:_ header clears the status bar in the home-screen PWA.
+3. **Dead taps → press feedback (central).** For **library** tappables, set the central press/focus vars in `theme.css`: `--button-active-transform: scale(0.97)`, `--button-focus-visible-box-shadow: 0 0 0 2px var(--accent)`, plus the `Card`/`ListItem`/`Pill` equivalents where `onclick` is set. For the two **custom** app-shell surfaces (`.session-card`, `.tab-item`, `.terminal-card`), add a single central rule in `app.css`: `@media (hover: none) { .session-card:active, .terminal-card:active, .tab-item:active { transform: scale(0.978); transition: transform 60ms ease; } }`. Pair the tab-item press with a light haptic (Unit D). _Verify:_ every tappable depresses instantly on touch.
+4. **One elevation language.** Collapse the flat `.card`/`.list-item` vs. gradient+shadow `.session-card` split (`app.css:686–703`) into one committed treatment (gradient bg + `box-shadow: 0 1px 3px rgba(0,0,0,.3), inset 0 0 0 1px rgba(255,255,255,.03)`), applied via the shared central card classes + the library `Card` `--card-*` vars. _Verify:_ all card surfaces share one depth.
+5. **Desktop scrollbar on touch.** `app.css:663–680` `::-webkit-scrollbar`: `@media (hover: none) { ::-webkit-scrollbar { width: 0; height: 0; } }`. _Verify:_ no persistent track on device.
+6. **Glyph chevrons → SVG.** Replace text-arrow `.session-chevron` / `.session-back-btn` with the existing `Icon` component for consistent stroke weight. _Verify:_ chevrons match nav icons.
+7. **Bolder shape + type (central tokens).** In `app.css` `:root`: `--radius-lg` 8→**14px**, `--radius-xl` 12→**18px**; `--text-base` 14→**16px**; page-title tracking `--tracking-tighter`→`--tracking-tight`. Because the library reads sizing/radius via its own vars, mirror the radius bump into `theme.css` (`--button-border-radius`, `--card-*-radius`, input/pill radii) so the whole system moves together. _Verify (per Constraint 5):_ screenshot every screen at 16px base — confirm no clipped/overflowing text or broken dense rows (esp. `/config`, terminal topbar, quick keys); tune the specific offending row centrally if any.
+
+### Unit C — Motion primitives
+
+1. **List FLIP.** Add `animate:flip` (`svelte/animate`) to `DashboardView.svelte:25,39` `{#each}` blocks (keyed by `card.terminalId`, already stable). Reduced-motion-guarded.
+2. **Page-transition helper.** `onNavigate` hook in `+layout.svelte` wrapping navigation in `document.startViewTransition()` when supported (progressive enhancement); default `::view-transition` slide/cross-fade in `app.css`, gated by `@media (prefers-reduced-motion: no-preference)`.
+
+_Verify:_ dashboard reorders glide; route changes slide/cross-fade where supported; both inert under reduced-motion.
+
+### Unit D — Haptics (web API + native impl, this slice)
+
+**Web (`native-bridge.ts`).**
+
+```ts
+export type HapticKind =
+  | 'light'
+  | 'medium'
+  | 'heavy'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'selection';
+/** Fire a haptic tick. Native bridge → navigator.vibrate → no-op. Never throws. */
+export function haptic(kind: HapticKind = 'light'): void;
+```
+
+Resolution order: `window.ShooterBridge.haptic(kind)` → `window.ShooterNativeBridge.haptic(kind)` → `navigator.vibrate(map[kind])` → no-op. SSR/desktop-safe. Called on: bottom-tab switch (`+layout.svelte`), quick-key press (`QuickKeys.svelte`), primary-button press. `HapticKind` added to `src/lib/types` (union → hand-written, re-exported from barrel).
+
+**Native (this slice, per Constraint 4).** iOS: add `haptic(kind)` to the injected `ShooterBridge` and back it with `UIImpactFeedbackGenerator`/`UINotificationFeedbackGenerator` in `ios/…/ContentView.swift`'s Coordinator (mapping `light/medium/heavy`→impact styles, `success/warning/error`→notification types, `selection`→`UISelectionFeedbackGenerator`). Android: expose `ShooterNativeBridge.haptic(kind)` (`@JavascriptInterface`) backed by `Vibrator`/`VibrationEffect` (respect `HapticFeedbackConstants`).
+
+_Verify:_ `haptic()` is a silent no-op on desktop (no error); on a native iOS/Android build, a tab switch produces a physical tick.
+
+---
+
+## Testing & verification strategy (mandatory)
+
+Per Constraint 5, this slice is done only when all of the following pass:
+
+- **Screenshot regression (every screen).** Capture before/after for `/`, `/activity`, `/terminals`, `/terminals/[id]` (raw + chat + quick keys + launch/share sheets), `/project`, `/session/[id]`, `/config`, `/sos`, `/neurolink` — first for the library upgrade (Unit E), then again after the theme work. Compare and resolve regressions.
+- **Feature exercise.** Manually drive each feature end-to-end: launch/attach/kill a terminal, quick keys, send input, view a session, change + save config, generate QR, dashboard cards, activity feed. Nothing regresses from the upgrade or re-theme.
+- **Unit tests.** `haptic()` resolution order + no-op safety (mock `ShooterBridge` / `navigator.vibrate` / neither). Token guard: assert no button/tab/input/selection color resolves to `--ds-blue-700`.
+- **Reduced-motion.** With `prefers-reduced-motion: reduce`, FLIP and view-transitions are inert.
+- **Build.** `pnpm build` clean.
+
+## Risks & mitigations
+
+- **Library upgrade drift (2.18→2.87).** Mitigate: upgrade first (Unit E), full screenshot + feature pass before any theme change, so regressions are attributable to the upgrade, not the re-theme.
+- **16px base overflow in dense desktop rows.** Mitigate: the change is central; verify by screenshot; tune specific rows via central tokens, don't revert globally.
+- **Elevation unification regressing a screen.** Mitigate: apply via shared central classes + library `Card` vars; spot-check every list screen.
+- **View transitions vary by browser.** Progressive enhancement (feature-detected) — unsupported browsers keep today's instant swap, no regression.
+
+## Non-goals (this slice)
+
+Nav-bar architecture, grouped inset lists, pull-to-refresh, FAB, swipe-to-delete, terminal symbol row, keystroke streaming, immersive session, Web Push, Live Activity. Later slices, own specs.
+
+## Definition of done
+
+- `@juspay/svelte-ui-components` at `2.87.0`; upgrade regression-verified by screenshots + feature pass.
+- Amber `--accent` layer added centrally; all action/active/selected/focus consumers rewired via `theme.css` + central tokens; green = status only, blue = info only; **no per-component theming forks**.
+- The seven website-tell fixes (incl. 16px base + larger radii, delivered centrally) land and verify on a phone (PWA + Safari).
+- `animate:flip` + `startViewTransition` helper in place, reduced-motion-safe.
+- `haptic()` web API + `HapticKind` type shipped and called on existing tap points; **native iOS + Android haptics implemented** and verified on device.
+- Full screenshot + feature verification complete; `pnpm build` clean; design doc committed on `feat/native-feel-foundation`.

--- a/docs/superpowers/specs/2026-07-08-native-nav-shell-design.md
+++ b/docs/superpowers/specs/2026-07-08-native-nav-shell-design.md
@@ -1,0 +1,110 @@
+# Native Nav Shell — Design Spec (Slice 2)
+
+**Date:** 2026-07-08
+**Status:** Proposed (for review)
+**Branch:** `feat/native-nav-shell` (stacked on `feat/native-feel-foundation`)
+**Program:** "Make Shooter feel native" — Slice 2 of 6
+
+---
+
+## Why this exists
+
+Slice 1 (Foundation) gave the app its amber identity, safe-area/press/motion hygiene, and haptics — all delivered centrally. But the **navigation is still a desktop admin-dashboard IA wearing a bottom tab bar as a costume** (audit, `navigation-ia`, severity: critical):
+
+- **Two stacked headers.** Every screen shows the global brand header (`+layout.svelte` — logo + ONLINE pill + gear), and drill-in screens add a _second_ full-width header (`.page-header` on `/`, `/terminals`, `/config`; `.term-topbar` on the terminal page). ~100–128px of fixed chrome, on a phone, with no navigational payoff.
+- **Actions live in the thumb-dead zone.** `Refresh` and `New Terminal` are top-right `Button`s (`+page.svelte:167`, `terminals/+page.svelte:256,262`) — the hardest place to reach one-handed.
+- **Back is a scrolling link, not a nav affordance.** Slice 1 gave the back-links proper SVG icons, but they still live _inside the scroll container_ and scroll away.
+- **No pull-to-refresh; `Load More` buttons for pagination** (`+page.svelte:268`, `project/+page.svelte:332`) — website patterns, not app patterns.
+- **Two tabs both claim "now."** Dashboard and Activity both frame themselves as the real-time surface; nothing answers "what should I look at right now?"
+
+This slice replaces that with a **per-screen native nav bar**, thumb-zone actions, and pull-to-refresh — building on Slice 1's tokens and the library's `Toolbar` component.
+
+**Program context:** Slice 1 spec `docs/superpowers/specs/2026-07-08-native-feel-foundation-design.md` · plan `docs/superpowers/plans/2026-07-08-native-feel-foundation.md`.
+
+## Constraints (inherited + slice-specific)
+
+1. **Central theming still applies** to the _look_ (Slice 1 rule): the `Toolbar` and grouped-list styling are themed via the central theme layer (`theme.css` `--toolbar-*` / list vars + `app.css` global classes), not per-component forks. Structural/behavioral code (the nav config, pull-to-refresh handler, FAB) lives where it must.
+2. **Reuse the library.** Build the nav bar on `@juspay/svelte-ui-components` `Toolbar` (2.87.0) rather than hand-rolling — it already provides back button + title + right-content + a second `additionalContent` row. Theme its defaults (`position:fixed; width:100vw; background:#fff`) to the dark, in-flow, safe-area-aware shell.
+3. **Amber = action, green = status** (Slice 1): nav back-chevron, active states, and the FAB use `--accent`; live/connection stays green.
+4. **PWA + native both first-class**; reduced-motion-safe; **screenshot verification + exercise every feature** before done (owner mandate).
+
+## Scope
+
+**In:** the per-screen nav-bar architecture, collapsing the double header (incl. the terminal page), thumb-zone actions (FAB + pull-to-refresh), grouped inset lists for Settings, and resolving the Dashboard/Activity "now" overlap.
+
+**Explicitly out (later slices):** terminal keystroke streaming / immersive session / accessory key-row (Slice 3 — this slice only _reduces_ the terminal page's chrome, it does not touch input); Web Push / onboarding (Slice 5); swipe-to-delete, sliding tab indicator (Slice 4); Live Activity (Slice 6). The terminal page's `.term-back` `&larr;` glyph (left from Slice 1) is folded into this slice's nav-bar rebuild.
+
+---
+
+## Design
+
+### Unit A — Per-screen nav-bar system (the core)
+
+**Problem.** The global `.header` in `+layout.svelte` renders identically on every route; drill-in screens stack a second header on top.
+
+**Change.** Introduce a **navigation config** the layout reads to render exactly one contextual nav bar per screen:
+
+- A tiny `nav-store` (Svelte context or a `$state` store in `$lib/modules/client/common`) exposing `setNav({ title, showBack, backHref, trailing })`. Each `+page.svelte` calls it (in an `$effect`/`onMount`) to declare its bar; the layout renders one `<Toolbar>` from it.
+- **Root screens** (Dashboard, Activity, Terminals, SoS): brand/large title on the left, status pill + trailing action(s) on the right — no back button. Keep the amber-tab bottom nav for switching between them.
+- **Drill-in screens** (Project, Session, Terminal detail, Config): a persistent, non-scrolling bar with a **leading amber back-chevron + title**, and an optional trailing action (e.g. the Config gear becomes "Done"/save-less; the terminal page's Kill/Share move into a trailing overflow `Menu`).
+- The bar is **themed dark + safe-area-aware** centrally: `--toolbar-background: var(--background)`, `--toolbar-box-shadow: none` + a hairline bottom border, `--toolbar-position: sticky`, height + `padding-top: env(safe-area-inset-top)` folded in (reuse Slice 1's header safe-area pattern). Back icon uses the Slice 1 `arrow-left.svg` in `--accent`.
+
+**Outcome.** One bar per screen, back always visible, brand no longer repeated on drill-in screens — reclaims ~50–80px on every drill-in screen and kills the scroll-away back-link.
+
+**Files (primary):** `src/routes/+layout.svelte` (render one nav bar from config), a new `nav-store` in `src/lib/modules/client/common/`, `theme.css` (`--toolbar-*`), and each `+page.svelte` (declare its nav config; remove its local `.page-header`/`.term-topbar`/back-link). Remove the now-dead `.page-header` / `.term-topbar` / `.term-back` CSS.
+
+### Unit B — Thumb-zone actions (FAB + pull-to-refresh)
+
+**Problem.** `Refresh` and `New Terminal` sit top-right (thumb-dead); refresh is a manual tap; pagination is a `Load More` button.
+
+**Change.**
+
+- **Pull-to-refresh primitive** — a small reusable `usePullToRefresh` action (or a `PullToRefresh.svelte` wrapper) with a `touchstart/touchmove/touchend` rubber-band + threshold spinner, wired to the existing `forceRefresh()` on `/`, `/terminals`, `/project`. Fires a `haptic('light')` (Slice 1) on trigger; reduced-motion-aware via `resolveMotionDuration` (Slice 1). Replaces the top-right `Refresh` buttons.
+- **FAB for "New Terminal"** — a floating amber circular button pinned bottom-right, just above the tab bar + safe-area, on `/terminals` (replaces the top-right `New Terminal` button; opens the existing `LaunchSheet`).
+- **Infinite scroll** — replace the `Load More` buttons (`+page.svelte:268`, `project/+page.svelte:332`) with an `IntersectionObserver` sentinel that grows `visibleCount` on scroll.
+
+**Files:** a `pull-to-refresh` module in `src/lib/modules/client/common/`, a `Fab.svelte` (central-themed), edits to `/`, `/terminals`, `/project`.
+
+### Unit C — Grouped inset lists (Settings + list surfaces)
+
+**Problem.** Settings is a two-column web form (Slice 1 softened the cards but the structure is still form-like); lists render as separate bordered cards.
+
+**Change.** Introduce a central **grouped-inset-list** treatment (single rounded block per section, hairline row dividers, section header above — the iOS Settings idiom) applied to `/config`'s sections and the registered-devices list. Single-column on phone. Delivered via central classes in `app.css` + the library `ListItem`/`Card` vars. (Native toggles / commit-on-change are Slice 5's Settings work — this slice only restructures layout, not the save model.)
+
+**Files:** `app.css` (grouped-list classes), `config/+page.svelte` (apply structure), `theme.css` (`--list-*` if needed).
+
+### Unit D — Resolve the Dashboard / Activity "now" overlap (IA)
+
+**Problem.** Two tabs both claim the live/now surface.
+
+**Change.** Make **Dashboard the single canonical "now"** (live/running work, strong visual weight) and **demote Activity to a badged bell** in the nav bar (notification-style history) rather than a full tab slot — freeing the 4th tab. Move the historical Projects/Sessions archive under a clear "History" divider beneath the live section on Dashboard, or its own tab. (Final tab lineup to be confirmed in the plan; the principle: each tab has one unambiguous job.)
+
+**Files:** `+layout.svelte` (tab lineup), `+page.svelte` / `activity/+page.svelte` (framing), `DashboardView.svelte`.
+
+---
+
+## Testing & verification (mandatory, per owner mandate)
+
+- **Screenshot regression** across every screen at phone size (390×844) — before/after — confirming: one nav bar per screen (no double header), back-chevron persistent (doesn't scroll away), FAB reachable in the thumb zone, grouped Settings, safe-area respected.
+- **Feature exercise:** pull-to-refresh triggers a real reload + haptic; FAB opens LaunchSheet; back navigation works from every drill-in screen; infinite scroll loads more; every existing flow still works.
+- **Reduced-motion:** pull-to-refresh + any nav animation inert.
+- **Gates:** `pnpm check` 0 errors, `pnpm build` clean, full `pnpm test` green.
+
+## Risks & mitigations
+
+- **`Toolbar` defaults (`fixed`, `100vw`, white)** fight the current flex-column shell. Mitigate: theme to `position: sticky` + `--background` + hairline; integrate as the top row of `.app`, verify no overlap with content or the notch.
+- **Nav-config store adds indirection.** Mitigate: keep it a tiny typed store; each page sets it declaratively; SSR-safe default.
+- **Removing per-page headers touches many files.** Mitigate: do it screen-by-screen with a screenshot after each; keep the bottom tab bar untouched.
+- **Pull-to-refresh vs. native scroll/overscroll.** Mitigate: only engage when the scroll container is at `scrollTop === 0`; `touch-action` guard; test on device + desktop (no-op with a mouse).
+
+## Non-goals (this slice)
+
+Terminal input/keystroke streaming, accessory key-row, immersive full-bleed session (Slice 3); Web Push, QR, native toggles/commit-on-change Settings (Slice 5); swipe-to-delete, sliding tab indicator (Slice 4); Live Activity (Slice 6).
+
+## Definition of done
+
+- One themed, safe-area-aware nav bar per screen (built on `Toolbar`); the double header is gone everywhere including the terminal page; back is persistent, not scroll-away.
+- Primary actions in the thumb zone: pull-to-refresh replaces the top `Refresh` buttons (with haptic); a FAB opens the LaunchSheet; `Load More` replaced by infinite scroll.
+- Settings + device list render as grouped inset lists.
+- Dashboard is the single "now" surface; Activity demoted to a badged affordance.
+- All look changes delivered centrally; screenshot + feature verification complete; `check`/`build`/`test` green; committed on `feat/native-nav-shell`.

--- a/docs/superpowers/specs/2026-07-11-keyboard-aware-terminal-design.md
+++ b/docs/superpowers/specs/2026-07-11-keyboard-aware-terminal-design.md
@@ -1,0 +1,59 @@
+# Keyboard-Aware Immersive Terminal — Design (Slice 3 core)
+
+## Context / finding
+
+The terminal subsystem already implements live keystroke streaming (xterm `onData` →
+`{type:'input'}` over WS → `pty.write` on the server), a raw/chat toggle, QuickKeys,
+CommandPalette, keyboard shortcuts, and terminal sharing. So "build streaming" is a
+solved problem. The genuine native-feel gap on a phone is that **the on-screen keyboard
+overlays the input and output** — there is no `visualViewport` handling anywhere, and the
+viewport meta does not use `interactive-widget`. When you tap the terminal or chat input on
+iOS/Android, the software keyboard covers the very field you are typing into.
+
+## Goal
+
+Keep the terminal input bar, the chat composer, and (where useful) the message scroll
+position **above** the software keyboard, so typing on a phone feels native.
+
+## Approach
+
+A single source of truth for the keyboard overlap, exposed both reactively and as a CSS
+custom property so plain CSS can consume it with zero per-component JS.
+
+### Units
+
+1. **`keyboard.ts` — pure math.**
+   `computeKeyboardInset(layoutHeight, viewportHeight, offsetTop): number =
+max(0, layoutHeight - viewportHeight - offsetTop)`.
+   Closed keyboard → 0; open → keyboard height. Clamped at 0. Unit-tested in Node.
+
+2. **`keyboard-inset.svelte.ts` — tracker store.**
+   `startKeyboardInsetTracking(): () => void` attaches `resize`/`scroll` listeners to
+   `window.visualViewport`, recomputes the inset, writes it to
+   `document.documentElement.style['--keyboard-inset']`, and updates a reactive
+   `$state`. `getKeyboardInset()` reads it. SSR-safe / no-op when `visualViewport`
+   is unavailable (desktop, older engines). Started once in the root layout `onMount`.
+
+3. **Consumers (CSS var `--keyboard-inset`, default 0px).**
+   - Terminal `.term-page` height shrinks by the inset. This is the surface that
+     genuinely needs it: `.term-page` is a fixed-height `overflow: hidden` flex column
+     with the input pinned at its bottom, so the browser cannot scroll the focused
+     input above the keyboard on its own — the explicit shrink does it.
+   - The **session viewer is intentionally NOT changed**: it is a normal
+     `overflow: auto` scroller, so the browser natively scrolls the focused composer
+     into view above the keyboard. Shrinking a shared ancestor there would only _clip_
+     the composer (verified), so it is left to native behaviour.
+
+## Non-goals (this slice)
+
+Re-plumbing streaming (already done), restyling the term topbar to the amber NavBar,
+gesture navigation. Those are separate follow-ups.
+
+## Verification
+
+- Unit test the pure math (Node, `.cjs`).
+- Simulate a `visualViewport` resize in a real browser and assert `--keyboard-inset`
+  updates and the composer offsets (screenshot the session/chat input).
+- `pnpm check` / `build` / full test suite / lint clean.
+- On-device confirmation (real iOS/Android keyboard) is the final acceptance step and
+  is called out honestly as not reproducible in desktop Chrome.

--- a/docs/superpowers/specs/2026-07-11-live-activity-ambient-design.md
+++ b/docs/superpowers/specs/2026-07-11-live-activity-ambient-design.md
@@ -1,0 +1,57 @@
+# Ambient Status / Live Activity — Design (Slice 6)
+
+**Program:** "Make Shooter feel native" — Slice 6 of 6.
+
+## Split: verifiable server foundation now, Xcode-gated iOS extension provided as reference
+
+Slice 6's on-screen payoff (Lock Screen Live Activity + Dynamic Island) needs an
+iOS **widget-extension target**, which can only be created in Xcode — adding an
+app-extension target rewrites dozens of interlinked `pbxproj` UUIDs (target,
+build phases, embed step, Info.plist, entitlements) and hand-editing that blind
+would likely corrupt the project. So this slice ships:
+
+1. **The full server-side push foundation** — real, tested, buildable.
+2. **The complete iOS ActivityKit reference** under `ios/Shooter/LiveActivityReference/`
+   plus a step-by-step Xcode integration guide, so the extension is a
+   drag-and-drop + wire-up rather than net-new code.
+
+## Server (built + tested)
+
+- **APNs transport:** `LibraryAPNsService.sendLiveActivity(token, input, nowSec?)`.
+  `deliverPreSerialized` gained a `liveactivity` push type and a topic override so
+  the same curl/HTTP-2 path targets `<bundleId>.push-type.liveactivity` with
+  `apns-push-type: liveactivity`. The existing alert/background paths are unchanged
+  (options-object refactor kept param count within lint limits).
+- **Pure builder** (`apns-liveactivity.ts`): `buildLiveActivityBody` (timestamp,
+  event, content-state; dismissal-date only on `end`; optional stale-date /
+  relevance-score / alert) + `liveActivityTopic`. `nowSec` injected → 12 unit tests.
+- **Token store** (`live-activity-store.ts`): session → rotating activity push
+  token; idempotent upsert, remove by session, remove by token (410 cleanup). 6 tests.
+- **Endpoints:** `POST/DELETE /api/live-activity/register` (app registers its
+  token); `POST /api/live-activity` pushes a `start`/`update`/`end` — targets an
+  explicit token or a registered `sessionId`, and forgets the token on `end`/410.
+- **Types** (`src/lib/types/live-activity.ts`): `LiveActivityContentState` is the
+  contract the Swift `ContentState` must mirror.
+
+## iOS reference (`ios/Shooter/LiveActivityReference/`)
+
+`ShooterActivityAttributes.swift` (shared), `ShooterLiveActivity.swift` (Lock
+Screen + Dynamic Island, Amber Phosphor), `ShooterWidgetBundle.swift`,
+`LiveActivityManager.swift` (start/end + streams the push token to
+`/api/live-activity/register`), and `README.md` with the exact Xcode steps.
+SourceKit flags these outside a target (ActivityKit/WidgetKit are iOS-only) — expected.
+
+## Verification
+
+- Unit: 12 (builder) + 6 (store) tests.
+- Integration (curl): register → `success`, store persists the token, update-by-
+  `sessionId` resolves the token and reaches the real APNs curl; missing
+  token/session → 400.
+- Gates: `pnpm check` / `build` / full `test` / eslint `--max-warnings 0` green.
+
+## On-device / Xcode caveat
+
+The Live Activity UI, Dynamic Island, and push-driven updates are the on-device
+acceptance step (create the widget target in Xcode per the README, build for a
+device, iOS 16.2+). The server push path + token lifecycle are unit- and
+curl-verified here.

--- a/docs/superpowers/specs/2026-07-11-terminal-immersion-edgeswipe-design.md
+++ b/docs/superpowers/specs/2026-07-11-terminal-immersion-edgeswipe-design.md
@@ -1,0 +1,49 @@
+# Terminal Immersion + Edge-Swipe Back — Design (Slice 3 follow-ups)
+
+The keyboard-aware terminal (Slice 3 core) shipped earlier. These are the
+immersion follow-ups the keyboard spec deferred: the terminal topbar's amber
+cohesion and the iOS edge-swipe-back gesture across drill-in screens.
+
+## Changes
+
+### Terminal topbar — amber back chevron
+
+`.term-back` used a grey `--text-secondary` chevron. Retinted to `var(--accent)`
+with a press-scale (`:active { scale(0.9) }`) and `-webkit-tap-highlight-color:
+transparent`, matching the native `NavBar` back button (Slice 2 rule: amber = action).
+
+### Edge-swipe-back gesture
+
+`EdgeSwipeBack.svelte` — a wrapper that navigates back when the user drags right
+from the left screen edge, the core iOS one-handed back gesture. Applied to the
+Session and Project drill-in screens (each keeps its NavBar back button too).
+
+- **Arms only from the edge:** the gesture engages only when a touch _starts_
+  within `edge` (28px) of the left screen edge, so it never interferes with
+  content scrolling, taps, or the terminal's own touch handling.
+- **Axis-locked** with an 8px dead-zone; vertical or leftward motion disengages.
+- **Commit threshold:** past 32% of the width (or handled by the caller), it
+  slides fully off and calls `goto(backHref)` / `history.back()` with a light
+  haptic; below threshold it snaps back.
+- **Sticky-safe:** emits `transform: none` at rest (a zero transform would form a
+  containing block and break the sticky NavBar inside); only transforms mid-gesture.
+- Reduced-motion-aware via `resolveMotionDuration`.
+
+The decision logic (edge engagement, axis lock, commit threshold) is extracted
+to a pure `edge-swipe.ts` module — the pull-refresh.ts / keyboard.ts pattern —
+so it is deterministically unit-tested.
+
+## Verification
+
+- Unit: `tests/edge-swipe.test.cjs` — 15 tests (edge engagement boundaries,
+  axis-lock dead-zone + tie-break, commit threshold incl. strict-`>` and zero-width).
+- Gates: `pnpm check` / `build` / full `test` / eslint `--max-warnings 0` green.
+- Amber back chevron: CSS mirrors the screenshot-verified `.navbar-back` amber.
+
+## On-device caveat
+
+Live swipe feel (rubber-band, commit animation, back navigation) is the on-device
+acceptance step. In automated desktop Chrome the backend-less dev server stalls
+page hydration intermittently, so synthetic TouchEvent runs are flaky; the gesture
+_decision_ logic is covered deterministically by the unit tests instead, and a
+hydrated instance was observed committing the gesture during testing.

--- a/docs/superpowers/specs/2026-07-11-web-push-onboarding-design.md
+++ b/docs/superpowers/specs/2026-07-11-web-push-onboarding-design.md
@@ -1,0 +1,73 @@
+# Web Push + Onboarding — Design (Slice 5)
+
+**Program:** "Make Shooter feel native" — Slice 5 of 6. Stacked on `feat/native-nav-shell`.
+
+## Why
+
+Native push (APNs/FCM) needs an app-store build. The PWA promise of Shooter is
+"open it in Safari/Chrome, add to Home Screen, get pushed" with no store. This
+slice adds real **Web Push** as a third delivery channel, plus the Settings UX
+to enable it with a permission rehearsal and a self-test.
+
+## Architecture
+
+Web Push is structurally different from the APNs/FCM `device_tokens` table (flat
+opaque token, `platform IN ('ios','android')`, no key columns). A subscription is
+an endpoint URL + a p256dh/auth key pair, so it gets its **own** store and table —
+`web_push_subscriptions` in the same `~/.shooter/shooter.db`. The existing native
+registry is untouched.
+
+### Server
+
+- `webpush/vapid.ts` — resolves VAPID keys from env (`VAPID_PUBLIC_KEY/_PRIVATE_KEY/_SUBJECT`),
+  else generates once and persists to `~/.shooter/vapid.json` (mode 0600). Stable
+  keys across restarts — rotating the public key would invalidate every subscription.
+- `webpush/web-push-store.ts` — SQLite store (same better-sqlite3 + WAL +
+  globalThis-singleton idiom as device-token-store). Idempotent upsert keyed by
+  endpoint, key rotation, lazy prune-by-endpoint on 404/410, 30-day cleanup.
+- `webpush/web-push-service.ts` — `web-push` library transport. `isWebPushConfigured()`,
+  `getWebPushPublicKey()`, `sendWebPushMulti(subs, payload)` returning a
+  `WebPushFanOutResult` (success/failure counts + stale endpoints), mirroring FCM.
+- `/api/web-push/vapid-public-key` GET (public — a client needs it to subscribe).
+- `/api/web-push/subscribe` POST (upsert) / DELETE (unsubscribe by endpoint), auth-gated.
+- `/api/notify` folds web push into the parallel fan-out: skipped on a single-token
+  override send; stale endpoints pruned; delivered endpoints touched; the web
+  success/failure counts merge into the aggregate delivery summary.
+- `static/sw.js` — minimal service worker: `push` → `showNotification`,
+  `notificationclick` → focus/navigate an existing window or open one.
+
+### Client
+
+- `client/push/web-push.ts` — `isWebPushSupported`, `getWebPushPermission`,
+  `isWebPushSubscribed`, `enableWebPush` (rehearse permission → register SW →
+  fetch VAPID key → subscribe → POST), `disableWebPush` (unsubscribe + DELETE).
+  Every entry point guards on support and returns a typed `WebPushStatus`.
+- Settings "Browser Notifications" grouped section: status dot + state label
+  (enabled / not enabled / blocked), Enable / Turn off, and a "Send test push"
+  that fires a real notify so the user sees it land.
+
+### Types (`src/lib/types/webpush.ts`)
+
+`WebPushSubscriptionInput` (+ `isWebPushSubscriptionInput` guard),
+`WebPushSubscriptionRecord`, `WebPushFanOutResult`, `WebPushPayload`, `VapidKeys`,
+`WebPushStatus`. Hand-written (nested shape + runtime guard), re-exported from the barrel.
+
+## Verification
+
+- Unit: `tests/web-push-store.test.cjs` — 9 tests (upsert/rotate/COALESCE/prune/
+  reactivate/touch/delete/cleanup/validation).
+- Integration (curl against dev server): VAPID key endpoint returns a key and
+  persists `vapid.json`; subscribe stores an active row; notify runs the web
+  fan-out and folds its result into the summary; DELETE removes the row.
+- UI: Settings "Browser Notifications" section renders with correct support/permission
+  state (screenshot, phone width).
+- SW: `/sw.js` served (HTTP 200, text/javascript) with both handlers.
+- Gates: `pnpm check` / `build` / full `test` / eslint `--max-warnings 0` green.
+
+## Needs a real browser grant (NOT reproducible in automated Chrome)
+
+The final step — an actual push arriving in a live browser — needs a genuine
+Notification-permission grant and an FCM/Mozilla push-service roundtrip. Automated
+Chrome keeps permission at "default" and blocks `pushManager.subscribe`, so live
+delivery is confirmed on a real device the same way the iOS on-device pieces are.
+Everything up to and including the SW registration + VAPID key fetch is verified here.

--- a/ios/Shooter/LiveActivityReference/LiveActivityManager.swift
+++ b/ios/Shooter/LiveActivityReference/LiveActivityManager.swift
@@ -1,0 +1,74 @@
+// LiveActivityManager.swift
+//
+// App-side controller: starts a Live Activity for a coding session, forwards its
+// APNs push token to the Shooter server (so the server can push updates), and
+// ends the activity. Belongs to the MAIN APP target.
+//
+// The server pushes updates to `POST /api/live-activity` using the token this
+// registers. Requires iOS 16.1+; push-token updates require iOS 16.2+.
+
+import ActivityKit
+import Foundation
+
+@available(iOS 16.2, *)
+final class LiveActivityManager {
+    static let shared = LiveActivityManager()
+    private var current: Activity<ShooterActivityAttributes>?
+    private var tokenTask: Task<Void, Never>?
+
+    /// Start a Live Activity for a session and stream its push token to the server.
+    func start(sessionId: String, title: String, status: String, detail: String? = nil) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+        let attributes = ShooterActivityAttributes(sessionId: sessionId)
+        let state = ShooterActivityAttributes.ContentState(
+            title: title, status: status, detail: detail, progress: nil,
+            updatedAt: ISO8601DateFormatter().string(from: Date())
+        )
+        do {
+            let activity = try Activity.request(
+                attributes: attributes,
+                content: .init(state: state, staleDate: nil),
+                pushType: .token
+            )
+            current = activity
+            // Stream the push token to the server as ActivityKit rotates it.
+            tokenTask = Task {
+                for await tokenData in activity.pushTokenUpdates {
+                    let token = tokenData.map { String(format: "%02x", $0) }.joined()
+                    await self.registerToken(token, sessionId: sessionId)
+                }
+            }
+        } catch {
+            print("[LiveActivity] start failed: \(error)")
+        }
+    }
+
+    /// End the current activity (optionally showing a final state briefly).
+    func end(finalStatus: String = "Done") {
+        tokenTask?.cancel()
+        guard let activity = current else { return }
+        let state = ShooterActivityAttributes.ContentState(
+            title: activity.content.state.title, status: finalStatus, detail: nil,
+            progress: nil, updatedAt: ISO8601DateFormatter().string(from: Date())
+        )
+        Task {
+            await activity.end(.init(state: state, staleDate: nil), dismissalPolicy: .default)
+            current = nil
+        }
+    }
+
+    /// POST the activity push token to the Shooter server. Server config (base URL
+    /// + API key) comes from the app's existing Config store.
+    private func registerToken(_ token: String, sessionId: String) async {
+        guard let baseURL = Config.serverURL, let apiKey = Config.apiKey,
+              let url = URL(string: "\(baseURL)/api/live-activity/register") else { return }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try? JSONSerialization.data(withJSONObject: [
+            "activityPushToken": token, "sessionId": sessionId,
+        ])
+        _ = try? await URLSession.shared.data(for: req)
+    }
+}

--- a/ios/Shooter/LiveActivityReference/README.md
+++ b/ios/Shooter/LiveActivityReference/README.md
@@ -1,0 +1,69 @@
+# Live Activity (Slice 6) — iOS integration guide
+
+The server side of Slice 6 (Ambient status) is built and tested:
+
+- **APNs transport:** `LibraryAPNsService.sendLiveActivity(token, input)` pushes to
+  `<bundleId>.push-type.liveactivity` with `apns-push-type: liveactivity`.
+- **Pure body builder:** `apns-liveactivity.ts` (`buildLiveActivityBody`, `liveActivityTopic`)
+  — 12 unit tests.
+- **Token store:** `live-activity-store.ts` maps a session → its rotating activity
+  push token — 6 unit tests.
+- **Endpoints:** `POST /api/live-activity/register` (+ `DELETE`) to register a
+  session's token; `POST /api/live-activity` to push a `start`/`update`/`end`
+  update (targets an explicit token or a registered `sessionId`; forgets the token
+  on `end`/410).
+- **Types:** `src/lib/types/live-activity.ts` — `LiveActivityContentState` is the
+  contract the Swift `ContentState` must mirror.
+
+The iOS half needs an Xcode **widget-extension target**, which must be created in
+Xcode (adding an app-extension target rewrites dozens of interlinked `pbxproj`
+UUIDs — too fragile to hand-edit safely). The Swift here is the ready-to-use
+reference; the SourceKit errors you see on these files in a plain editor are
+expected — ActivityKit/WidgetKit only resolve inside a real iOS target.
+
+## Files
+
+| File | Target |
+|------|--------|
+| `ShooterActivityAttributes.swift` | **both** app + widget extension |
+| `ShooterLiveActivity.swift` | widget extension only |
+| `ShooterWidgetBundle.swift` | widget extension only (`@main`) |
+| `LiveActivityManager.swift` | app target only |
+
+## Xcode steps
+
+1. **File ▸ New ▸ Target… ▸ Widget Extension.** Name it `ShooterWidget`. Check
+   **Include Live Activity**; uncheck Configuration Intent. This creates the
+   target, its `Info.plist`, and the embed build phase automatically.
+2. **Delete** the template `ShooterWidget.swift`/bundle Xcode generated.
+3. **Add the reference files** (drag them out of `LiveActivityReference/` into the
+   project, or copy their contents):
+   - `ShooterActivityAttributes.swift` → Target Membership: **app + ShooterWidget**.
+   - `ShooterLiveActivity.swift`, `ShooterWidgetBundle.swift` → **ShooterWidget** only.
+   - `LiveActivityManager.swift` → **app** only.
+4. **App target ▸ Info.plist:** add `NSSupportsLiveActivities = YES`.
+5. **Capabilities:** the app already has Push Notifications; no new entitlement is
+   needed for Live Activity push (it reuses the APNs key).
+6. **Wire it up:** call `LiveActivityManager.shared.start(sessionId:title:status:)`
+   when a session begins (e.g. from the existing notification/session handling in
+   `ContentView`/`AppDelegate`) and `.end()` when it completes. The manager streams
+   the activity push token to `POST /api/live-activity/register`; the server then
+   drives updates via `POST /api/live-activity`.
+7. **Build for a device** (Live Activities don't run in older simulators; iOS 16.2+
+   for push-token updates). Verify the Lock Screen + Dynamic Island presentation.
+
+## Server → activity update example
+
+```bash
+curl -X POST "$BASE/api/live-activity" \
+  -H "Authorization: Bearer $API_KEY" -H 'Content-Type: application/json' \
+  -d '{"sessionId":"<id>","event":"update",
+       "contentState":{"title":"claude","status":"Awaiting input",
+                        "detail":"Permission: Edit file","updatedAt":"2026-07-11T00:00:00Z"}}'
+```
+
+## On-device caveat
+
+Live Activity rendering, the Dynamic Island, and push-driven updates are the
+on-device acceptance step (real device, iOS 16.2+, `xcodebuild` on the created
+target). The server push path + token lifecycle are unit-tested here.

--- a/ios/Shooter/LiveActivityReference/ShooterActivityAttributes.swift
+++ b/ios/Shooter/LiveActivityReference/ShooterActivityAttributes.swift
@@ -1,0 +1,25 @@
+// ShooterActivityAttributes.swift
+//
+// Shared between the main app (which starts/ends activities) and the widget
+// extension (which renders them). The nested `ContentState` MUST stay in lockstep
+// with `LiveActivityContentState` in src/lib/types/live-activity.ts — the server
+// pushes exactly this shape as the ActivityKit `content-state`.
+//
+// Requires iOS 16.1+ (ActivityKit). Add this file to BOTH the app target and the
+// widget-extension target (Target Membership).
+
+import ActivityKit
+import Foundation
+
+struct ShooterActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var title: String        // session / terminal name
+        var status: String       // "Running", "Awaiting input", "Done"
+        var detail: String?      // last tool or message
+        var progress: Double?    // 0...1 optional
+        var updatedAt: String    // ISO timestamp
+    }
+
+    // Static attributes fixed for the life of the activity.
+    var sessionId: String
+}

--- a/ios/Shooter/LiveActivityReference/ShooterLiveActivity.swift
+++ b/ios/Shooter/LiveActivityReference/ShooterLiveActivity.swift
@@ -1,0 +1,89 @@
+// ShooterLiveActivity.swift
+//
+// The Lock Screen / Dynamic Island presentation for a Shooter coding session.
+// Belongs to the WIDGET EXTENSION target only. Amber Phosphor accent (#F5B14C)
+// matches the app identity.
+//
+// Requires iOS 16.1+ (WidgetKit + ActivityKit).
+
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+private let amber = Color(red: 0.961, green: 0.694, blue: 0.298) // #F5B14C
+
+struct ShooterLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: ShooterActivityAttributes.self) { context in
+            // ── Lock Screen / banner ──
+            HStack(spacing: 12) {
+                Image(systemName: statusIcon(context.state.status))
+                    .foregroundColor(amber)
+                    .font(.title3)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(context.state.title)
+                        .font(.headline)
+                        .lineLimit(1)
+                    Text(context.state.detail ?? context.state.status)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer()
+                statusPill(context.state.status)
+            }
+            .padding()
+            .activityBackgroundTint(Color.black.opacity(0.85))
+            .activitySystemActionForegroundColor(amber)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: statusIcon(context.state.status))
+                        .foregroundColor(amber)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Text(context.state.title).font(.caption).lineLimit(1)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    statusPill(context.state.status)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    if let detail = context.state.detail {
+                        Text(detail).font(.caption2).foregroundColor(.secondary).lineLimit(1)
+                    }
+                }
+            } compactLeading: {
+                Image(systemName: statusIcon(context.state.status)).foregroundColor(amber)
+            } compactTrailing: {
+                Text(shortStatus(context.state.status)).font(.caption2).foregroundColor(amber)
+            } minimal: {
+                Image(systemName: statusIcon(context.state.status)).foregroundColor(amber)
+            }
+            .keylineTint(amber)
+        }
+    }
+
+    private func statusIcon(_ status: String) -> String {
+        switch status.lowercased() {
+        case let s where s.contains("await"): return "questionmark.circle.fill"
+        case let s where s.contains("done"), let s where s.contains("complete"): return "checkmark.circle.fill"
+        case let s where s.contains("error"), let s where s.contains("fail"): return "exclamationmark.triangle.fill"
+        default: return "terminal.fill"
+        }
+    }
+
+    private func shortStatus(_ status: String) -> String {
+        String(status.prefix(4))
+    }
+
+    @ViewBuilder
+    private func statusPill(_ status: String) -> some View {
+        Text(status)
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(amber.opacity(0.18))
+            .foregroundColor(amber)
+            .clipShape(Capsule())
+    }
+}

--- a/ios/Shooter/LiveActivityReference/ShooterWidgetBundle.swift
+++ b/ios/Shooter/LiveActivityReference/ShooterWidgetBundle.swift
@@ -1,0 +1,16 @@
+// ShooterWidgetBundle.swift
+//
+// Entry point for the widget extension target. Add more widgets (e.g. a
+// home-screen WidgetKit widget) to the bundle here as they are built.
+//
+// Belongs to the WIDGET EXTENSION target only. Requires iOS 16.1+.
+
+import SwiftUI
+import WidgetKit
+
+@main
+struct ShooterWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        ShooterLiveActivity()
+    }
+}

--- a/ios/Shooter/Shooter/ContentView.swift
+++ b/ios/Shooter/Shooter/ContentView.swift
@@ -392,6 +392,9 @@ struct WebView: UIViewRepresentable {
         window.ShooterBridge.saveConfig = function(json) {
             window.webkit.messageHandlers.shooterBridge.postMessage(json);
         };
+        window.ShooterBridge.haptic = function(kind) {
+            window.webkit.messageHandlers.shooterHaptic.postMessage(kind || 'light');
+        };
 
         // Generic native callback infrastructure — reusable for scanner, image picker, etc.
         window.handleNativeResponse = function(callbackId, jsonString) {
@@ -448,6 +451,11 @@ struct WebView: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
         config.allowsInlineMediaPlayback = true
+        // Match the web meta[name=format-detection] behavior natively: plain text
+        // (session paths, timestamps, IDs) should never auto-link as tel/date/address/email.
+        if #available(iOS 14.5, *) {
+            config.dataDetectorTypes = []
+        }
 
         let prefs = WKWebpagePreferences()
         prefs.allowsContentJavaScript = true
@@ -469,6 +477,8 @@ struct WebView: UIViewRepresentable {
         // Phone-resident agent: durable file persistence + on-device decide step
         config.userContentController.add(context.coordinator, name: "shooterFiles")
         config.userContentController.add(context.coordinator, name: "shooterAgentDecide")
+        // Native haptic feedback ticks
+        config.userContentController.add(context.coordinator, name: "shooterHaptic")
 
         let webView = WKWebView(frame: .zero, configuration: config)
         #if DEBUG
@@ -543,6 +553,8 @@ struct WebView: UIViewRepresentable {
                 handleFiles(message)
             case "shooterAgentDecide":
                 handleAgentDecide(message)
+            case "shooterHaptic":
+                handleHaptic(message)
             default:
                 break
             }
@@ -563,6 +575,35 @@ struct WebView: UIViewRepresentable {
                 KeychainHelper.save(key: "apiKey", value: apiKey)
             }
             print("[ShooterBridge] saveConfig: serverUrl=\(obj["serverUrl"] ?? "nil"), apiKey=\((obj["apiKey"] as? String)?.isEmpty == false ? "(set)" : "(empty)")")
+        }
+
+        // MARK: - Haptic feedback handler
+
+        /// Maps a web-side HapticKind string to the matching UIKit feedback generator.
+        /// Impact generators for light/medium/heavy taps, notification generator for
+        /// success/warning/error outcomes, selection generator for picker-style changes.
+        private func handleHaptic(_ message: WKScriptMessage) {
+            guard let kind = message.body as? String else { return }
+            DispatchQueue.main.async {
+                switch kind {
+                case "light":
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                case "medium":
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                case "heavy":
+                    UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+                case "success":
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                case "warning":
+                    UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                case "error":
+                    UINotificationFeedbackGenerator().notificationOccurred(.error)
+                case "selection":
+                    UISelectionFeedbackGenerator().selectionChanged()
+                default:
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                }
+            }
         }
 
         // MARK: - QR Scanner handler

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "format:generated": "prettier --write ./src/lib/types/generated/*",
     "quality:all": "pnpm run lint && pnpm run format:check && pnpm run check",
     "gen:types": "npx type-crafter generate typescript-with-decoders ./specs/types/index.yaml ./src/lib/types/generated SingleFile SingleFile && bash scripts/postgen-types.sh && pnpm run format:generated",
-    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/service-manager.test.cjs && node tests/plan-mode-routing.test.cjs && node tests/dynamic-options-extraction.test.cjs && node tests/next-step-consensus.test.cjs && node tests/summaries-route.test.cjs && node tests/litellm-client.test.cjs && node tests/decide-injection.test.cjs && node tests/presence-store.test.cjs && node tests/autopilot-context.test.cjs && node tests/apns-payload.test.cjs && node tests/agent-launch.test.cjs && node tests/codex-parser.test.cjs && node tests/provider-readers.test.cjs && node tests/generic-watcher.test.cjs && node tests/sos-coordinator.test.cjs && node tests/sos-policy.test.cjs && node tests/pty-input.test.cjs && node tests/share-store.test.cjs && node tests/seq-ring.test.cjs && node tests/terminal-emulator.test.cjs && node tests/resize-authority.test.cjs && node tests/device-token-resolution.test.cjs && node tests/pty-holder-integration.cjs && node tests/device-token-store.test.cjs && node tests/device-format.test.cjs && node tests/classify-apns-reason.test.cjs && node tests/fcm-classify.test.cjs && node tests/notify-fanout.test.cjs && node tests/device-registry-prune.test.cjs && node tests/summary-store.test.cjs",
+    "test": "node tests/terminal-store.test.cjs && node tests/pending-requests.test.cjs && node tests/tunnel-discovery.test.cjs && node tests/service-manager.test.cjs && node tests/plan-mode-routing.test.cjs && node tests/dynamic-options-extraction.test.cjs && node tests/next-step-consensus.test.cjs && node tests/summaries-route.test.cjs && node tests/litellm-client.test.cjs && node tests/decide-injection.test.cjs && node tests/presence-store.test.cjs && node tests/autopilot-context.test.cjs && node tests/apns-payload.test.cjs && node tests/agent-launch.test.cjs && node tests/codex-parser.test.cjs && node tests/provider-readers.test.cjs && node tests/generic-watcher.test.cjs && node tests/sos-coordinator.test.cjs && node tests/sos-policy.test.cjs && node tests/pty-input.test.cjs && node tests/share-store.test.cjs && node tests/seq-ring.test.cjs && node tests/terminal-emulator.test.cjs && node tests/resize-authority.test.cjs && node tests/device-token-resolution.test.cjs && node tests/pty-holder-integration.cjs && node tests/device-token-store.test.cjs && node tests/device-format.test.cjs && node tests/classify-apns-reason.test.cjs && node tests/fcm-classify.test.cjs && node tests/notify-fanout.test.cjs && node tests/device-registry-prune.test.cjs && node tests/summary-store.test.cjs && node tests/motion.test.cjs && node tests/native-bridge.test.cjs && node tests/pull-refresh.test.cjs && node tests/keyboard.test.cjs && node tests/web-push-store.test.cjs && node tests/edge-swipe.test.cjs && node tests/apns-liveactivity.test.cjs && node tests/live-activity-store.test.cjs",
     "setup": "node scripts/setup.cjs",
     "prepare": "husky || true",
     "prepublishOnly": "pnpm build"
@@ -96,6 +96,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.2.0",
     "@types/qrcode": "^1.5.6",
+    "@types/web-push": "^3.6.4",
     "@types/ws": "^8.18.1",
     "conventional-changelog-conventionalcommits": "^9.3.0",
     "eslint": "^9.39.2",
@@ -116,7 +117,7 @@
     "vite": "^7.3.2"
   },
   "dependencies": {
-    "@juspay/svelte-ui-components": "^2.18.0",
+    "@juspay/svelte-ui-components": "2.87.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-serialize": "0.14.0",
     "@xterm/addon-web-links": "^0.11.0",
@@ -133,6 +134,7 @@
     "qrcode": "^1.5.4",
     "tsx": "^4.19.0",
     "type-decoder": "^2.2.0",
+    "web-push": "^3.6.7",
     "ws": "^8.18.0"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   .:
     dependencies:
       '@juspay/svelte-ui-components':
-        specifier: ^2.18.0
-        version: 2.18.0(svelte@5.55.7(@typescript-eslint/types@8.57.2))(type-decoder@2.3.1)
+        specifier: 2.87.0
+        version: 2.87.0(svelte@5.55.7(@typescript-eslint/types@8.57.2))(type-decoder@2.3.1)
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -71,6 +71,9 @@ importers:
       type-decoder:
         specifier: ^2.2.0
         version: 2.3.1
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       ws:
         specifier: ^8.18.0
         version: 8.21.0
@@ -117,6 +120,9 @@ importers:
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -640,11 +646,15 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@juspay/svelte-ui-components@2.18.0':
-    resolution: {integrity: sha512-cq+HsFuAQsB3CCE6AED7cX6wViGGnAaOmtHIEh4ltfKU7y9XfxWkzCezpQieMg8g6Y5FMqqbTqgEUhRnsJDX7A==}
+  '@juspay/svelte-ui-components@2.87.0':
+    resolution: {integrity: sha512-g9HBDJypDrPbpqu2E+W9Ht+8Mk9kPQbd7UYZhXoOG2Tx5iOvDklJqP2mvh4Gr1m7o5lSIW5URBuNorHpf/7ACw==}
     peerDependencies:
+      lottie-web: '>=5.0.0'
       svelte: ^5.41.2
       type-decoder: ^2.1.0
+    peerDependenciesMeta:
+      lottie-web:
+        optional: true
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
@@ -1224,6 +1234,9 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1387,6 +1400,9 @@ packages:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
@@ -1422,6 +1438,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bn.js@4.12.5:
+    resolution: {integrity: sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==}
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
@@ -2143,6 +2162,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -2523,6 +2546,9 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -3052,6 +3078,9 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   semantic-release@24.2.8:
     resolution: {integrity: sha512-uvoLiKEB/AvvA3SCPE78cd90nVJXn220kkEA6sNGzDpas4s7pe4OgYWvhfR0lvWBdBH/T0RFCI6U+GvcT2CypQ==}
     engines: {node: '>=20.8.1'}
@@ -3470,6 +3499,11 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -3957,7 +3991,7 @@ snapshots:
   '@js-sdsl/ordered-map@4.4.2':
     optional: true
 
-  '@juspay/svelte-ui-components@2.18.0(svelte@5.55.7(@typescript-eslint/types@8.57.2))(type-decoder@2.3.1)':
+  '@juspay/svelte-ui-components@2.87.0(svelte@5.55.7(@typescript-eslint/types@8.57.2))(type-decoder@2.3.1)':
     dependencies:
       svelte: 5.55.7(@typescript-eslint/types@8.57.2)
       type-decoder: 2.3.1
@@ -4479,6 +4513,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.5.0
@@ -4658,6 +4696,13 @@ snapshots:
   arrify@2.0.1:
     optional: true
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.5
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   async-retry@1.3.3:
     dependencies:
       retry: 0.13.1
@@ -4692,6 +4737,8 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bn.js@4.12.5: {}
 
   bottleneck@2.19.5: {}
 
@@ -5570,6 +5617,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -5919,6 +5968,8 @@ snapshots:
   mimic-function@5.0.1: {}
 
   mimic-response@3.1.0: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -6402,6 +6453,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safer-buffer@2.1.2: {}
+
   semantic-release@24.2.8(typescript@5.9.3):
     dependencies:
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.8(typescript@5.9.3))
@@ -6826,6 +6879,16 @@ snapshots:
   vitefu@1.1.2(vite@7.3.5(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 7.3.5(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   web-streams-polyfill@3.3.3: {}
 

--- a/server.ts
+++ b/server.ts
@@ -35,6 +35,7 @@ import { openCodeWatcher } from './src/lib/modules/server/terminal/opencode-watc
 import { ptySubmitSequence } from './src/lib/modules/server/terminal/pty-input.js';
 import { ptyManager } from './src/lib/modules/server/terminal/pty-manager.js';
 import { sessionWatcher } from './src/lib/modules/server/terminal/session-watcher.js';
+import { webPushStore } from './src/lib/modules/server/webpush/web-push-store.js';
 import { startKeepalive, stopKeepalive } from './src/lib/modules/server/ws/keepalive.js';
 import { setupWebSocketHandlers } from './src/lib/modules/server/ws/server.js';
 import {
@@ -270,6 +271,11 @@ server.listen(requestedPort, () => {
     deviceTokenStore.startupCleanup();
   } catch (err) {
     console.error('[device-token] startup migrate/cleanup failed:', err);
+  }
+  try {
+    webPushStore.startupCleanup();
+  } catch (err) {
+    console.error('[web-push] startup cleanup failed:', err);
   }
   startAutopilotEngine();
 });

--- a/src/app.css
+++ b/src/app.css
@@ -70,7 +70,7 @@
   /* Font Sizes - Geist Typography Scale */
   --text-xs: 12px;
   --text-sm: 13px;
-  --text-base: 14px;
+  --text-base: 16px;
   --text-md: 15px;
   --text-lg: 16px;
   --text-xl: 20px;
@@ -106,8 +106,8 @@
   /* Border Radius */
   --radius-sm: 4px;
   --radius-md: 6px;
-  --radius-lg: 8px;
-  --radius-xl: 12px;
+  --radius-lg: 14px;
+  --radius-xl: 18px;
   --radius-full: 9999px;
 
   /* Transitions */
@@ -117,6 +117,24 @@
   /* Layout */
   --max-width: 1100px;
   --header-height: 64px;
+
+  /* Brand accent — Amber Phosphor. The ONLY hue for actions/active/selected/focus. */
+  --ds-amber-accent: #f5b14c;
+  --ds-amber-accent-hover: #ffc266;
+  --ds-amber-accent-fg: #0c0d0b;
+  --ds-amber-accent-dim: rgba(245, 177, 76, 0.14);
+  --ds-amber-accent-line: rgba(245, 177, 76, 0.32);
+  --accent: var(--ds-amber-accent);
+  --accent-hover: var(--ds-amber-accent-hover);
+  --accent-fg: var(--ds-amber-accent-fg);
+  --accent-dim: var(--ds-amber-accent-dim);
+  --accent-line: var(--ds-amber-accent-line);
+
+  /* Status — semantic and separate from accent. Never repurpose these for actions. */
+  --status-live: var(--ds-green-700);
+  --status-success: var(--ds-green-700);
+  --status-info: var(--ds-blue-700);
+  --status-danger: var(--ds-red-700);
 }
 
 /* Reset */
@@ -146,6 +164,7 @@ body {
 /* App Layout */
 .app {
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -153,7 +172,8 @@ body {
 
 /* Header */
 .header {
-  height: var(--header-height);
+  height: calc(var(--header-height) + env(safe-area-inset-top, 0px));
+  padding-top: env(safe-area-inset-top, 0px);
   background: var(--background);
   border-bottom: 1px solid var(--border);
   position: sticky;
@@ -244,7 +264,7 @@ body {
 .page-title {
   font-size: var(--text-2xl);
   font-weight: 600;
-  letter-spacing: var(--tracking-tighter);
+  letter-spacing: var(--tracking-tight);
   color: var(--text-primary);
   line-height: var(--leading-tight);
   margin-bottom: var(--space-2);
@@ -354,10 +374,13 @@ body {
 
 /* Cards */
 .card {
-  background: var(--component-bg);
-  border: 1px solid var(--border);
+  background: linear-gradient(135deg, rgba(20, 20, 20, 0.9) 0%, rgba(28, 28, 32, 0.9) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: var(--radius-lg);
   overflow: hidden;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
 }
 
 .card-header {
@@ -478,17 +501,20 @@ body {
 
 /* List */
 .list {
-  border: 1px solid var(--border);
+  border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: var(--radius-lg);
   overflow: hidden;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
 }
 
 .list-item {
   display: flex;
   align-items: center;
   padding: var(--space-4) var(--space-5);
-  background: var(--component-bg);
-  border-bottom: 1px solid var(--ds-gray-alpha-200);
+  background: linear-gradient(135deg, rgba(20, 20, 20, 0.9) 0%, rgba(28, 28, 32, 0.9) 100%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   transition: background var(--transition-fast);
 }
 
@@ -639,7 +665,7 @@ body {
 .btn:focus-visible,
 .input:focus-visible,
 .nav-link:focus-visible {
-  outline: 2px solid var(--ds-blue-700);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -654,10 +680,40 @@ body {
   }
 }
 
+/* Page transitions (View Transitions API) — see +layout.svelte's onNavigate
+   hook. Browsers without support (or with reduced motion requested) fall
+   through to SvelteKit's normal instant route swap. */
+@keyframes shooter-view-fade-out {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes shooter-view-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  ::view-transition-old(root) {
+    animation: shooter-view-fade-out 150ms ease both;
+  }
+
+  ::view-transition-new(root) {
+    animation: shooter-view-slide-in 220ms ease both;
+  }
+}
+
 /* Selection */
 ::selection {
-  background: var(--ds-blue-700);
-  color: #fff;
+  background: var(--accent);
+  color: var(--accent-fg);
 }
 
 /* Scrollbar */
@@ -677,6 +733,22 @@ body {
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--ds-gray-500);
+}
+
+/* Touch devices: hide the desktop scrollbar chrome and give custom (non-library)
+   app-shell tappables an instant press-down. Library tappables get press feedback
+   via the --button-active-transform var in theme.css. */
+@media (hover: none) {
+  ::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+  .session-card:active,
+  .terminal-card:active,
+  .tab-item:active {
+    transform: scale(0.978);
+    transition: transform 60ms ease;
+  }
 }
 
 /* ============================================
@@ -850,12 +922,6 @@ body {
   color: var(--text-tertiary, #737373);
 }
 
-.session-chevron {
-  color: var(--text-tertiary, #737373);
-  font-size: 1.2rem;
-  align-self: center;
-}
-
 /* ============================================
    Session Detail Page
    ============================================ */
@@ -865,28 +931,6 @@ body {
   align-items: center;
   gap: var(--space-3, 0.75rem);
   margin-bottom: var(--space-4, 1rem);
-}
-
-.session-back-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-md, 8px);
-  background: var(--bg-secondary, #141414);
-  border: 1px solid var(--border, #2a2a2a);
-  color: var(--text-secondary, #a3a3a3);
-  cursor: pointer;
-  transition: all var(--transition-fast, 150ms);
-  text-decoration: none;
-  font-size: 1.1rem;
-}
-
-.session-back-btn:hover {
-  background: var(--bg-tertiary, #1a1a1a);
-  color: var(--text-primary, #fafafa);
-  border-color: var(--gray-600, #525252);
 }
 
 .session-info-bar {

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -9,6 +9,7 @@ declare global {
     getEnvironment?: () => string;
     getFcmToken?: () => string;
     getPlatform?: () => string;
+    haptic?: (kind: string) => void;
     saveConfig?: (config: string) => void;
     scanner?: ShooterBridgeScanner;
   }

--- a/src/app.html
+++ b/src/app.html
@@ -6,6 +6,7 @@
     <link rel="icon" type="image/png" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0a0a0a" />
+    <meta name="format-detection" content="telephone=no, date=no, address=no, email=no" />
     <link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />
     <link rel="manifest" href="%sveltekit.assets%/manifest.json" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/lib/assets/icons/arrow-left.svg
+++ b/src/lib/assets/icons/arrow-left.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="19" y1="12" x2="5" y2="12"/>
+  <polyline points="12 19 5 12 12 5"/>
+</svg>

--- a/src/lib/assets/icons/trash.svg
+++ b/src/lib/assets/icons/trash.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 6h18"/>
+  <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+  <path d="M10 11v6M14 11v6"/>
+</svg>

--- a/src/lib/modules/client/common/Glyph.svelte
+++ b/src/lib/modules/client/common/Glyph.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  // Decorative SVG glyph. Renders a trusted, build-time SVG string WITHOUT the
+  // Icon component's hardcoded role=button/tabindex — so it never becomes a
+  // nested, unlabeled focus stop inside an already-labeled button or link.
+  const { size = 24, svg }: { size?: number; svg: string } = $props();
+</script>
+
+<span class="glyph" style="--glyph-size: {size}px" aria-hidden="true">
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG asset, never user input -->
+  {@html svg}
+</span>
+
+<style>
+  .glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .glyph :global(svg) {
+    display: block;
+    width: var(--glyph-size);
+    height: var(--glyph-size);
+  }
+</style>

--- a/src/lib/modules/client/common/SkeletonCard.svelte
+++ b/src/lib/modules/client/common/SkeletonCard.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  // Content-shaped loading placeholder that mirrors a real session/terminal card
+  // (title line, subtitle, a meta chip) instead of a featureless grey block, so
+  // the loading state reads as "content is arriving here" rather than "blank".
+  const { lines = 1 }: { lines?: number } = $props();
+</script>
+
+<div class="skeleton-card" aria-hidden="true">
+  <div class="skeleton-row">
+    <div class="skeleton-bar sk-line skeleton-title"></div>
+    <div class="skeleton-bar sk-line skeleton-chip"></div>
+  </div>
+  <div class="skeleton-bar sk-line skeleton-subtitle"></div>
+  {#each Array(lines) as _, i (i)}
+    <div class="skeleton-bar sk-line skeleton-meta"></div>
+  {/each}
+</div>
+
+<style>
+  .skeleton-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-4) var(--space-5);
+    background: var(--component-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+  }
+  .skeleton-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+  .skeleton-bar {
+    position: relative;
+    overflow: hidden;
+    height: 12px;
+    border-radius: 6px;
+    background: var(--ds-gray-alpha-200, rgba(255, 255, 255, 0.06));
+  }
+  .skeleton-bar::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      var(--shimmer-highlight, rgba(255, 255, 255, 0.08)),
+      transparent
+    );
+    animation: shimmer 1.5s infinite;
+  }
+  .skeleton-title {
+    width: 44%;
+    height: 16px;
+  }
+  .skeleton-chip {
+    width: 72px;
+    height: 20px;
+    border-radius: 10px;
+  }
+  .skeleton-subtitle {
+    width: 68%;
+  }
+  .skeleton-meta {
+    width: 30%;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton-bar::after {
+      animation: none;
+    }
+  }
+</style>

--- a/src/lib/modules/client/common/activity-badge.svelte.ts
+++ b/src/lib/modules/client/common/activity-badge.svelte.ts
@@ -1,0 +1,86 @@
+import { browser } from '$app/environment';
+
+import { getApiKey } from './config-guard';
+
+/**
+ * Lightweight "new activity" signal for the root NavBar bell. Polls the
+ * sessions endpoint for the single most-recently-modified project and compares
+ * its timestamp against the last time the user opened the Activity screen.
+ * A dot (not a count) is shown when something changed since — honest and native.
+ * SSR-safe: polling only runs in the browser.
+ */
+
+const SEEN_KEY = 'shooter_activity_seen';
+const POLL_MS = 30_000;
+
+let hasNew = $state(false);
+let poller: null | ReturnType<typeof setInterval> = null;
+
+const noop = (): void => undefined;
+
+/** Reactive: true when session activity is newer than the last Activity visit. */
+export function getHasNewActivity(): boolean {
+  return hasNew;
+}
+
+/** Record that the user has seen the current activity; clears the badge. */
+export function markActivitySeen(): void {
+  if (!browser) {
+    return;
+  }
+  localStorage.setItem(SEEN_KEY, String(Date.now()));
+  hasNew = false;
+}
+
+/** Begin polling for new activity every 30s. Returns a stop function. No-op during SSR. */
+export function startActivityBadgePolling(): () => void {
+  if (!browser) {
+    return noop;
+  }
+  void check();
+  poller ??= setInterval((): void => {
+    void check();
+  }, POLL_MS);
+  return (): void => {
+    if (poller) {
+      clearInterval(poller);
+      poller = null;
+    }
+  };
+}
+
+async function check(): Promise<void> {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    return;
+  }
+  try {
+    const response = await fetch('/api/sessions?limit=1&offset=0', {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!response.ok) {
+      return;
+    }
+    const data = (await response.json()) as { projects?: { lastModified?: string }[] };
+    const projects = data.projects ?? [];
+    let newest = 0;
+    for (const project of projects) {
+      const ts = project.lastModified ? new Date(project.lastModified).getTime() : 0;
+      if (Number.isFinite(ts) && ts > newest) {
+        newest = ts;
+      }
+    }
+    hasNew = newest > readSeen();
+  } catch {
+    // Best effort — a badge must never surface fetch errors.
+  }
+}
+
+function readSeen(): number {
+  if (!browser) {
+    return 0;
+  }
+  const raw = localStorage.getItem(SEEN_KEY);
+  const parsed = raw ? Number(raw) : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/src/lib/modules/client/common/edge-swipe.ts
+++ b/src/lib/modules/client/common/edge-swipe.ts
@@ -1,0 +1,29 @@
+// Pure decision helpers for the edge-swipe-back gesture, extracted so the logic
+// is unit-testable in Node without a DOM (the touch plumbing that calls these
+// lives in EdgeSwipeBack.svelte). Mirrors the pull-refresh.ts / keyboard.ts split.
+
+/**
+ * Lock the gesture to an axis once movement clears an 8px dead-zone. Returns ''
+ * while still inside the dead-zone (undecided), 'x' for a horizontal swipe, 'y'
+ * for a vertical scroll. Horizontal wins ties so a mostly-sideways drag from the
+ * edge is treated as a back-swipe.
+ */
+export function resolveSwipeAxis(dx: number, dy: number, deadZone = 8): '' | 'x' | 'y' {
+  if (Math.abs(dx) < deadZone && Math.abs(dy) < deadZone) {
+    return '';
+  }
+  return Math.abs(dx) >= Math.abs(dy) ? 'x' : 'y';
+}
+
+/** Commit the back-navigation when the rightward drag passes `threshold` of the width. */
+export function shouldCommitBack(dx: number, width: number, threshold = 0.32): boolean {
+  if (width <= 0) {
+    return false;
+  }
+  return dx > width * threshold;
+}
+
+/** The gesture only arms when the touch STARTS within `edge` px of the left screen edge. */
+export function shouldEngageEdge(startX: number, edge: number): boolean {
+  return startX <= edge;
+}

--- a/src/lib/modules/client/common/index.ts
+++ b/src/lib/modules/client/common/index.ts
@@ -1,10 +1,20 @@
 // Shared client utilities
+export {
+  getHasNewActivity,
+  markActivitySeen,
+  startActivityBadgePolling,
+} from './activity-badge.svelte';
 export { clearCache, getCached, setCache } from './cache';
 export { getApiKey, isShooterConfig } from './config-guard';
+export { resolveSwipeAxis, shouldCommitBack, shouldEngageEdge } from './edge-swipe';
 export { toErrorMessage } from './error';
+export { getKeyboardInset, startKeyboardInsetTracking } from './keyboard-inset.svelte';
 export { renderMarkdown } from './markdown';
-export { hasScanner, isNativeBridge, scanQR } from './native-bridge';
+export { prefersReducedMotion, resolveMotionDuration } from './motion';
+export { haptic, hasScanner, isNativeBridge, scanQR } from './native-bridge';
 export { startPresenceReporting } from './presence';
 export { AI_COMMANDS, sourceLabel, sourceToCommand } from './provider';
+export { resistPull, shouldTriggerRefresh } from './pull-refresh';
+export { getSystemStatus, startSystemStatusPolling } from './system-status.svelte';
 export { formatRelativeTime } from './time';
 export { getToolDescription } from './tool-title';

--- a/src/lib/modules/client/common/keyboard-inset.svelte.ts
+++ b/src/lib/modules/client/common/keyboard-inset.svelte.ts
@@ -1,0 +1,49 @@
+import { browser } from '$app/environment';
+
+import { computeKeyboardInset } from './keyboard';
+
+/**
+ * Tracks how much the on-screen keyboard overlaps the viewport and publishes it
+ * both reactively (`getKeyboardInset()`) and as the CSS custom property
+ * `--keyboard-inset` on the document root, so plain CSS can lift inputs above
+ * the keyboard with zero per-component JS. SSR-safe and a no-op where
+ * `visualViewport` is unavailable (desktop, older engines).
+ */
+
+let inset = $state(0);
+let viewport: null | VisualViewport = null;
+
+const noop = (): void => undefined;
+
+/** Reactive: current keyboard overlap in px (0 when closed). */
+export function getKeyboardInset(): number {
+  return inset;
+}
+
+/** Begin tracking the keyboard inset. Returns a stop function. No-op during SSR / no visualViewport. */
+export function startKeyboardInsetTracking(): () => void {
+  if (!browser || !window.visualViewport) {
+    return noop;
+  }
+  viewport = window.visualViewport;
+  document.documentElement.style.setProperty('--keyboard-inset', '0px');
+  update();
+  viewport.addEventListener('resize', update);
+  viewport.addEventListener('scroll', update);
+  return (): void => {
+    viewport?.removeEventListener('resize', update);
+    viewport?.removeEventListener('scroll', update);
+    viewport = null;
+  };
+}
+
+function update(): void {
+  if (!viewport) {
+    return;
+  }
+  const next = computeKeyboardInset(window.innerHeight, viewport.height, viewport.offsetTop);
+  if (next !== inset) {
+    inset = next;
+    document.documentElement.style.setProperty('--keyboard-inset', `${next}px`);
+  }
+}

--- a/src/lib/modules/client/common/keyboard.ts
+++ b/src/lib/modules/client/common/keyboard.ts
@@ -1,0 +1,18 @@
+/**
+ * On-screen-keyboard geometry. Pure function so the visualViewport tracking in
+ * keyboard-inset.svelte.ts stays thin and this is unit-testable in Node.
+ */
+
+/**
+ * How many pixels the software keyboard overlaps the layout viewport from the
+ * bottom. `layoutHeight` is the layout viewport (window.innerHeight),
+ * `viewportHeight`/`offsetTop` come from `window.visualViewport`. Clamped at 0
+ * (no negative inset when the keyboard is closed or the viewport is taller).
+ */
+export function computeKeyboardInset(
+  layoutHeight: number,
+  viewportHeight: number,
+  offsetTop: number
+): number {
+  return Math.max(0, layoutHeight - viewportHeight - offsetTop);
+}

--- a/src/lib/modules/client/common/motion.ts
+++ b/src/lib/modules/client/common/motion.ts
@@ -1,0 +1,19 @@
+/**
+ * Reduced-motion-aware duration primitive shared by every animation entry
+ * point (list FLIP, view-transition route hook, future motion work). Centralizing
+ * the `prefers-reduced-motion` read here means every consumer honors the OS
+ * accessibility setting identically instead of re-implementing the check.
+ */
+
+/** True when the OS/browser requests reduced motion. Always false during SSR (no `window`). */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/** Resolves an animation duration to 0 when reduced motion is requested, else the base duration. */
+export function resolveMotionDuration(baseMs: number, reducedMotion: boolean): number {
+  return reducedMotion ? 0 : baseMs;
+}

--- a/src/lib/modules/client/common/native-bridge.ts
+++ b/src/lib/modules/client/common/native-bridge.ts
@@ -8,6 +8,8 @@
  * resolving scanner/picker promises using its own callback registry.
  */
 
+import type { HapticKind } from '$lib/types';
+
 /** True when the native bridge exposes a QR scanner */
 export function hasScanner(): boolean {
   return getScanFn() !== null;
@@ -55,4 +57,41 @@ function getScanFn(): (() => Promise<string>) | null {
     return () => androidScanner.scan();
   }
   return null;
+}
+
+/** navigator.vibrate() fallback durations (ms) per haptic kind, for browsers/PWA with no native bridge. */
+const VIBRATION_MS: Record<HapticKind, number> = {
+  error: 40,
+  heavy: 30,
+  light: 10,
+  medium: 20,
+  selection: 5,
+  success: 15,
+  warning: 25,
+};
+
+/**
+ * Fire a haptic tick.
+ * Resolution order: window.ShooterBridge.haptic (iOS) → window.ShooterNativeBridge.haptic
+ * (Android) → navigator.vibrate (web/PWA) → no-op. SSR/desktop-safe — never throws.
+ */
+export function haptic(kind: HapticKind = 'light'): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    if (typeof window.ShooterBridge?.haptic === 'function') {
+      window.ShooterBridge.haptic(kind);
+      return;
+    }
+    if (typeof window.ShooterNativeBridge?.haptic === 'function') {
+      window.ShooterNativeBridge.haptic(kind);
+      return;
+    }
+    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+      navigator.vibrate(VIBRATION_MS[kind]);
+    }
+  } catch {
+    // Haptics are best-effort — never let a native-bridge exception surface to callers.
+  }
 }

--- a/src/lib/modules/client/common/pull-refresh.ts
+++ b/src/lib/modules/client/common/pull-refresh.ts
@@ -1,0 +1,22 @@
+/**
+ * Pull-to-refresh gesture math. Kept as pure functions so the touch handling in
+ * PullToRefresh.svelte stays thin and this behaviour is unit-testable in Node.
+ */
+
+/**
+ * Rubber-band resistance for a downward drag. Maps a raw drag distance (px,
+ * clamped at 0) onto an eased pull distance that asymptotes toward `max`: the
+ * indicator moves nearly 1:1 at first and stiffens as it nears the cap, so an
+ * over-pull can never run away.
+ */
+export function resistPull(dragY: number, max = 120): number {
+  if (dragY <= 0 || max <= 0) {
+    return 0;
+  }
+  return max * (1 - Math.exp(-dragY / max));
+}
+
+/** True once the eased pull distance reaches the release threshold. */
+export function shouldTriggerRefresh(pull: number, threshold = 64): boolean {
+  return pull >= threshold;
+}

--- a/src/lib/modules/client/common/system-status.svelte.ts
+++ b/src/lib/modules/client/common/system-status.svelte.ts
@@ -1,0 +1,52 @@
+import type { SystemStatus } from '$lib/types';
+
+/**
+ * Shared system-status state (health polling), read by the root NavBar so the
+ * ONLINE/Offline pill lives in one place instead of the old global header.
+ * SSR-safe: polling only starts in the browser.
+ */
+import { browser } from '$app/environment';
+
+let status = $state<SystemStatus>('unknown');
+let poller: null | ReturnType<typeof setInterval> = null;
+
+const noop = (): void => undefined;
+
+/** Current health status. Reactive when read in a component/`$derived` context. */
+export function getSystemStatus(): SystemStatus {
+  return status;
+}
+
+/** Begin polling /api/health every 30s. Returns a stop function. No-op during SSR. */
+export function startSystemStatusPolling(): () => void {
+  if (!browser) {
+    return noop;
+  }
+  void check();
+  poller ??= setInterval((): void => {
+    void check();
+  }, 30000);
+  return (): void => {
+    if (poller) {
+      clearInterval(poller);
+      poller = null;
+    }
+  };
+}
+
+async function check(): Promise<void> {
+  try {
+    const response = await fetch('/api/health');
+    if (!response.ok) {
+      status = 'error';
+      return;
+    }
+    const data = (await response.json()) as { status?: string };
+    status =
+      data.status === 'healthy' || data.status === 'degraded' || data.status === 'error'
+        ? data.status
+        : 'unknown';
+  } catch {
+    status = 'error';
+  }
+}

--- a/src/lib/modules/client/dashboard/DashboardView.svelte
+++ b/src/lib/modules/client/dashboard/DashboardView.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { DashboardCard } from '$lib/types';
 
+  import { prefersReducedMotion, resolveMotionDuration } from '$lib/modules/client/common';
+  import { flip } from 'svelte/animate';
+
   import DashboardCardComponent from './DashboardCard.svelte';
 
   const {
@@ -14,6 +17,9 @@
   const runningCards = $derived(cards.filter((c) => c.status === 'running'));
   const otherCards = $derived(cards.filter((c) => c.status !== 'running'));
 
+  // Computed once — a fixed FLIP duration, not a live media-query subscription.
+  const flipDuration = resolveMotionDuration(220, prefersReducedMotion());
+
   function handleClick(card: DashboardCard): void {
     onCardClick?.(card);
   }
@@ -23,12 +29,14 @@
   <div class="section">
     <h3 class="section-label">Active</h3>
     {#each runningCards as card (card.terminalId)}
-      <DashboardCardComponent
-        {card}
-        onclick={(): void => {
-          handleClick(card);
-        }}
-      />
+      <div class="card-flip" animate:flip={{ duration: flipDuration }}>
+        <DashboardCardComponent
+          {card}
+          onclick={(): void => {
+            handleClick(card);
+          }}
+        />
+      </div>
     {/each}
   </div>
 {/if}
@@ -37,12 +45,14 @@
   <div class="section">
     <h3 class="section-label">Recent</h3>
     {#each otherCards as card (card.terminalId)}
-      <DashboardCardComponent
-        {card}
-        onclick={(): void => {
-          handleClick(card);
-        }}
-      />
+      <div class="card-flip" animate:flip={{ duration: flipDuration }}>
+        <DashboardCardComponent
+          {card}
+          onclick={(): void => {
+            handleClick(card);
+          }}
+        />
+      </div>
     {/each}
   </div>
 {/if}

--- a/src/lib/modules/client/nav/EdgeSwipeBack.svelte
+++ b/src/lib/modules/client/nav/EdgeSwipeBack.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  import { goto } from '$app/navigation';
+  import {
+    haptic,
+    prefersReducedMotion,
+    resolveMotionDuration,
+    resolveSwipeAxis,
+    shouldCommitBack,
+    shouldEngageEdge,
+  } from '$lib/modules/client/common';
+
+  const {
+    backHref,
+    children,
+    edge = 28,
+    threshold = 0.32,
+  }: { backHref?: string; children: Snippet; edge?: number; threshold?: number } = $props();
+
+  let wrapEl: HTMLDivElement | undefined;
+  let dx = $state(0); // live rightward drag distance
+  let animating = $state(false); // transition enabled (snap-back or leave)
+  let leaving = $state(false); // sliding fully off before navigating back
+
+  // Non-reactive touch bookkeeping
+  let startX = 0;
+  let startY = 0;
+  let axis: '' | 'x' | 'y' = '';
+  let engaged = false; // the gesture began at the left edge
+
+  const width = $derived(wrapEl?.offsetWidth ?? 390);
+  const tx = $derived(leaving ? width : Math.max(0, dx));
+  // At rest, emit `none` (not translateX(0px)) — a zero transform still forms a
+  // containing block that would break a sticky NavBar inside. Only transform
+  // while actually swiping or animating.
+  const active = $derived(tx !== 0 || animating || leaving);
+  const transformCss = $derived(active ? `translateX(${tx}px)` : 'none');
+
+  function onStart(e: TouchEvent): void {
+    if (leaving || e.touches.length === 0) {
+      return;
+    }
+    const t = e.touches[0];
+    engaged = shouldEngageEdge(t.clientX, edge); // only catch swipes from the left edge
+    if (!engaged) {
+      return;
+    }
+    startX = t.clientX;
+    startY = t.clientY;
+    axis = '';
+    animating = false;
+  }
+
+  function onMove(e: TouchEvent): void {
+    if (!engaged || leaving || e.touches.length === 0) {
+      return;
+    }
+    const t = e.touches[0];
+    const ddx = t.clientX - startX;
+    const ddy = t.clientY - startY;
+
+    if (axis === '') {
+      axis = resolveSwipeAxis(ddx, ddy);
+      if (axis === '') {
+        return; // still inside the dead-zone
+      }
+    }
+    if (axis === 'y' || ddx < 0) {
+      engaged = false; // vertical scroll, or leftward — not our gesture
+      return;
+    }
+
+    e.preventDefault();
+    dx = ddx;
+  }
+
+  function goBack(): void {
+    haptic('light');
+    if (backHref) {
+      void goto(backHref);
+    } else if (typeof history !== 'undefined') {
+      history.back();
+    }
+  }
+
+  function onEnd(): void {
+    if (!engaged || axis !== 'x') {
+      engaged = false;
+      return;
+    }
+    engaged = false;
+    animating = true;
+    if (shouldCommitBack(dx, width, threshold)) {
+      leaving = true;
+      window.setTimeout(goBack, resolveMotionDuration(200, prefersReducedMotion()));
+    } else {
+      dx = 0; // snap back
+    }
+  }
+
+  const transitionMs = $derived(resolveMotionDuration(240, prefersReducedMotion()));
+</script>
+
+<!-- Edge-swipe surface: only engages when a touch begins within `edge`px of the
+     left screen edge, so it never interferes with content scrolling or taps. -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="edge-swipe"
+  bind:this={wrapEl}
+  ontouchstart={onStart}
+  ontouchmove={onMove}
+  ontouchend={onEnd}
+  ontouchcancel={onEnd}
+>
+  <div
+    class="edge-swipe-dim"
+    style="opacity: {Math.min(0.45, tx / width)}"
+    aria-hidden="true"
+  ></div>
+  <div
+    class="edge-swipe-content"
+    class:active
+    style="transform: {transformCss}; transition-duration: {animating || leaving
+      ? transitionMs
+      : 0}ms"
+    ontransitionend={(): void => {
+      animating = false;
+    }}
+  >
+    {@render children()}
+  </div>
+</div>
+
+<style>
+  .edge-swipe {
+    position: relative;
+    min-height: 100%;
+  }
+  /* A dark scrim under the sliding page, revealed as it moves right. */
+  .edge-swipe-dim {
+    position: absolute;
+    inset: 0;
+    background: #000;
+    pointer-events: none;
+    z-index: 0;
+  }
+  .edge-swipe-content {
+    position: relative;
+    z-index: 1;
+    transition-property: transform;
+    transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .edge-swipe-content.active {
+    will-change: transform;
+  }
+</style>

--- a/src/lib/modules/client/nav/Fab.svelte
+++ b/src/lib/modules/client/nav/Fab.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  import { haptic } from '$lib/modules/client/common';
+
+  const {
+    ariaLabel = 'Add',
+    children,
+    onclick,
+  }: {
+    ariaLabel?: string;
+    children?: Snippet;
+    onclick: () => void;
+  } = $props();
+
+  function handle(): void {
+    haptic('medium');
+    onclick();
+  }
+</script>
+
+<button class="fab" onclick={handle} aria-label={ariaLabel}>
+  {#if children}{@render children()}{:else}<span class="fab-plus">+</span>{/if}
+</button>
+
+<style>
+  .fab {
+    position: fixed;
+    right: var(--space-4);
+    bottom: calc(64px + var(--space-4) + env(safe-area-inset-bottom, 0px));
+    z-index: 90;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border: none;
+    border-radius: 50%;
+    background: var(--accent);
+    color: var(--accent-fg);
+    cursor: pointer;
+    box-shadow:
+      0 6px 20px -4px color-mix(in srgb, var(--accent) 55%, transparent),
+      0 2px 6px rgba(0, 0, 0, 0.35);
+    -webkit-tap-highlight-color: transparent;
+    transition: transform 80ms ease;
+  }
+  .fab:active {
+    transform: scale(0.92);
+  }
+  .fab-plus {
+    font-size: 30px;
+    font-weight: 300;
+    line-height: 1;
+    margin-top: -2px;
+  }
+</style>

--- a/src/lib/modules/client/nav/InfiniteScroll.svelte
+++ b/src/lib/modules/client/nav/InfiniteScroll.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  // Scroll-triggered "load more" — replaces tap-to-paginate buttons. Renders a
+  // sentinel that, when it scrolls near the viewport, invokes onLoadMore().
+  const {
+    hasMore,
+    onLoadMore,
+  }: {
+    hasMore: boolean;
+    onLoadMore: () => void;
+  } = $props();
+
+  let sentinel = $state<HTMLDivElement | undefined>();
+
+  $effect(() => {
+    const el = sentinel;
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          onLoadMore();
+        }
+      },
+      { rootMargin: '400px' }
+    );
+    io.observe(el);
+    return (): void => {
+      io.disconnect();
+    };
+  });
+</script>
+
+{#if hasMore}
+  <div bind:this={sentinel} class="infinite-sentinel" aria-hidden="true"></div>
+{/if}
+
+<style>
+  .infinite-sentinel {
+    height: 1px;
+    width: 100%;
+  }
+</style>

--- a/src/lib/modules/client/nav/NavBar.svelte
+++ b/src/lib/modules/client/nav/NavBar.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+  import ArrowLeftSvg from '$lib/assets/icons/arrow-left.svg?raw';
+  import BellSvg from '$lib/assets/icons/bell.svg?raw';
+  import SettingsSvg from '$lib/assets/icons/settings.svg?raw';
+  import { getHasNewActivity, getSystemStatus, haptic } from '$lib/modules/client/common';
+  import Glyph from '$lib/modules/client/common/Glyph.svelte';
+  import { Button, Pill } from '@juspay/svelte-ui-components';
+
+  const statusLabels: Record<string, string> = {
+    degraded: 'Degraded',
+    error: 'Offline',
+    healthy: 'Online',
+    unknown: 'Checking',
+  };
+  const statusClasses: Record<string, string> = {
+    degraded: 'pill-status-degraded',
+    error: 'pill-status-offline',
+    healthy: 'pill-status-online',
+    unknown: 'pill-status-unknown',
+  };
+  const status = $derived(getSystemStatus());
+
+  const {
+    backHref,
+    showBack,
+    title = '',
+    trailing,
+    variant = 'drilldown',
+  }: {
+    backHref?: string;
+    showBack?: boolean;
+    title?: string;
+    trailing?: Snippet;
+    variant?: 'drilldown' | 'root';
+  } = $props();
+
+  const withBack = $derived(showBack ?? variant === 'drilldown');
+  const onActivity = $derived(page.url.pathname.startsWith('/activity'));
+  const showBell = $derived(variant === 'root' && !onActivity);
+  const hasNewActivity = $derived(getHasNewActivity());
+
+  function onBack(): void {
+    haptic('light');
+    if (backHref) {
+      void goto(backHref);
+    } else if (typeof history !== 'undefined') {
+      history.back();
+    }
+  }
+
+  function onBell(): void {
+    haptic('light');
+    void goto('/activity');
+  }
+</script>
+
+<header class="navbar" class:navbar-root={variant === 'root'}>
+  <div class="navbar-inner">
+    {#if withBack}
+      <button class="navbar-back" onclick={onBack} aria-label="Back">
+        <Glyph svg={ArrowLeftSvg} size={24} />
+      </button>
+    {:else if variant === 'root'}
+      <a href="/" class="navbar-brand" aria-label="Home">
+        <img src="/app-icon.png" alt="" class="navbar-logo" width="26" height="26" />
+      </a>
+    {/if}
+    <h1 class="navbar-title" class:navbar-title-root={variant === 'root'}>{title}</h1>
+    <div class="navbar-trailing">
+      {#if trailing}{@render trailing()}{/if}
+      {#if showBell}
+        <span class="navbar-bell">
+          <Button
+            classes="btn-gear"
+            onclick={onBell}
+            ariaLabel={hasNewActivity ? 'Activity — new updates' : 'Activity'}
+          >
+            {#snippet icon()}<Glyph svg={BellSvg} size={18} />{/snippet}
+          </Button>
+          {#if hasNewActivity}
+            <span class="navbar-bell-dot" aria-hidden="true"></span>
+          {/if}
+        </span>
+      {/if}
+      {#if variant === 'root'}
+        <Pill
+          text={statusLabels[status] || 'Checking'}
+          classes={statusClasses[status] || 'pill-status-unknown'}
+        />
+        <Button
+          classes="btn-gear"
+          onclick={(): void => {
+            haptic('light');
+            void goto('/config');
+          }}
+          ariaLabel="Settings"
+        >
+          {#snippet icon()}<Glyph svg={SettingsSvg} size={18} />{/snippet}
+        </Button>
+      {/if}
+    </div>
+  </div>
+</header>
+
+<style>
+  .navbar {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: color-mix(in srgb, var(--background) 82%, transparent);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+
+  .navbar-inner {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    height: var(--header-height);
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0 var(--space-4);
+  }
+
+  .navbar-back {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    margin-left: -8px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--accent);
+    cursor: pointer;
+    border-radius: var(--radius-md);
+    -webkit-tap-highlight-color: transparent;
+    flex-shrink: 0;
+  }
+  .navbar-back:active {
+    transform: scale(0.9);
+    transition: transform 60ms ease;
+  }
+
+  .navbar-brand {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    text-decoration: none;
+  }
+  .navbar-logo {
+    display: block;
+  }
+
+  .navbar-title {
+    flex: 1;
+    min-width: 0;
+    font-size: var(--text-lg);
+    font-weight: 600;
+    letter-spacing: var(--tracking-tight);
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .navbar-title-root {
+    font-size: var(--text-xl);
+  }
+
+  .navbar-trailing {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+  }
+
+  .navbar-bell {
+    position: relative;
+    display: inline-flex;
+  }
+  .navbar-bell-dot {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--accent);
+    border: 2px solid var(--background);
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/modules/client/nav/PullToRefresh.svelte
+++ b/src/lib/modules/client/nav/PullToRefresh.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  import {
+    haptic,
+    prefersReducedMotion,
+    resistPull,
+    shouldTriggerRefresh,
+  } from '$lib/modules/client/common';
+
+  // Native-style pull-to-refresh. Wraps a page's <main>; when the user drags
+  // down while the scroll container is already at the top, an indicator slides
+  // out from under the sticky NavBar and onRefresh() fires past the threshold.
+  // It only ever preventDefault()s while actively pulling from the top, so
+  // normal scrolling is never affected.
+  const {
+    children,
+    onRefresh,
+  }: {
+    children: Snippet;
+    onRefresh: () => Promise<void> | void;
+  } = $props();
+
+  const REST = 56; // indicator height / spinner rest position while refreshing
+
+  let wrap = $state<HTMLDivElement | undefined>();
+  let pull = $state(0);
+  let refreshing = $state(false);
+  let animating = $state(false);
+
+  // Non-reactive gesture bookkeeping
+  let scroller: HTMLElement | null = null;
+  let startY = 0;
+  let active = false;
+  let firedHaptic = false;
+
+  function findScrollParent(node: HTMLElement): HTMLElement | null {
+    // Match the scroll container by its overflow style, NOT by whether it
+    // currently overflows — content may still be loading (short) at mount, but
+    // the container is the scroller by design and stays that way.
+    let el: HTMLElement | null = node.parentElement;
+    while (el) {
+      const oy = getComputedStyle(el).overflowY;
+      if (oy === 'auto' || oy === 'scroll') {
+        return el;
+      }
+      el = el.parentElement;
+    }
+    return null;
+  }
+
+  $effect(() => {
+    const el = wrap;
+    if (!el) {
+      return;
+    }
+    scroller = findScrollParent(el);
+    const listenEl: EventTarget = scroller ?? document;
+
+    function abortPull(): void {
+      active = false;
+      // A second finger / scroll mid-pull must not leave the content frozen
+      // in a translated state — snap it back.
+      if (pull !== 0 && !refreshing) {
+        animating = true;
+        pull = 0;
+      }
+    }
+
+    function onStart(event: Event): void {
+      const e = event as TouchEvent;
+      if (refreshing || e.touches.length !== 1 || !scroller || scroller.scrollTop > 0) {
+        abortPull();
+        return;
+      }
+      startY = e.touches[0].clientY;
+      active = true;
+      firedHaptic = false;
+    }
+
+    function onMove(event: Event): void {
+      const e = event as TouchEvent;
+      if (!active || refreshing || e.touches.length === 0) {
+        return;
+      }
+      if (scroller && scroller.scrollTop > 0) {
+        active = false;
+        pull = 0;
+        return;
+      }
+      const dy = e.touches[0].clientY - startY;
+      if (dy <= 0) {
+        pull = 0;
+        return;
+      }
+      // Taking over a downward pull from the top — suppress native rubber-band.
+      e.preventDefault();
+      animating = false;
+      pull = resistPull(dy);
+      if (!firedHaptic && shouldTriggerRefresh(pull)) {
+        firedHaptic = true;
+        haptic('light');
+      } else if (firedHaptic && !shouldTriggerRefresh(pull)) {
+        firedHaptic = false;
+      }
+    }
+
+    function onEnd(): void {
+      if (!active || refreshing) {
+        abortPull();
+        return;
+      }
+      active = false;
+      animating = true;
+      if (shouldTriggerRefresh(pull)) {
+        refreshing = true;
+        pull = REST;
+        haptic('medium');
+        void runRefresh();
+      } else {
+        pull = 0;
+      }
+    }
+
+    listenEl.addEventListener('touchstart', onStart, { passive: true });
+    listenEl.addEventListener('touchmove', onMove, { passive: false });
+    listenEl.addEventListener('touchend', onEnd, { passive: true });
+    listenEl.addEventListener('touchcancel', onEnd, { passive: true });
+    return (): void => {
+      listenEl.removeEventListener('touchstart', onStart);
+      listenEl.removeEventListener('touchmove', onMove);
+      listenEl.removeEventListener('touchend', onEnd);
+      listenEl.removeEventListener('touchcancel', onEnd);
+    };
+  });
+
+  async function runRefresh(): Promise<void> {
+    try {
+      await onRefresh();
+    } finally {
+      animating = true;
+      pull = 0;
+      window.setTimeout((): void => {
+        refreshing = false;
+      }, 280);
+    }
+  }
+
+  const transition = $derived(
+    animating && !prefersReducedMotion() ? 'transform 0.28s cubic-bezier(0.22, 1, 0.36, 1)' : 'none'
+  );
+  const indicatorOpacity = $derived(Math.min(pull / REST, 1));
+</script>
+
+<div
+  class="ptr"
+  bind:this={wrap}
+  style="transform: translateY({pull}px); transition: {transition}; will-change: {pull !== 0 ||
+  refreshing
+    ? 'transform'
+    : 'auto'};"
+>
+  <div class="ptr-indicator" style="opacity: {indicatorOpacity};" aria-hidden={pull === 0}>
+    <span
+      class="ptr-spinner"
+      class:spinning={refreshing}
+      style="transform: rotate({refreshing ? 0 : pull * 2.4}deg);"
+    ></span>
+  </div>
+  {@render children()}
+</div>
+
+<style>
+  .ptr {
+    position: relative;
+  }
+
+  .ptr-indicator {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 56px;
+    transform: translateY(-100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+  }
+
+  .ptr-spinner {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 2px solid var(--accent-line, rgba(245, 177, 76, 0.28));
+    border-top-color: var(--accent);
+  }
+  .ptr-spinner.spinning {
+    animation: ptr-spin 0.7s linear infinite;
+  }
+
+  @keyframes ptr-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ptr-spinner.spinning {
+      animation-duration: 1.4s;
+    }
+  }
+</style>

--- a/src/lib/modules/client/nav/SwipeToDelete.svelte
+++ b/src/lib/modules/client/nav/SwipeToDelete.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  import TrashSvg from '$lib/assets/icons/trash.svg?raw';
+  import { haptic, prefersReducedMotion, resolveMotionDuration } from '$lib/modules/client/common';
+  import Glyph from '$lib/modules/client/common/Glyph.svelte';
+
+  const {
+    actionLabel = 'Delete',
+    children,
+    onDelete,
+  }: { actionLabel?: string; children: Snippet; onDelete: () => void } = $props();
+
+  const ACTION_WIDTH = 92; // px revealed when the row snaps open
+  const OPEN_THRESHOLD = ACTION_WIDTH / 2;
+  const RIGHT_RUBBER = 8; // px of give when swiping right past closed
+
+  let rowEl: HTMLDivElement | undefined;
+  let restBase = $state(0); // committed rest offset: 0 (closed) or -ACTION_WIDTH (open)
+  let drag = $state(0); // live delta while a finger is down
+  let animating = $state(false); // enables the transform transition on release
+  let removing = $state(false); // sliding fully out before onDelete fires
+
+  // Touch bookkeeping (non-reactive — never needs to re-render)
+  let startX = 0;
+  let startY = 0;
+  let axis: '' | 'x' | 'y' = '';
+  let swiped = false; // a horizontal swipe happened → suppress the row's click
+
+  const rowWidth = $derived(rowEl?.offsetWidth ?? 320);
+  const commitThreshold = $derived(rowWidth * 0.45); // full-swipe delete distance
+
+  const translateX = $derived(
+    removing ? -rowWidth : Math.max(-rowWidth, Math.min(RIGHT_RUBBER, restBase + drag))
+  );
+  const revealed = $derived(Math.max(0, -translateX)); // how much backdrop shows
+
+  function onStart(e: TouchEvent): void {
+    if (removing || e.touches.length === 0) {
+      return;
+    }
+    startX = e.touches[0].clientX;
+    startY = e.touches[0].clientY;
+    axis = '';
+    swiped = false;
+    animating = false;
+  }
+
+  function onMove(e: TouchEvent): void {
+    if (removing || e.touches.length === 0) {
+      return;
+    }
+    const dx = e.touches[0].clientX - startX;
+    const dy = e.touches[0].clientY - startY;
+
+    if (axis === '') {
+      if (Math.abs(dx) < 8 && Math.abs(dy) < 8) {
+        return;
+      }
+      axis = Math.abs(dx) > Math.abs(dy) ? 'x' : 'y';
+    }
+    if (axis === 'y') {
+      return; // vertical → let the list scroll
+    }
+
+    e.preventDefault(); // own the horizontal gesture
+    swiped = true;
+    drag = dx;
+  }
+
+  function settle(next: number): void {
+    animating = true;
+    restBase = next;
+    drag = 0;
+  }
+
+  function commitDelete(): void {
+    haptic('warning');
+    animating = true;
+    removing = true;
+    const ms = resolveMotionDuration(200, prefersReducedMotion());
+    window.setTimeout(onDelete, ms);
+  }
+
+  function onEnd(): void {
+    if (removing || axis !== 'x') {
+      axis = '';
+      return;
+    }
+    const total = restBase + drag;
+    if (total <= -commitThreshold) {
+      drag = 0;
+      commitDelete();
+    } else if (total <= -OPEN_THRESHOLD) {
+      settle(-ACTION_WIDTH);
+    } else {
+      settle(0);
+    }
+    axis = '';
+  }
+
+  // Swallow the row's navigation when the gesture was a swipe or the row is open.
+  function onClickCapture(e: MouseEvent): void {
+    if (swiped || restBase !== 0) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (restBase !== 0) {
+        settle(0); // a tap while open just closes it
+      }
+      swiped = false;
+    }
+  }
+
+  function onDeleteTap(e: MouseEvent): void {
+    e.preventDefault();
+    e.stopPropagation();
+    commitDelete();
+  }
+
+  const transitionMs = $derived(resolveMotionDuration(220, prefersReducedMotion()));
+</script>
+
+<div class="swipe" bind:this={rowEl}>
+  <button
+    class="swipe-action"
+    style="width: {ACTION_WIDTH}px; opacity: {Math.min(1, revealed / OPEN_THRESHOLD)}"
+    aria-label={actionLabel}
+    tabindex={restBase !== 0 ? 0 : -1}
+    onclick={onDeleteTap}
+  >
+    <Glyph svg={TrashSvg} size={18} />
+    <span class="swipe-action-label">{actionLabel}</span>
+  </button>
+
+  <!-- Gesture surface; delete is also reachable via the revealed Delete button and the
+       desktop × button, so the touch handlers here are a progressive enhancement. -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="swipe-row"
+    class:animating={animating || removing}
+    style="transform: translateX({translateX}px); transition-duration: {animating || removing
+      ? transitionMs
+      : 0}ms"
+    ontouchstart={onStart}
+    ontouchmove={onMove}
+    ontouchend={onEnd}
+    ontouchcancel={onEnd}
+    onclickcapture={onClickCapture}
+    ontransitionend={(): void => {
+      animating = false;
+    }}
+  >
+    {@render children()}
+  </div>
+</div>
+
+<style>
+  .swipe {
+    position: relative;
+    overflow: hidden;
+    border-radius: var(--radius-lg);
+  }
+
+  .swipe-action {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    border: none;
+    background: var(--status-danger, var(--ds-red-700));
+    color: #fff;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .swipe-action-label {
+    line-height: 1;
+  }
+
+  .swipe-row {
+    position: relative;
+    touch-action: pan-y;
+    will-change: transform;
+    transition-property: transform;
+    transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .swipe-row.animating {
+    transition-property: transform;
+  }
+</style>

--- a/src/lib/modules/client/push/web-push.ts
+++ b/src/lib/modules/client/push/web-push.ts
@@ -1,0 +1,153 @@
+// Client-side Web Push: register the service worker, request permission,
+// subscribe with the server's VAPID public key, and hand the subscription to
+// the server. Browser-only — every entry point guards on feature support and
+// returns a typed status so the UI can explain what happened.
+
+import type { WebPushStatus } from '$lib/types';
+
+/** Unsubscribe locally and remove the subscription from the server. */
+export async function disableWebPush(apiKey: string): Promise<boolean> {
+  if (!isWebPushSupported()) {
+    return false;
+  }
+  try {
+    const reg = await navigator.serviceWorker.getRegistration();
+    const sub = reg ? await reg.pushManager.getSubscription() : null;
+    if (!sub) {
+      return true;
+    }
+    const endpoint = sub.endpoint;
+    await sub.unsubscribe();
+    await fetch('/api/web-push/subscribe', {
+      body: JSON.stringify({ endpoint }),
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      method: 'DELETE',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Register the SW, ask permission, subscribe, and POST the subscription.
+ * Idempotent: an existing subscription is re-sent (keeps the server in sync).
+ */
+export async function enableWebPush(apiKey: string): Promise<WebPushStatus> {
+  if (!isWebPushSupported()) {
+    return 'unsupported';
+  }
+
+  try {
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') {
+      return permission === 'denied' ? 'denied' : 'error';
+    }
+
+    const registration = await navigator.serviceWorker.register('/sw.js');
+    await navigator.serviceWorker.ready;
+
+    const keyRes = await fetch('/api/web-push/vapid-public-key');
+    if (!keyRes.ok) {
+      return 'error';
+    }
+    const { publicKey } = (await keyRes.json()) as { publicKey: string };
+    if (!publicKey) {
+      return 'error';
+    }
+
+    const existing = await registration.pushManager.getSubscription();
+    const subscription =
+      existing ??
+      (await registration.pushManager.subscribe({
+        applicationServerKey: urlBase64ToUint8Array(publicKey),
+        userVisibleOnly: true,
+      }));
+
+    const res = await fetch('/api/web-push/subscribe', {
+      body: JSON.stringify({
+        ...subscription.toJSON(),
+        friendlyName: navigatorLabel(),
+      }),
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+    return res.ok ? 'granted' : 'error';
+  } catch {
+    return 'error';
+  }
+}
+
+/** Current notification permission, or 'unsupported' when the API is absent. */
+export function getWebPushPermission(): 'default' | 'denied' | 'granted' | 'unsupported' {
+  if (typeof Notification === 'undefined') {
+    return 'unsupported';
+  }
+  return Notification.permission;
+}
+
+/** True when an active push subscription already exists for this browser. */
+export async function isWebPushSubscribed(): Promise<boolean> {
+  if (!isWebPushSupported()) {
+    return false;
+  }
+  try {
+    const reg = await navigator.serviceWorker.getRegistration();
+    if (!reg) {
+      return false;
+    }
+    const sub = await reg.pushManager.getSubscription();
+    return sub !== null;
+  } catch {
+    return false;
+  }
+}
+
+/** True when this browser can do service-worker push at all. */
+export function isWebPushSupported(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    typeof window !== 'undefined' &&
+    'PushManager' in window &&
+    'Notification' in window
+  );
+}
+
+/** A short human label for the subscription row (best-effort). */
+function navigatorLabel(): string {
+  if (typeof navigator === 'undefined') {
+    return 'Browser';
+  }
+  const ua = navigator.userAgent;
+  if (/iPhone|iPad|iPod/.test(ua)) {
+    return 'iOS Safari';
+  }
+  if (ua.includes('Android')) {
+    return 'Android Chrome';
+  }
+  if (ua.includes('Chrome')) {
+    return 'Chrome';
+  }
+  if (ua.includes('Safari')) {
+    return 'Safari';
+  }
+  if (ua.includes('Firefox')) {
+    return 'Firefox';
+  }
+  return 'Browser';
+}
+
+/** Decode a base64url VAPID public key into the Uint8Array the Push API wants. */
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  // Back the view with an explicit ArrayBuffer so the type is Uint8Array<ArrayBuffer>
+  // (assignable to BufferSource), not Uint8Array<ArrayBufferLike>.
+  const output = new Uint8Array(new ArrayBuffer(raw.length));
+  for (let i = 0; i < raw.length; i += 1) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}

--- a/src/lib/modules/client/terminal/ConnectionStatus.svelte
+++ b/src/lib/modules/client/terminal/ConnectionStatus.svelte
@@ -52,23 +52,71 @@
   }
 
   .conn-dot {
+    position: relative;
     width: 8px;
     height: 8px;
     border-radius: 50%;
     flex-shrink: 0;
   }
+  /* Expanding ring, shared by the live states. */
+  .conn-dot::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: 0;
+  }
 
   .conn-dot.connected {
     background: var(--ds-green-700);
+    color: var(--ds-green-700);
+  }
+  /* A slow breathing ripple so "connected" reads as alive, not just a static dot. */
+  .conn-dot.connected::after {
+    animation: conn-ripple 2.4s ease-out infinite;
   }
 
   .conn-dot.reconnecting {
     background: var(--ds-amber-700);
-    animation: pulse-dot 1.5s ease-in-out infinite;
+    color: var(--ds-amber-700);
+    animation: conn-pulse 1.2s ease-in-out infinite;
+  }
+  /* A faster, more insistent ripple while reconnecting. */
+  .conn-dot.reconnecting::after {
+    animation: conn-ripple 1.2s ease-out infinite;
   }
 
   .conn-dot.disconnected {
     background: var(--ds-red-700);
+    color: var(--ds-red-700);
+  }
+
+  @keyframes conn-ripple {
+    0% {
+      transform: scale(1);
+      opacity: 0.55;
+    }
+    100% {
+      transform: scale(2.6);
+      opacity: 0;
+    }
+  }
+  @keyframes conn-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.45;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .conn-dot.connected::after,
+    .conn-dot.reconnecting::after,
+    .conn-dot.reconnecting {
+      animation: none;
+    }
   }
 
   .status-label {

--- a/src/lib/modules/client/terminal/LaunchSheet.svelte
+++ b/src/lib/modules/client/terminal/LaunchSheet.svelte
@@ -259,10 +259,10 @@
   }
 
   :global(.btn-launch) {
-    --button-color: var(--ds-green-700);
-    --button-text-color: #fff;
-    --button-hover-color: var(--ds-green-900);
-    --button-hover-text-color: #fff;
+    --button-color: var(--accent);
+    --button-text-color: var(--accent-fg);
+    --button-hover-color: var(--accent-hover);
+    --button-hover-text-color: var(--accent-fg);
     --button-border-radius: var(--radius-lg);
     --button-height: 48px;
     --button-width: 100%;

--- a/src/lib/modules/client/terminal/QuickKeys.svelte
+++ b/src/lib/modules/client/terminal/QuickKeys.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { QuickKey, QuickKeysProps } from '$lib/types';
 
+  import { haptic } from '$lib/modules/client/common';
   import { Button } from '@juspay/svelte-ui-components';
 
   const { onKey }: QuickKeysProps = $props();
@@ -21,6 +22,7 @@
     <Button
       classes="btn-quick-key"
       onclick={(): void => {
+        haptic('light');
         onKey(k.escape);
       }}
       text={k.label}

--- a/src/lib/modules/server/apn/apns-liveactivity.ts
+++ b/src/lib/modules/server/apn/apns-liveactivity.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure builders for the APNs Live Activity (ActivityKit) push shape.
+ *
+ * Separated from library-apns.ts so the exact `aps` envelope and topic — the
+ * parts APNs is picky about — are deterministically unit-tested. ActivityKit
+ * pushes go to a topic of `<bundleId>.push-type.liveactivity` with
+ * `apns-push-type: liveactivity`, and the body carries `event`, a unix
+ * `timestamp`, and the `content-state` mirroring the Swift struct.
+ */
+
+import type { LiveActivityPushInput } from '$lib/types';
+
+/**
+ * Build the `{ aps: {...} }` body for a Live Activity push. `nowSec` is the unix
+ * timestamp (seconds) APNs requires on every ActivityKit push; it is injected
+ * so the builder stays pure and testable.
+ */
+export function buildLiveActivityBody(
+  input: LiveActivityPushInput,
+  nowSec: number
+): Record<string, unknown> {
+  const aps: Record<string, unknown> = {
+    'content-state': input.contentState,
+    event: input.event,
+    timestamp: nowSec,
+  };
+
+  if (typeof input.staleDate === 'number') {
+    aps['stale-date'] = input.staleDate;
+  }
+  if (input.event === 'end' && typeof input.dismissalDate === 'number') {
+    aps['dismissal-date'] = input.dismissalDate;
+  }
+  if (typeof input.relevanceScore === 'number') {
+    aps['relevance-score'] = input.relevanceScore;
+  }
+  if (input.alert) {
+    aps.alert = { body: input.alert.body, title: input.alert.title };
+  }
+
+  return { aps };
+}
+
+/** The APNs topic ActivityKit pushes must target. */
+export function liveActivityTopic(bundleId: string): string {
+  return `${bundleId}.push-type.liveactivity`;
+}

--- a/src/lib/modules/server/apn/library-apns.ts
+++ b/src/lib/modules/server/apn/library-apns.ts
@@ -4,6 +4,7 @@ import type {
   APNsSendResult,
   AppEnv,
   DeviceRecord,
+  LiveActivityPushInput,
   NotificationPayload,
 } from '$lib/types';
 
@@ -14,6 +15,7 @@ import { promisify } from 'util';
 
 import { toErrorMessage } from '../utils/error';
 import { summarizeApnsFanOut } from './apns-classify.js';
+import { buildLiveActivityBody, liveActivityTopic } from './apns-liveactivity.js';
 import { fitApnsPayload } from './apns-payload.js';
 
 // APNs delivery via curl. Replaces @parse/node-apn (which times out on Node 24
@@ -89,6 +91,34 @@ export class LibraryAPNsService {
     return this.configured;
   }
 
+  /**
+   * Push a Live Activity (ActivityKit) update to a single activity push token.
+   * These tokens come from the iOS app (`Activity.pushToken`), are distinct from
+   * the device token, and target the `<bundleId>.push-type.liveactivity` topic
+   * with `apns-push-type: liveactivity`. `nowSec` is injected for deterministic
+   * tests. An 'end' event tears the activity down (optionally at dismissalDate).
+   */
+  async sendLiveActivity(
+    activityPushToken: string,
+    input: LiveActivityPushInput,
+    nowSec: number = Math.floor(Date.now() / 1000)
+  ): Promise<APNsSendResult> {
+    if (!this.configured) {
+      throw new Error('APNs service not configured properly');
+    }
+    if (!activityPushToken) {
+      throw new Error('Live Activity push token is required');
+    }
+    // Updates are user-visible and timely → priority 10.
+    return this.deliver(
+      activityPushToken,
+      buildLiveActivityBody(input, nowSec),
+      'liveactivity',
+      '10',
+      liveActivityTopic(this.bundleId ?? '')
+    );
+  }
+
   async sendNotification(
     deviceToken: string,
     payload: NotificationPayload
@@ -160,7 +190,9 @@ export class LibraryAPNsService {
           'alert',
           '10',
           jwtToken,
-          collapseId
+          {
+            collapseId,
+          }
         );
         return {
           appEnv: device.appEnv,
@@ -213,13 +245,16 @@ export class LibraryAPNsService {
   private async deliver(
     deviceToken: string,
     body: Record<string, unknown>,
-    pushType: 'alert' | 'background',
-    priority: '5' | '10'
+    pushType: 'alert' | 'background' | 'liveactivity',
+    priority: '5' | '10',
+    topic?: string
   ): Promise<APNsSendResult> {
     // Cap the payload to APNs' size limit. A long agent message in alert.body otherwise blows
     // past ~4 KB → APNs 413 PayloadTooLarge (or curl E2BIG), so the notification never arrives.
     const bodyJson = JSON.stringify(fitApnsPayload(body));
-    return this.deliverPreSerialized(deviceToken, bodyJson, pushType, priority, this.getJwt());
+    return this.deliverPreSerialized(deviceToken, bodyJson, pushType, priority, this.getJwt(), {
+      topic,
+    });
   }
 
   /**
@@ -230,11 +265,12 @@ export class LibraryAPNsService {
   private async deliverPreSerialized(
     deviceToken: string,
     bodyJson: string,
-    pushType: 'alert' | 'background',
+    pushType: 'alert' | 'background' | 'liveactivity',
     priority: '5' | '10',
     jwtToken: string,
-    collapseId?: string
+    opts: { collapseId?: string; topic?: string } = {}
   ): Promise<APNsSendResult> {
+    const { collapseId, topic } = opts;
     const url = `https://${this.host}/3/device/${deviceToken}`;
 
     // collapseId can originate from caller-supplied data (data.requestId on
@@ -257,7 +293,7 @@ export class LibraryAPNsService {
       '-H',
       'content-type: application/json',
       '-H',
-      `apns-topic: ${this.bundleId}`,
+      `apns-topic: ${topic ?? this.bundleId}`,
       '-H',
       `authorization: bearer ${jwtToken}`,
       '-H',

--- a/src/lib/modules/server/apn/live-activity-store.ts
+++ b/src/lib/modules/server/apn/live-activity-store.ts
@@ -1,0 +1,86 @@
+/**
+ * Live Activity push-token store — maps a session to its current ActivityKit
+ * push token so the server can push updates by sessionId.
+ *
+ * ActivityKit rotates the push token over an activity's life, so registration is
+ * an idempotent upsert keyed by sessionId (latest token wins). Small table in the
+ * shared `~/.shooter/shooter.db`; same better-sqlite3 + globalThis-singleton idiom
+ * as the other stores. Tokens are dropped on end() or a 410 from APNs.
+ */
+
+import type { LiveActivityRecord } from '$lib/types';
+
+import Database from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { shooterDataDir } from '../utils/shooter-home.js';
+
+export class LiveActivityStore {
+  private db: Database.Database;
+
+  constructor(dataDir: string = shooterDataDir()) {
+    fs.mkdirSync(dataDir, { recursive: true });
+    this.db = new Database(path.join(dataDir, 'shooter.db'));
+    this.db.pragma('journal_mode = WAL');
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS live_activities (
+        session_id          TEXT PRIMARY KEY,
+        activity_push_token TEXT NOT NULL,
+        registered_at       TEXT NOT NULL
+      );
+    `);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  getBySession(sessionId: string): LiveActivityRecord | null {
+    const row = this.db
+      .prepare('SELECT * FROM live_activities WHERE session_id = ?')
+      .get(sessionId) as Record<string, unknown> | undefined;
+    return row
+      ? {
+          activityPushToken: row.activity_push_token as string,
+          registeredAt: row.registered_at as string,
+          sessionId: row.session_id as string,
+        }
+      : null;
+  }
+
+  remove(sessionId: string): number {
+    return this.db.prepare('DELETE FROM live_activities WHERE session_id = ?').run(sessionId)
+      .changes;
+  }
+
+  /** Drop any row holding a dead token (after a 410 from APNs). */
+  removeByToken(token: string): number {
+    return this.db.prepare('DELETE FROM live_activities WHERE activity_push_token = ?').run(token)
+      .changes;
+  }
+
+  upsert(sessionId: string, activityPushToken: string, now: Date = new Date()): LiveActivityRecord {
+    const id = sessionId.trim();
+    const token = activityPushToken.trim();
+    if (id.length === 0 || token.length === 0) {
+      throw new Error('LiveActivityStore.upsert: sessionId and token must be non-empty');
+    }
+    this.db
+      .prepare(
+        `INSERT INTO live_activities (session_id, activity_push_token, registered_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(session_id) DO UPDATE SET
+           activity_push_token = excluded.activity_push_token,
+           registered_at       = excluded.registered_at`
+      )
+      .run(id, token, now.toISOString());
+    return { activityPushToken: token, registeredAt: now.toISOString(), sessionId: id };
+  }
+}
+
+const LAS_GLOBAL_KEY = '__shooter_live_activity_store';
+export const liveActivityStore: LiveActivityStore =
+  ((globalThis as Record<string, unknown>)[LAS_GLOBAL_KEY] as LiveActivityStore) ||
+  new LiveActivityStore();
+(globalThis as Record<string, unknown>)[LAS_GLOBAL_KEY] = liveActivityStore;

--- a/src/lib/modules/server/webpush/vapid.ts
+++ b/src/lib/modules/server/webpush/vapid.ts
@@ -1,0 +1,88 @@
+/**
+ * VAPID key resolution for Web Push.
+ *
+ * Keys come from the environment (VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY /
+ * VAPID_SUBJECT) when set. Otherwise a pair is generated once and persisted to
+ * `~/.shooter/vapid.json`, so browser push works out-of-the-box with zero
+ * config and the same keys survive restarts (a rotated public key would
+ * invalidate every existing subscription).
+ */
+
+import type { VapidKeys } from '$lib/types';
+
+import * as fs from 'fs';
+import * as path from 'path';
+import webpush from 'web-push';
+
+import { shooterDataDir } from '../utils/shooter-home.js';
+
+let cached: null | VapidKeys = null;
+
+/** Resolve VAPID keys: env first, then a persisted pair, generating one if needed. */
+export function getVapidKeys(): VapidKeys {
+  if (cached) {
+    return cached;
+  }
+
+  const subject = (process.env.VAPID_SUBJECT || '').trim() || 'mailto:shooter@localhost';
+  const envPublic = (process.env.VAPID_PUBLIC_KEY || '').trim();
+  const envPrivate = (process.env.VAPID_PRIVATE_KEY || '').trim();
+  if (envPublic && envPrivate) {
+    cached = { privateKey: envPrivate, publicKey: envPublic, subject };
+    return cached;
+  }
+
+  const file = path.join(shooterDataDir(), 'vapid.json');
+  const persisted = readPersisted(file);
+  if (persisted) {
+    cached = { ...persisted, subject };
+    return cached;
+  }
+
+  const generated = webpush.generateVAPIDKeys();
+  const keys: VapidKeys = {
+    privateKey: generated.privateKey,
+    publicKey: generated.publicKey,
+    subject,
+  };
+  writePersisted(file, keys);
+  cached = keys;
+  return keys;
+}
+
+/** Reset the in-process cache (tests only). */
+export function resetVapidCache(): void {
+  cached = null;
+}
+
+function readPersisted(file: string): null | Pick<VapidKeys, 'privateKey' | 'publicKey'> {
+  try {
+    if (!fs.existsSync(file)) {
+      return null;
+    }
+    const raw: unknown = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (!raw || typeof raw !== 'object') {
+      return null;
+    }
+    const obj = raw as Record<string, unknown>;
+    if (typeof obj.publicKey === 'string' && typeof obj.privateKey === 'string') {
+      return { privateKey: obj.privateKey, publicKey: obj.publicKey };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writePersisted(file: string, keys: VapidKeys): void {
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ privateKey: keys.privateKey, publicKey: keys.publicKey }, null, 2),
+      { mode: 0o600 }
+    );
+  } catch (err) {
+    console.warn('[vapid] failed to persist keys:', err);
+  }
+}

--- a/src/lib/modules/server/webpush/web-push-service.ts
+++ b/src/lib/modules/server/webpush/web-push-service.ts
@@ -1,0 +1,92 @@
+/**
+ * Web Push transport — signs and delivers browser/PWA notifications.
+ *
+ * Mirrors the shape of fcm-service.ts (isConfigured + sendMulti) so the notify
+ * fan-out can treat it as a third delivery channel alongside APNs and FCM.
+ * Uses the `web-push` library for VAPID signing + aes128gcm payload encryption.
+ */
+
+import type { WebPushFanOutResult, WebPushPayload, WebPushSubscriptionRecord } from '$lib/types';
+
+import webpush from 'web-push';
+
+import { getVapidKeys } from './vapid.js';
+
+let vapidApplied = false;
+
+/** The VAPID public key clients need to subscribe. */
+export function getWebPushPublicKey(): string {
+  return getVapidKeys().publicKey;
+}
+
+/** Web Push is always available (keys auto-generate) — a defensive guard for callers. */
+export function isWebPushConfigured(): boolean {
+  try {
+    const keys = getVapidKeys();
+    return Boolean(keys.publicKey && keys.privateKey);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fan a notification out to every active browser subscription. HTTP 404/410
+ * from the push service means the subscription is dead → returned in
+ * `staleEndpoints` for the caller to prune.
+ */
+export async function sendWebPushMulti(
+  subscriptions: readonly WebPushSubscriptionRecord[],
+  payload: WebPushPayload
+): Promise<WebPushFanOutResult> {
+  const result: WebPushFanOutResult = {
+    failureCount: 0,
+    results: [],
+    staleEndpoints: [],
+    successCount: 0,
+  };
+  if (subscriptions.length === 0) {
+    return result;
+  }
+
+  ensureVapid();
+
+  const body = JSON.stringify({
+    body: payload.body,
+    category: payload.category,
+    data: { url: payload.url ?? '/', ...payload.data },
+    tag: payload.tag,
+    title: payload.title,
+  });
+
+  await Promise.all(
+    subscriptions.map(async (sub) => {
+      try {
+        await webpush.sendNotification(
+          { endpoint: sub.endpoint, keys: { auth: sub.auth, p256dh: sub.p256dh } },
+          body,
+          { TTL: 60 }
+        );
+        result.successCount += 1;
+        result.results.push({ endpoint: sub.endpoint, success: true });
+      } catch (err) {
+        result.failureCount += 1;
+        result.results.push({ endpoint: sub.endpoint, success: false });
+        const status = (err as { statusCode?: number }).statusCode;
+        if (status === 404 || status === 410) {
+          result.staleEndpoints.push(sub.endpoint);
+        }
+      }
+    })
+  );
+
+  return result;
+}
+
+function ensureVapid(): void {
+  if (vapidApplied) {
+    return;
+  }
+  const keys = getVapidKeys();
+  webpush.setVapidDetails(keys.subject, keys.publicKey, keys.privateKey);
+  vapidApplied = true;
+}

--- a/src/lib/modules/server/webpush/web-push-store.ts
+++ b/src/lib/modules/server/webpush/web-push-store.ts
@@ -1,0 +1,195 @@
+/**
+ * Web Push Subscription Store — SQLite registry for browser / PWA push.
+ *
+ * A separate table from device_tokens (which is APNs/FCM-only: flat opaque
+ * tokens, platform CHECK IN ('ios','android'), no key columns). A web-push
+ * subscription is structurally different — an endpoint URL plus a p256dh/auth
+ * key pair — so it gets its own `web_push_subscriptions` table in the same
+ * `~/.shooter/shooter.db`.
+ *
+ * Same better-sqlite3 + WAL + globalThis-singleton pattern as
+ * device-token-store.ts. Idempotent upsert keyed by endpoint (the browser
+ * rotates the endpoint, not the keys, on refresh), lazy stale pruning after a
+ * 404/410 from the push service, and a 30-day inactive-row cleanup.
+ */
+
+import type { WebPushSubscriptionInput, WebPushSubscriptionRecord } from '$lib/types';
+
+import Database from 'better-sqlite3';
+import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Relative import (not the `$lib` alias) so this module loads under tsx in
+// server.ts at startup, where the SvelteKit alias is unresolvable.
+import { shooterDataDir } from '../utils/shooter-home.js';
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+// Defensive upper bounds — real endpoints are ~200 chars, keys are fixed-size
+// base64url. These only reject pathological input that would bloat a row.
+export const MAX_ENDPOINT_LENGTH = 2048;
+export const MAX_KEY_LENGTH = 256;
+export const MAX_DEVICE_ID_LENGTH = 256;
+export const MAX_NAME_LENGTH = 256;
+
+export class WebPushStore {
+  private dataDir: string;
+  private db: Database.Database;
+
+  constructor(dataDir: string = shooterDataDir()) {
+    this.dataDir = dataDir;
+    fs.mkdirSync(dataDir, { recursive: true });
+
+    this.db = new Database(path.join(dataDir, 'shooter.db'));
+    this.db.pragma('journal_mode = WAL');
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS web_push_subscriptions (
+        id            TEXT PRIMARY KEY,
+        endpoint      TEXT NOT NULL UNIQUE,
+        p256dh        TEXT NOT NULL,
+        auth          TEXT NOT NULL,
+        device_id     TEXT,
+        friendly_name TEXT,
+        registered_at TEXT NOT NULL,
+        last_seen_at  TEXT NOT NULL,
+        failure_count INTEGER NOT NULL DEFAULT 0,
+        is_active     INTEGER NOT NULL DEFAULT 1
+      );
+      CREATE INDEX IF NOT EXISTS idx_web_push_active
+        ON web_push_subscriptions(is_active);
+    `);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  /** Remove a subscription by endpoint (explicit unsubscribe → hard delete). */
+  deleteByEndpoint(endpoint: string): number {
+    return this.db.prepare('DELETE FROM web_push_subscriptions WHERE endpoint = ?').run(endpoint)
+      .changes;
+  }
+
+  /** All active subscriptions, most-recently-seen first. */
+  listActive(): WebPushSubscriptionRecord[] {
+    const rows = this.db
+      .prepare(
+        'SELECT * FROM web_push_subscriptions WHERE is_active = 1 ORDER BY last_seen_at DESC'
+      )
+      .all() as Record<string, unknown>[];
+    return rows.map(rowToRecord);
+  }
+
+  /** Soft-delete dead subscriptions (lazy pruning after a 404/410 from the push service). */
+  pruneByEndpoints(endpoints: readonly string[]): number {
+    if (endpoints.length === 0) {
+      return 0;
+    }
+    const placeholders = endpoints.map(() => '?').join(', ');
+    return this.db
+      .prepare(
+        `UPDATE web_push_subscriptions SET is_active = 0 WHERE endpoint IN (${placeholders})`
+      )
+      .run(...endpoints).changes;
+  }
+
+  /** Hard-delete inactive rows whose last_seen_at is older than 30 days. */
+  startupCleanup(now: Date = new Date()): number {
+    const cutoff = new Date(now.getTime() - THIRTY_DAYS_MS).toISOString();
+    return this.db
+      .prepare('DELETE FROM web_push_subscriptions WHERE is_active = 0 AND last_seen_at < ?')
+      .run(cutoff).changes;
+  }
+
+  /** Bump last_seen_at for subscriptions that just delivered successfully. */
+  touchLastSeen(endpoints: readonly string[], now: Date = new Date()): number {
+    if (endpoints.length === 0) {
+      return 0;
+    }
+    const placeholders = endpoints.map(() => '?').join(', ');
+    return this.db
+      .prepare(
+        `UPDATE web_push_subscriptions SET last_seen_at = ? WHERE endpoint IN (${placeholders})`
+      )
+      .run(now.toISOString(), ...endpoints).changes;
+  }
+
+  /** Register or refresh a subscription, keyed by endpoint (idempotent). */
+  upsert(input: WebPushSubscriptionInput, now: Date = new Date()): WebPushSubscriptionRecord {
+    const ts = now.toISOString();
+    const endpoint = input.endpoint.trim();
+    const p256dh = input.keys.p256dh.trim();
+    const auth = input.keys.auth.trim();
+    const deviceId = input.deviceId?.trim() || null;
+    const friendlyName = input.friendlyName?.trim() || null;
+
+    if (endpoint.length === 0 || p256dh.length === 0 || auth.length === 0) {
+      throw new Error('WebPushStore.upsert: endpoint and keys must be non-empty');
+    }
+    if (endpoint.length > MAX_ENDPOINT_LENGTH) {
+      throw new Error(`WebPushStore.upsert: endpoint exceeds ${MAX_ENDPOINT_LENGTH} chars`);
+    }
+    if (p256dh.length > MAX_KEY_LENGTH || auth.length > MAX_KEY_LENGTH) {
+      throw new Error(`WebPushStore.upsert: key exceeds ${MAX_KEY_LENGTH} chars`);
+    }
+    if (deviceId !== null && deviceId.length > MAX_DEVICE_ID_LENGTH) {
+      throw new Error(`WebPushStore.upsert: deviceId exceeds ${MAX_DEVICE_ID_LENGTH} chars`);
+    }
+    if (friendlyName !== null && friendlyName.length > MAX_NAME_LENGTH) {
+      throw new Error(`WebPushStore.upsert: friendlyName exceeds ${MAX_NAME_LENGTH} chars`);
+    }
+
+    this.db
+      .prepare(
+        `INSERT INTO web_push_subscriptions
+           (id, endpoint, p256dh, auth, device_id, friendly_name,
+            registered_at, last_seen_at, failure_count, is_active)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 1)
+         ON CONFLICT(endpoint) DO UPDATE SET
+           p256dh        = excluded.p256dh,
+           auth          = excluded.auth,
+           last_seen_at  = excluded.last_seen_at,
+           failure_count = 0,
+           is_active     = 1,
+           device_id     = COALESCE(excluded.device_id, web_push_subscriptions.device_id),
+           friendly_name = COALESCE(excluded.friendly_name, web_push_subscriptions.friendly_name)`
+      )
+      .run(randomUUID(), endpoint, p256dh, auth, deviceId, friendlyName, ts, ts);
+
+    const rec = this.getByEndpoint(endpoint);
+    if (!rec) {
+      throw new Error('WebPushStore.upsert: row not found after write');
+    }
+    return rec;
+  }
+
+  private getByEndpoint(endpoint: string): null | WebPushSubscriptionRecord {
+    const row = this.db
+      .prepare('SELECT * FROM web_push_subscriptions WHERE endpoint = ?')
+      .get(endpoint) as Record<string, unknown> | undefined;
+    return row ? rowToRecord(row) : null;
+  }
+}
+
+function rowToRecord(row: Record<string, unknown>): WebPushSubscriptionRecord {
+  return {
+    auth: row.auth as string,
+    deviceId: (row.device_id as string) ?? null,
+    endpoint: row.endpoint as string,
+    failureCount: row.failure_count as number,
+    friendlyName: (row.friendly_name as string) ?? null,
+    id: row.id as string,
+    isActive: row.is_active === 1,
+    lastSeenAt: row.last_seen_at as string,
+    p256dh: row.p256dh as string,
+    registeredAt: row.registered_at as string,
+  };
+}
+
+// ── Singleton ────────────────────────────────────────────────────────
+const WPS_GLOBAL_KEY = '__shooter_web_push_store';
+export const webPushStore: WebPushStore =
+  ((globalThis as Record<string, unknown>)[WPS_GLOBAL_KEY] as WebPushStore) || new WebPushStore();
+(globalThis as Record<string, unknown>)[WPS_GLOBAL_KEY] = webPushStore;

--- a/src/lib/theme.css
+++ b/src/lib/theme.css
@@ -13,28 +13,32 @@
   --button-font-family: var(--font-sans);
   --button-font-size: var(--text-sm);
   --button-font-weight: 500;
-  --button-color: var(--ds-blue-700);
-  --button-text-color: #fff;
+  --button-color: var(--accent);
+  --button-text-color: var(--accent-fg);
   --button-padding: 8px 16px;
-  --button-border-radius: var(--radius-md);
+  --button-border-radius: var(--radius-lg);
   --button-border: 1px solid transparent;
-  --button-hover-color: var(--ds-blue-900);
-  --button-hover-text-color: #fff;
+  --button-hover-color: var(--accent-hover);
+  --button-hover-text-color: var(--accent-fg);
+  --button-active-background: var(--accent-hover);
   --button-content-gap: 8px;
+  /* Press/focus feedback read by the library Button (:active + :focus-visible on 2.87.0). */
+  --button-active-transform: scale(0.97);
+  --button-focus-visible-box-shadow: 0 0 0 2px var(--accent);
 
   /* ===== Input ===== */
   --input-background: var(--ds-gray-100);
   --input-font-family: var(--font-sans);
   --input-font-size: var(--text-base);
   --input-font-weight: 400;
-  --input-radius: var(--radius-md);
+  --input-radius: var(--radius-lg);
   --input-padding: 10px 12px;
   --input-height: 40px;
   --input-width: 100%;
   --input-margin: 0;
   --input-box-shadow: none;
   --input-border: 1px solid var(--border);
-  --input-focus-border: 1px solid var(--ds-blue-700);
+  --input-focus-border: 1px solid var(--accent);
   --input-text-color: var(--text-primary);
   --input-placeholder-color: var(--text-tertiary);
   --input-label-msg-text-color: var(--text-secondary);
@@ -47,6 +51,22 @@
   --input-info-msg-text-size: var(--text-xs);
   --input-info-msg-margin: var(--space-2) 0 0 0;
   --input-container-margin: 0 0 var(--space-5) 0;
+
+  /* ===== Card ===== */
+  --card-background: linear-gradient(135deg, rgba(20, 20, 20, 0.9) 0%, rgba(28, 28, 32, 0.9) 100%);
+  --card-border: 1px solid rgba(255, 255, 255, 0.06);
+  --card-border-radius: var(--radius-lg);
+  --card-overflow: hidden;
+  --card-header-padding: var(--space-4) var(--space-5) 0;
+  --card-header-border-bottom: none;
+  --card-title-font-size: var(--text-sm);
+  --card-title-font-weight: 500;
+  --card-title-color: var(--text-primary);
+  --card-description-font-size: var(--text-sm);
+  --card-description-color: var(--text-tertiary);
+  --card-description-opacity: 1;
+  --card-description-margin-top: var(--space-1);
+  --card-content-padding: var(--space-5);
 
   /* ===== Banner (replaces Alert) ===== */
   --banner-background: var(--ds-gray-100);
@@ -107,7 +127,7 @@
   --tabs-item-background: transparent;
   --tabs-active-color: var(--text-primary);
   --tabs-active-font-weight: 600;
-  --tabs-indicator-color: var(--ds-blue-700);
+  --tabs-indicator-color: var(--accent);
   --tabs-indicator-height: 2px;
   --tabs-hover-color: var(--text-secondary);
   --tabs-hover-background: var(--ds-gray-alpha-100);
@@ -136,7 +156,7 @@
   --select-bgcolor: var(--ds-gray-100);
   --select-font-family: var(--font-sans);
   --select-font-size: var(--text-base);
-  --select-radius: var(--radius-md);
+  --select-radius: var(--radius-lg);
   --select-box-shadow: none;
   --select-border: 1px solid var(--border);
   --select-color: var(--text-primary);
@@ -186,8 +206,8 @@
   --choicebox-gap: 12px;
   --choicebox-hover-border-color: var(--border-hover);
   --choicebox-hover-background: var(--ds-gray-200);
-  --choicebox-selected-border-color: var(--ds-blue-700);
-  --choicebox-selected-background: var(--ds-blue-100);
+  --choicebox-selected-border-color: var(--accent);
+  --choicebox-selected-background: var(--accent-dim);
   --choicebox-title-color: var(--text-primary);
   --choicebox-title-font-size: var(--text-base);
   --choicebox-title-font-weight: 500;
@@ -195,8 +215,8 @@
   --choicebox-description-color: var(--text-tertiary);
   --choicebox-description-font-size: var(--text-sm);
   --choicebox-indicator-border: 2px solid var(--ds-gray-500);
-  --choicebox-indicator-selected-color: var(--ds-blue-700);
-  --choicebox-focus-ring: 0 0 0 3px rgba(0, 112, 243, 0.2);
+  --choicebox-indicator-selected-color: var(--accent);
+  --choicebox-focus-ring: 0 0 0 3px var(--accent-line);
 
   /* ===== Toast ===== */
   --toast-font-family: var(--font-sans);
@@ -238,12 +258,12 @@
 /* Library Button has NO variant/size props. Use classes prop + CSS vars. */
 
 .btn-primary {
-  --button-color: var(--ds-gray-1000);
-  --button-text-color: var(--ds-background-100);
-  --button-border: 1px solid var(--ds-gray-1000);
-  --button-hover-color: #fff;
-  --button-hover-text-color: var(--ds-background-100);
-  --button-hover-border: 1px solid #fff;
+  --button-color: var(--accent);
+  --button-text-color: var(--accent-fg);
+  --button-border: 1px solid var(--accent);
+  --button-hover-color: var(--accent-hover);
+  --button-hover-text-color: var(--accent-fg);
+  --button-hover-border: 1px solid var(--accent-hover);
 }
 
 .btn-secondary {
@@ -714,6 +734,12 @@
   }
   100% {
     transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shimmer::after {
+    animation: none;
   }
 }
 

--- a/src/lib/types/haptics.ts
+++ b/src/lib/types/haptics.ts
@@ -1,0 +1,12 @@
+// Haptic feedback kinds for the web haptic() bridge. A string-literal union —
+// not expressible in the type-crafter YAML schema — mirrored by iOS
+// (UIImpactFeedbackGenerator/UINotificationFeedbackGenerator/UISelectionFeedbackGenerator)
+// and Android (VibrationEffect) native implementations.
+export type HapticKind =
+  | 'error'
+  | 'heavy'
+  | 'light'
+  | 'medium'
+  | 'selection'
+  | 'success'
+  | 'warning';

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -12,10 +12,11 @@ export * from './decision';
 export * from './device';
 export type * from './gemini';
 export * from './generated';
+export type * from './haptics';
+export type * from './live-activity';
 export type * from './neurolink';
 export type * from './server';
 export type * from './sessions';
-
 // Explicit re-exports to resolve conflicts between generated types and the
 // hand-written sessions.ts versions. The generated Sessions module exports
 // wrapper-class variants (CMessagePartTextPart, etc.) with `type: string`
@@ -29,6 +30,9 @@ export type {
   ToolResultPart,
   ToolUsePart,
 } from './sessions';
+
 export type * from './sos';
+export type * from './system-status';
 export type * from './terminal-client';
+export * from './webpush';
 export type * from './ws';

--- a/src/lib/types/live-activity.ts
+++ b/src/lib/types/live-activity.ts
@@ -1,0 +1,38 @@
+// iOS Live Activity (ActivityKit) push types.
+//
+// Hand-written (nested content-state shape + used by a pure builder that is
+// unit-tested). Deliberately free of Node built-ins so the barrel stays
+// client-safe. The iOS ActivityKit extension that consumes these lives under
+// ios/ (see the Live Activity integration guide) and is added in Xcode.
+
+/**
+ * The dynamic content ActivityKit renders on the Lock Screen / Dynamic Island.
+ * Must stay in sync with the Swift `ContentState` struct in the widget extension.
+ */
+export interface LiveActivityContentState {
+  detail?: string; // secondary line, e.g. the last tool or message
+  progress?: number; // 0..1, optional determinate progress
+  status: string; // e.g. "Running", "Awaiting input", "Done"
+  title: string; // e.g. the session / terminal name
+  updatedAt: string; // ISO timestamp of this update
+}
+
+/** ActivityKit push event: start a new activity, update it, or end it. */
+export type LiveActivityEvent = 'end' | 'start' | 'update';
+
+/** Everything needed to push one Live Activity update to APNs. */
+export interface LiveActivityPushInput {
+  alert?: { body: string; title: string }; // optional breakthrough alert
+  contentState: LiveActivityContentState;
+  dismissalDate?: number; // unix seconds; only meaningful for event='end'
+  event: LiveActivityEvent;
+  relevanceScore?: number; // ranking among the user's activities
+  staleDate?: number; // unix seconds after which the UI is considered stale
+}
+
+/** One stored session → activity push-token mapping. */
+export interface LiveActivityRecord {
+  activityPushToken: string;
+  registeredAt: string;
+  sessionId: string;
+}

--- a/src/lib/types/system-status.ts
+++ b/src/lib/types/system-status.ts
@@ -1,0 +1,3 @@
+// Health status of the Shooter server, surfaced by the root NavBar status pill.
+// String-literal union — hand-written (not expressible in the type-crafter YAML).
+export type SystemStatus = 'degraded' | 'error' | 'healthy' | 'unknown';

--- a/src/lib/types/webpush.ts
+++ b/src/lib/types/webpush.ts
@@ -1,0 +1,101 @@
+// Web Push (browser / PWA) subscription types.
+//
+// Hand-written (not generated from specs/types) because the subscription shape
+// is nested (endpoint + keys) and needs a runtime guard used by the HTTP route
+// and the SQLite store — the same rationale as device.ts. Deliberately free of
+// Node built-ins so the $lib/types barrel stays client-safe.
+
+/** Resolved VAPID key material for signing web-push messages. */
+export interface VapidKeys {
+  privateKey: string;
+  publicKey: string;
+  subject: string;
+}
+
+/** Outcome of one web-push delivery, before aggregation. */
+export interface WebPushDeliveryResult {
+  endpoint: string;
+  success: boolean;
+}
+
+/** Aggregate web-push fan-out result across all active subscriptions. */
+export interface WebPushFanOutResult {
+  failureCount: number;
+  results: WebPushDeliveryResult[];
+  staleEndpoints: string[];
+  successCount: number;
+}
+
+/** The notification content sent to the service worker's push handler. */
+export interface WebPushPayload {
+  body: string;
+  category?: string;
+  data?: Record<string, unknown>;
+  tag?: string;
+  title: string;
+  url?: string;
+}
+
+/** Outcome of a client-side enable attempt. */
+export type WebPushStatus =
+  | 'denied' // the user blocked notifications
+  | 'error' // registration / subscribe / network failure
+  | 'granted' // subscribed successfully
+  | 'unsupported'; // no service worker or push manager in this browser
+
+/** The browser's `PushSubscription.toJSON()` shape, plus optional device metadata. */
+export interface WebPushSubscriptionInput {
+  deviceId?: null | string;
+  endpoint: string;
+  friendlyName?: null | string;
+  keys: {
+    auth: string;
+    p256dh: string;
+  };
+}
+
+/** One stored web-push subscription row. */
+export interface WebPushSubscriptionRecord {
+  auth: string;
+  deviceId: null | string;
+  endpoint: string;
+  failureCount: number;
+  friendlyName: null | string;
+  id: string;
+  isActive: boolean;
+  lastSeenAt: string;
+  p256dh: string;
+  registeredAt: string;
+}
+
+/** Narrow unknown JSON into a WebPushSubscriptionInput (endpoint + keys present). */
+export function isWebPushSubscriptionInput(value: unknown): value is WebPushSubscriptionInput {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.endpoint !== 'string' || obj.endpoint.length === 0) {
+    return false;
+  }
+  if (!obj.keys || typeof obj.keys !== 'object') {
+    return false;
+  }
+  const keys = obj.keys as Record<string, unknown>;
+  if (typeof keys.p256dh !== 'string' || typeof keys.auth !== 'string') {
+    return false;
+  }
+  if (keys.p256dh.length === 0 || keys.auth.length === 0) {
+    return false;
+  }
+  if (obj.deviceId !== undefined && obj.deviceId !== null && typeof obj.deviceId !== 'string') {
+    return false;
+  }
+  if (
+    obj.friendlyName !== undefined &&
+    obj.friendlyName !== null &&
+    typeof obj.friendlyName !== 'string'
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,17 +4,27 @@
   import '../app.css';
   import '$lib/theme.css';
   import { browser } from '$app/environment';
-  import { goto } from '$app/navigation';
+  import { onNavigate } from '$app/navigation';
   import { page } from '$app/stores';
-  import BellSvg from '$lib/assets/icons/bell.svg?raw';
   import DashboardSvg from '$lib/assets/icons/dashboard.svg?raw';
-  import SettingsSvg from '$lib/assets/icons/settings.svg?raw';
   import TerminalSvg from '$lib/assets/icons/terminal.svg?raw';
   import ToolSvg from '$lib/assets/icons/tool.svg?raw';
-  import { Button, Icon, Pill } from '@juspay/svelte-ui-components';
+  import {
+    haptic,
+    prefersReducedMotion,
+    startActivityBadgePolling,
+    startKeyboardInsetTracking,
+    startSystemStatusPolling,
+  } from '$lib/modules/client/common';
+  import { Icon } from '@juspay/svelte-ui-components';
   import { onMount, type Snippet } from 'svelte';
 
   const { children, data }: { children: Snippet; data: LayoutData } = $props();
+
+  // Sliding tab indicator: 0 = Dashboard (+ its drill-ins), 1 = Terminals, 2 = SoS.
+  const activeTabIndex = $derived(
+    $page.url.pathname.startsWith('/terminals') ? 1 : $page.url.pathname.startsWith('/sos') ? 2 : 0
+  );
 
   // Expose AI provider flags for summarizers (they run outside SvelteKit's data flow)
   $effect(() => {
@@ -45,111 +55,77 @@
     }
   });
 
-  let systemStatus = $state<'degraded' | 'error' | 'healthy' | 'unknown'>('unknown');
-
-  const statusLabels: Record<string, string> = {
-    degraded: 'Degraded',
-    error: 'Offline',
-    healthy: 'Online',
-    unknown: 'Checking',
-  };
-  const statusClasses: Record<string, string> = {
-    degraded: 'pill-status-degraded',
-    error: 'pill-status-offline',
-    healthy: 'pill-status-online',
-    unknown: 'pill-status-unknown',
-  };
-
   onMount(() => {
-    void checkSystemStatus();
-    const interval = setInterval(() => {
-      void checkSystemStatus();
-    }, 30000);
+    const stopStatus = startSystemStatusPolling();
+    const stopBadge = startActivityBadgePolling();
+    const stopKeyboard = startKeyboardInsetTracking();
     return (): void => {
-      clearInterval(interval);
+      stopStatus();
+      stopBadge();
+      stopKeyboard();
     };
   });
 
-  async function checkSystemStatus(): Promise<void> {
-    try {
-      const response = await fetch('/api/health');
-      if (!response.ok) {
-        systemStatus = 'error';
-        return;
-      }
-      const data = (await response.json()) as { status?: string };
-      systemStatus =
-        data.status === 'healthy' || data.status === 'degraded' || data.status === 'error'
-          ? data.status
-          : 'unknown';
-    } catch {
-      systemStatus = 'error';
+  // Progressive enhancement: cross-fade/slide between routes via the View
+  // Transitions API when supported and the user has not asked for reduced
+  // motion. Falls through to SvelteKit's normal instant swap everywhere else.
+  onNavigate((navigation) => {
+    if (prefersReducedMotion() || typeof document.startViewTransition !== 'function') {
+      return;
     }
-  }
+
+    return new Promise((resolve) => {
+      document.startViewTransition(async () => {
+        resolve();
+        await navigation.complete;
+      });
+    });
+  });
 </script>
 
 <div class="app">
-  <!-- Top bar: Logo + Status + Gear -->
-  <header class="header">
-    <div class="header-content">
-      <a href="/" class="logo">
-        <img src="/app-icon.png" alt="Shooter" class="logo-icon" width="24" height="24" />
-        <span class="logo-text">Shooter</span>
-      </a>
-
-      <div class="nav-right">
-        <Pill
-          text={statusLabels[systemStatus] || 'Checking'}
-          classes={statusClasses[systemStatus] || 'pill-status-unknown'}
-        />
-        <Button
-          classes="btn-gear {$page.url.pathname === '/config' ? 'btn-gear-active' : ''}"
-          onclick={(): void => {
-            void goto('/config');
-          }}
-          ariaLabel="Settings"
-        >
-          {#snippet icon()}<Icon svg={SettingsSvg} classes="icon-18" />{/snippet}
-        </Button>
-      </div>
-    </div>
-  </header>
-
   <!-- Scrollable content area -->
   <div class="content-area">
     {@render children()}
   </div>
 
-  <!-- Bottom tab bar: Dashboard + Activity + Terminals -->
+  <!-- Bottom tab bar: Dashboard + Terminals + SoS (Activity lives in the NavBar bell) -->
   <nav class="bottom-tabs">
     <div class="bottom-tabs-inner">
+      <span class="tab-indicator" style="--active-index: {activeTabIndex}" aria-hidden="true"
+      ></span>
       <a
         href="/"
         class="tab-item"
         class:active={$page.url.pathname === '/' ||
           $page.url.pathname.startsWith('/project') ||
           $page.url.pathname.startsWith('/session')}
+        onclick={(): void => {
+          haptic('light');
+        }}
       >
         <Icon svg={DashboardSvg} classes="icon-26" />
         <span>Dashboard</span>
       </a>
       <a
-        href="/activity"
-        class="tab-item"
-        class:active={$page.url.pathname.startsWith('/activity')}
-      >
-        <Icon svg={BellSvg} classes="icon-26" />
-        <span>Activity</span>
-      </a>
-      <a
         href="/terminals"
         class="tab-item"
         class:active={$page.url.pathname.startsWith('/terminals')}
+        onclick={(): void => {
+          haptic('light');
+        }}
       >
         <Icon svg={TerminalSvg} classes="icon-26" />
         <span>Terminals</span>
       </a>
-      <a href="/sos" class="tab-item" class:active={$page.url.pathname.startsWith('/sos')}>
+      <a
+        href="/sos"
+        class="tab-item"
+        class:active={$page.url.pathname.startsWith('/sos')}
+        onclick={(): void => {
+          haptic('light');
+        }}
+      >
         <Icon svg={ToolSvg} classes="icon-26" />
         <span>SoS</span>
       </a>
@@ -158,12 +134,6 @@
 </div>
 
 <style>
-  .nav-right {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-  }
-
   :global(.btn-gear) {
     --button-color: transparent;
     --button-text-color: var(--text-muted);
@@ -176,7 +146,7 @@
     --button-hover-text-color: var(--text-primary);
   }
   :global(.btn-gear:focus-visible) {
-    outline: 2px solid var(--ds-green-700);
+    outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
   :global(.btn-gear-active) {
@@ -200,6 +170,7 @@
     padding-bottom: env(safe-area-inset-bottom, 0);
   }
   .bottom-tabs-inner {
+    position: relative;
     max-width: 600px;
     margin: 0 auto;
     padding: 6px var(--space-4) 4px;
@@ -208,6 +179,36 @@
     justify-content: space-around;
     height: 100%;
     box-sizing: border-box;
+  }
+
+  /* Sliding amber indicator that glides between the three equal-width tabs.
+     Width = one content-box third; translate steps by exactly one tab-width. */
+  .tab-indicator {
+    position: absolute;
+    top: 0;
+    left: var(--space-4);
+    width: calc((100% - 2 * var(--space-4)) / 3);
+    height: 2px;
+    pointer-events: none;
+    transform: translateX(calc(var(--active-index) * 100%));
+    transition: transform var(--transition-base, 220ms) cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .tab-indicator::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 50%;
+    width: 28px;
+    height: 100%;
+    transform: translateX(-50%);
+    border-radius: 0 0 3px 3px;
+    background: var(--accent);
+    box-shadow: 0 0 8px var(--accent-line, rgba(245, 177, 76, 0.32));
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .tab-indicator {
+      transition: none;
+    }
   }
   .tab-item {
     display: flex;
@@ -231,7 +232,7 @@
     color: var(--text-secondary);
   }
   .tab-item.active {
-    color: var(--ds-green-700);
+    color: var(--accent);
   }
   .tab-item :global(.icon) {
     flex-shrink: 0;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,8 @@
     isShooterConfig,
     setCache,
   } from '$lib/modules/client/common';
+  import Glyph from '$lib/modules/client/common/Glyph.svelte';
+  import SkeletonCard from '$lib/modules/client/common/SkeletonCard.svelte';
   import {
     AutopilotPanel,
     connect,
@@ -19,7 +21,10 @@
     disconnect,
     getCards,
   } from '$lib/modules/client/dashboard';
-  import { Banner, Button, EmptyState, Icon, Pill, Shimmer } from '@juspay/svelte-ui-components';
+  import InfiniteScroll from '$lib/modules/client/nav/InfiniteScroll.svelte';
+  import NavBar from '$lib/modules/client/nav/NavBar.svelte';
+  import PullToRefresh from '$lib/modules/client/nav/PullToRefresh.svelte';
+  import { Banner, Button, EmptyState, Icon, Pill } from '@juspay/svelte-ui-components';
   import { onDestroy, onMount } from 'svelte';
 
   const POLL_INTERVAL_MS = 10_000;
@@ -156,20 +161,16 @@
   <meta name="description" content="Active terminals and Claude Code sessions" />
 </svelte:head>
 
-<main class="main">
-  <div class="page-header">
-    <div class="page-header-content">
-      <div>
-        <h1 class="page-title">Dashboard</h1>
-        <p class="page-description">Active terminals and Claude Code sessions</p>
-      </div>
-      <div class="page-actions">
-        <Button classes="btn-secondary" onclick={forceRefresh} disabled={loading}>
-          <Icon svg={RefreshSvg} classes="icon-14" />
-          Refresh
-        </Button>
-      </div>
-    </div>
+<NavBar variant="root" title="Dashboard">
+  {#snippet trailing()}
+    <Button classes="btn-secondary" onclick={forceRefresh} disabled={loading} ariaLabel="Refresh">
+      <Glyph svg={RefreshSvg} size={14} />
+    </Button>
+  {/snippet}
+</NavBar>
+
+<PullToRefresh onRefresh={forceRefresh}>
+  <main class="main">
     {#if projects.length > 0}
       <div class="stats-bar">
         <div class="stat-chip">
@@ -188,89 +189,85 @@
         {/if}
       </div>
     {/if}
-  </div>
 
-  {#if fetchError}
-    <Banner text={fetchError} classes="banner-error" />
-  {/if}
-
-  {#if loading && projects.length === 0 && cards.length === 0}
-    <div class="loading-container">
-      {#each Array(3) as _, i (i)}
-        <Shimmer classes="shimmer-card" />
-      {/each}
-    </div>
-  {:else if !config?.apiKey}
-    <EmptyState
-      title="Configuration Required"
-      description="Set up your API credentials to start tracking sessions"
-    >
-      {#snippet icon()}<Icon svg={SettingsSvg} classes="icon-24" />{/snippet}
-      <Button classes="btn-primary" onclick={navigateToConfig} text="Configure Settings" />
-    </EmptyState>
-  {:else}
-    <AutopilotPanel />
-
-    <!-- Dashboard section: active terminal sessions -->
-    {#if cards.length > 0}
-      <div class="dashboard-section">
-        <DashboardView
-          {cards}
-          onCardClick={(card: DashboardCard): void => {
-            navigateToTerminal(card.terminalId);
-          }}
-        />
-      </div>
+    {#if fetchError}
+      <Banner text={fetchError} classes="banner-error" />
     {/if}
 
-    <!-- Sessions archive below dashboard -->
-    {#if loading && projects.length === 0}
+    {#if loading && projects.length === 0 && cards.length === 0}
       <div class="loading-container">
         {#each Array(3) as _, i (i)}
-          <Shimmer classes="shimmer-card" />
+          <SkeletonCard lines={1} />
         {/each}
       </div>
-    {:else if totalSessionCount() === 0 && cards.length === 0}
+    {:else if !config?.apiKey}
       <EmptyState
-        title="No sessions yet"
-        description="Claude Code sessions will appear here once JSONL files are found"
+        title="Configuration Required"
+        description="Set up your API credentials to start tracking sessions"
       >
-        {#snippet icon()}<Icon svg={BellSvg} classes="icon-24" />{/snippet}
+        {#snippet icon()}<Icon svg={SettingsSvg} classes="icon-24" />{/snippet}
+        <Button classes="btn-primary" onclick={navigateToConfig} text="Configure Settings" />
       </EmptyState>
-    {:else if projects.length > 0}
+    {:else}
+      <AutopilotPanel />
+
+      <!-- Dashboard section: active terminal sessions -->
       {#if cards.length > 0}
-        <h3 class="section-label">Sessions</h3>
-      {/if}
-      <div class="projects-container">
-        {#each projects as project (project.id)}
-          <a href="/project?id={project.id}" class="session-card">
-            <div class="session-card-header">
-              <div>
-                <h3 class="session-card-title">{project.name}</h3>
-                <div class="session-card-subtitle">{project.fullPath}</div>
-              </div>
-              <Pill
-                text="Last updated {formatRelativeTime(project.lastModified)}"
-                classes="pill-session-time"
-              />
-            </div>
-            <div class="session-stats">
-              <span
-                ><strong>{project.sessionCount}</strong>
-                {project.sessionCount === 1 ? 'session' : 'sessions'}</span
-              >
-            </div>
-          </a>
-        {/each}
-      </div>
-      {#if hasMore}
-        <div style="text-align: center; padding: 1rem;">
-          <Button classes="btn-secondary" onclick={loadMore} text="Load More" />
+        <div class="dashboard-section">
+          <DashboardView
+            {cards}
+            onCardClick={(card: DashboardCard): void => {
+              navigateToTerminal(card.terminalId);
+            }}
+          />
         </div>
       {/if}
+
+      <!-- Sessions archive below dashboard -->
+      {#if loading && projects.length === 0}
+        <div class="loading-container">
+          {#each Array(3) as _, i (i)}
+            <SkeletonCard lines={1} />
+          {/each}
+        </div>
+      {:else if totalSessionCount() === 0 && cards.length === 0}
+        <EmptyState
+          title="No sessions yet"
+          description="Claude Code sessions will appear here once JSONL files are found"
+        >
+          {#snippet icon()}<Icon svg={BellSvg} classes="icon-24" />{/snippet}
+        </EmptyState>
+      {:else if projects.length > 0}
+        {#if cards.length > 0}
+          <h3 class="section-label">Sessions</h3>
+        {/if}
+        <div class="projects-container">
+          {#each projects as project (project.id)}
+            <a href="/project?id={project.id}" class="session-card">
+              <div class="session-card-header">
+                <div>
+                  <h3 class="session-card-title">{project.name}</h3>
+                  <div class="session-card-subtitle">{project.fullPath}</div>
+                </div>
+                <Pill
+                  text="Last updated {formatRelativeTime(project.lastModified)}"
+                  classes="pill-session-time"
+                />
+              </div>
+              <div class="session-stats">
+                <span
+                  ><strong>{project.sessionCount}</strong>
+                  {project.sessionCount === 1 ? 'session' : 'sessions'}</span
+                >
+              </div>
+            </a>
+          {/each}
+        </div>
+        <InfiniteScroll {hasMore} onLoadMore={(): void => void loadMore()} />
+      {/if}
     {/if}
-  {/if}
-</main>
+  </main>
+</PullToRefresh>
 
 <style>
   .stats-bar {

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -2,7 +2,8 @@
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { ActivityFeed } from '$lib/modules/client/activity';
-  import { isShooterConfig } from '$lib/modules/client/common';
+  import { isShooterConfig, markActivitySeen } from '$lib/modules/client/common';
+  import NavBar from '$lib/modules/client/nav/NavBar.svelte';
   import { onMount } from 'svelte';
 
   let configured = $state(false);
@@ -11,6 +12,9 @@
     if (!browser) {
       return;
     }
+
+    // Opening the feed acknowledges current activity — clears the NavBar bell dot.
+    markActivitySeen();
 
     // Check config exists
     try {
@@ -40,19 +44,10 @@
   <meta name="description" content="Real-time activity feed" />
 </svelte:head>
 
+<NavBar variant="root" title="Activity" />
+
 <main class="main">
-  <h1 class="page-title">Activity Feed</h1>
   {#if configured}
     <ActivityFeed />
   {/if}
 </main>
-
-<style>
-  .page-title {
-    font-size: var(--text-2xl);
-    font-weight: 600;
-    letter-spacing: -0.03em;
-    color: var(--text-primary);
-    margin-bottom: var(--space-4);
-  }
-</style>

--- a/src/routes/api/live-activity/+server.ts
+++ b/src/routes/api/live-activity/+server.ts
@@ -1,0 +1,112 @@
+import type {
+  LiveActivityContentState,
+  LiveActivityEvent,
+  LiveActivityPushInput,
+} from '$lib/types';
+
+import { LibraryAPNsService } from '$lib/modules/server/apn/library-apns';
+import { liveActivityStore } from '$lib/modules/server/apn/live-activity-store';
+import { validateAuth } from '$lib/modules/server/auth';
+import { toErrorMessage } from '$lib/modules/server/utils/error';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+// Reuse a singleton APNs client (shared HTTP/2 connection), same as /api/notify.
+let apnsSingleton: LibraryAPNsService | null = null;
+function getAPNsClient(): LibraryAPNsService {
+  if (!apnsSingleton) {
+    apnsSingleton = new LibraryAPNsService();
+  }
+  return apnsSingleton;
+}
+
+const EVENTS: readonly LiveActivityEvent[] = ['end', 'start', 'update'];
+
+function isContentState(v: unknown): v is LiveActivityContentState {
+  if (!v || typeof v !== 'object') {
+    return false;
+  }
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.status === 'string' && typeof o.title === 'string' && typeof o.updatedAt === 'string'
+  );
+}
+
+/**
+ * Push one Live Activity (ActivityKit) update to a specific activity push token.
+ * The iOS app obtains the token from `Activity.pushToken` and registers it; the
+ * server (or autopilot engine) drives updates through here.
+ */
+export const POST: RequestHandler = async ({ request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+
+  try {
+    const raw: unknown = await request.json();
+    if (!raw || typeof raw !== 'object') {
+      return json({ error: 'Request body must be a JSON object' }, { status: 400 });
+    }
+    const body = raw as Record<string, unknown>;
+
+    // Target either an explicit push token or a registered session (token looked
+    // up from the store — the common path once the app has registered).
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId.trim() : '';
+    const activityPushToken =
+      typeof body.activityPushToken === 'string' && body.activityPushToken.trim()
+        ? body.activityPushToken.trim()
+        : sessionId
+          ? (liveActivityStore.getBySession(sessionId)?.activityPushToken ?? '')
+          : '';
+    if (!activityPushToken) {
+      return json(
+        { error: 'activityPushToken or a registered sessionId is required' },
+        { status: 400 }
+      );
+    }
+
+    const event = body.event as LiveActivityEvent;
+    if (!EVENTS.includes(event)) {
+      return json({ error: `event must be one of ${EVENTS.join(', ')}` }, { status: 400 });
+    }
+    if (!isContentState(body.contentState)) {
+      return json(
+        { error: 'contentState requires string title, status, and updatedAt' },
+        { status: 400 }
+      );
+    }
+
+    const apns = getAPNsClient();
+    if (!apns.isConfigured()) {
+      return json({ error: 'APNs is not configured on this server' }, { status: 503 });
+    }
+
+    const input: LiveActivityPushInput = {
+      contentState: body.contentState,
+      event,
+      ...(typeof body.staleDate === 'number' ? { staleDate: body.staleDate } : {}),
+      ...(typeof body.dismissalDate === 'number' ? { dismissalDate: body.dismissalDate } : {}),
+      ...(typeof body.relevanceScore === 'number' ? { relevanceScore: body.relevanceScore } : {}),
+      ...(body.alert &&
+      typeof body.alert === 'object' &&
+      typeof (body.alert as Record<string, unknown>).title === 'string' &&
+      typeof (body.alert as Record<string, unknown>).body === 'string'
+        ? { alert: body.alert as { body: string; title: string } }
+        : {}),
+    };
+
+    const result = await apns.sendLiveActivity(activityPushToken, input);
+
+    // Housekeeping: forget the token when the activity ends or APNs reports it
+    // gone (410), so we don't keep pushing to a dead activity.
+    if (event === 'end' || result.httpStatus === 410) {
+      liveActivityStore.removeByToken(activityPushToken);
+    }
+
+    return json({ httpStatus: result.httpStatus, success: result.success });
+  } catch (error) {
+    return json({ error: toErrorMessage(error) }, { status: 500 });
+  }
+};

--- a/src/routes/api/live-activity/register/+server.ts
+++ b/src/routes/api/live-activity/register/+server.ts
@@ -1,0 +1,48 @@
+import { liveActivityStore } from '$lib/modules/server/apn/live-activity-store';
+import { validateAuth } from '$lib/modules/server/auth';
+import { toErrorMessage } from '$lib/modules/server/utils/error';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+/** Register (or refresh) a session's ActivityKit push token from the iOS app. */
+export const POST: RequestHandler = async ({ request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  try {
+    const raw: unknown = await request.json();
+    const body = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId.trim() : '';
+    const activityPushToken =
+      typeof body.activityPushToken === 'string' ? body.activityPushToken.trim() : '';
+    if (!sessionId || !activityPushToken) {
+      return json({ error: 'sessionId and activityPushToken are required' }, { status: 400 });
+    }
+    liveActivityStore.upsert(sessionId, activityPushToken);
+    return json({ success: true });
+  } catch (error) {
+    return json({ error: toErrorMessage(error) }, { status: 500 });
+  }
+};
+
+/** Unregister a session's Live Activity (e.g. when the app ends it locally). */
+export const DELETE: RequestHandler = async ({ request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+  try {
+    const raw: unknown = await request.json();
+    const body = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId.trim() : '';
+    if (!sessionId) {
+      return json({ error: 'sessionId is required' }, { status: 400 });
+    }
+    const removed = liveActivityStore.remove(sessionId);
+    return json({ removed, success: true });
+  } catch (error) {
+    return json({ error: toErrorMessage(error) }, { status: 500 });
+  }
+};

--- a/src/routes/api/notify/+server.ts
+++ b/src/routes/api/notify/+server.ts
@@ -6,6 +6,7 @@ import type {
   NotificationData,
   OptionChoice,
   ResponseKind,
+  WebPushFanOutResult,
 } from '$lib/types';
 
 import { env } from '$env/dynamic/private';
@@ -17,6 +18,11 @@ import { validateAuth } from '$lib/modules/server/auth';
 import { isFCMConfigured, sendFCMNotificationMulti } from '$lib/modules/server/fcm/fcm-service.js';
 import { deviceTokenStore } from '$lib/modules/server/push/device-token-store';
 import { toErrorMessage } from '$lib/modules/server/utils/error';
+import {
+  isWebPushConfigured,
+  sendWebPushMulti,
+} from '$lib/modules/server/webpush/web-push-service';
+import { webPushStore } from '$lib/modules/server/webpush/web-push-store';
 import { broadcastEvent } from '$lib/modules/server/ws/server';
 import { json } from '@sveltejs/kit';
 
@@ -41,6 +47,12 @@ const EMPTY_FCM_RESULT: FCMFanOutResult = {
   failureCount: 0,
   results: [],
   staleTokens: [],
+  successCount: 0,
+};
+const EMPTY_WEB_RESULT: WebPushFanOutResult = {
+  failureCount: 0,
+  results: [],
+  staleEndpoints: [],
   successCount: 0,
 };
 
@@ -530,16 +542,44 @@ export const POST: RequestHandler = async ({ request }) => {
     // stacks) the prompt on every device, and answering on one clears it.
     const collapseId = waitForResponse ? canonicalRequestId : undefined;
 
-    const [apnsResult, fcmResult] = await Promise.all([
+    // Web Push (PWA / browser) is a third channel keyed on stored subscriptions,
+    // not a device-token override. Skip it on an override send (a one-off test
+    // targeting a single native token) so it doesn't buzz every browser too.
+    const webSubs = !override && isWebPushConfigured() ? webPushStore.listActive() : [];
+
+    const [apnsResult, fcmResult, webResult] = await Promise.all([
       iosDevices.length > 0 && apnsClient.isConfigured()
         ? apnsClient.sendToMany(iosDevices, payload, collapseId)
         : Promise.resolve(EMPTY_APNS_RESULT),
       androidTokens.length > 0 && isFCMConfigured()
         ? sendFCMNotificationMulti(androidTokens, payload)
         : Promise.resolve(EMPTY_FCM_RESULT),
+      webSubs.length > 0
+        ? sendWebPushMulti(webSubs, {
+            body: message,
+            category: payload.category,
+            data: payload.data,
+            tag: collapseId,
+            title,
+            url: typeof data?.terminalId === 'string' ? `/terminals/${data.terminalId}` : '/',
+          })
+        : Promise.resolve(EMPTY_WEB_RESULT),
     ]);
 
     const summary = summarizeNotifyDelivery(apnsResult, fcmResult);
+    // Fold the web-push channel into the aggregate delivery summary.
+    summary.sent += webResult.successCount;
+    summary.failed += webResult.failureCount;
+    summary.delivered = summary.sent > 0;
+
+    // Web subscriptions prune/touch by endpoint, in their own store.
+    if (!override && webResult.staleEndpoints.length > 0) {
+      webPushStore.pruneByEndpoints(webResult.staleEndpoints);
+    }
+    const succeededWebEndpoints = webResult.results.filter((r) => r.success).map((r) => r.endpoint);
+    if (succeededWebEndpoints.length > 0) {
+      webPushStore.touchLastSeen(succeededWebEndpoints);
+    }
 
     // Lazy prune dead tokens; bump last-seen for the ones that delivered.
     // Never prune on an override send: the override token is a one-off explicit

--- a/src/routes/api/web-push/subscribe/+server.ts
+++ b/src/routes/api/web-push/subscribe/+server.ts
@@ -1,0 +1,51 @@
+import { validateAuth } from '$lib/modules/server/auth';
+import { toErrorMessage } from '$lib/modules/server/utils/error';
+import { webPushStore } from '$lib/modules/server/webpush/web-push-store';
+import { isWebPushSubscriptionInput } from '$lib/types';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+/** Register (or refresh) a browser push subscription. */
+export const POST: RequestHandler = async ({ request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+
+  try {
+    const body: unknown = await request.json();
+    if (!isWebPushSubscriptionInput(body)) {
+      return json({ error: 'Invalid push subscription' }, { status: 400 });
+    }
+    const rec = webPushStore.upsert(body);
+    return json({ id: rec.id, success: true });
+  } catch (error) {
+    return json({ error: toErrorMessage(error) }, { status: 500 });
+  }
+};
+
+/** Remove a browser push subscription by endpoint. */
+export const DELETE: RequestHandler = async ({ request }) => {
+  const authError = validateAuth(request);
+  if (authError) {
+    return authError;
+  }
+
+  try {
+    const body: unknown = await request.json();
+    const endpoint =
+      body &&
+      typeof body === 'object' &&
+      typeof (body as Record<string, unknown>).endpoint === 'string'
+        ? ((body as Record<string, unknown>).endpoint as string)
+        : '';
+    if (!endpoint) {
+      return json({ error: 'endpoint is required' }, { status: 400 });
+    }
+    const removed = webPushStore.deleteByEndpoint(endpoint);
+    return json({ removed, success: true });
+  } catch (error) {
+    return json({ error: toErrorMessage(error) }, { status: 500 });
+  }
+};

--- a/src/routes/api/web-push/vapid-public-key/+server.ts
+++ b/src/routes/api/web-push/vapid-public-key/+server.ts
@@ -1,0 +1,10 @@
+import { getWebPushPublicKey } from '$lib/modules/server/webpush/web-push-service';
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+// The VAPID public key is, by design, public — a client needs it to subscribe.
+// No auth so the subscription flow can bootstrap before anything else.
+export const GET: RequestHandler = () => {
+  return json({ publicKey: getWebPushPublicKey() });
+};

--- a/src/routes/config/+page.svelte
+++ b/src/routes/config/+page.svelte
@@ -12,7 +12,15 @@
   import PlaySvg from '$lib/assets/icons/play.svg?raw';
   import XCircleSvg from '$lib/assets/icons/x-circle.svg?raw';
   import { hasScanner, isShooterConfig, scanQR, toErrorMessage } from '$lib/modules/client/common';
+  import NavBar from '$lib/modules/client/nav/NavBar.svelte';
   import { PROVIDERS } from '$lib/modules/client/neurolink/provider-config';
+  import {
+    disableWebPush,
+    enableWebPush,
+    getWebPushPermission,
+    isWebPushSubscribed,
+    isWebPushSupported,
+  } from '$lib/modules/client/push/web-push';
   import { Banner, Button, Card, Icon, Input, Stepper } from '@juspay/svelte-ui-components';
   import { onMount } from 'svelte';
 
@@ -35,6 +43,15 @@
   let _bridgeCheckDone = $state(false);
   let bridgeHydrated = false;
   let scanLoading = $state(false);
+
+  // Browser (Web Push) notifications — PWA/Safari/Chrome push, separate from the
+  // native iOS/Android device tokens shown under "Registered Devices".
+  let webPushSupported = $state(false);
+  let webPushPermission = $state<'default' | 'denied' | 'granted' | 'unsupported'>('default');
+  let webPushSubscribed = $state(false);
+  let webPushBusy = $state(false);
+  let webPushMsg = $state('');
+  let webPushTesting = $state(false);
 
   async function fetchQrCode(): Promise<void> {
     if (!apiKey.trim()) {
@@ -219,6 +236,7 @@
       }
       _bridgeCheckDone = true;
       void loadDevices();
+      void refreshWebPushState();
 
       // The native bridge may be injected after SvelteKit hydration.
       // Re-check periodically for a short window to catch late injection.
@@ -353,6 +371,80 @@
     }
   }
 
+  /** Read current Web Push support / permission / subscription state. */
+  async function refreshWebPushState(): Promise<void> {
+    webPushSupported = isWebPushSupported();
+    webPushPermission = getWebPushPermission();
+    webPushSubscribed = await isWebPushSubscribed();
+  }
+
+  /** Rehearse + request browser notification permission, then subscribe. */
+  async function enableBrowserPush(): Promise<void> {
+    if (!apiKey.trim()) {
+      webPushMsg = 'Save an API key first.';
+      return;
+    }
+    webPushBusy = true;
+    webPushMsg = '';
+    try {
+      const status = await enableWebPush(apiKey.trim());
+      if (status === 'granted') {
+        webPushMsg = 'Browser notifications enabled on this device.';
+      } else if (status === 'denied') {
+        webPushMsg =
+          'Notifications are blocked. Allow them for this site in your browser settings, then try again.';
+      } else if (status === 'unsupported') {
+        webPushMsg = 'This browser cannot receive push notifications.';
+      } else {
+        webPushMsg = 'Could not enable notifications. Please try again.';
+      }
+      await refreshWebPushState();
+    } finally {
+      webPushBusy = false;
+    }
+  }
+
+  /** Unsubscribe this browser from Web Push. */
+  async function disableBrowserPush(): Promise<void> {
+    webPushBusy = true;
+    webPushMsg = '';
+    try {
+      await disableWebPush(apiKey.trim());
+      webPushMsg = 'Browser notifications turned off on this device.';
+      await refreshWebPushState();
+    } finally {
+      webPushBusy = false;
+    }
+  }
+
+  /** Fire a real push through the server so the user sees it land. */
+  async function sendTestPush(): Promise<void> {
+    if (!apiKey.trim()) {
+      return;
+    }
+    webPushTesting = true;
+    webPushMsg = '';
+    try {
+      const res = await fetch('/api/notify', {
+        body: JSON.stringify({
+          data: { category: 'test', source: 'shooter-config' },
+          message: 'If you can see this, browser push is working. 🎯',
+          title: 'Shooter test push',
+        }),
+        headers: { Authorization: `Bearer ${apiKey.trim()}`, 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+      const body = (await res.json().catch(() => ({}))) as { sent?: number; success?: boolean };
+      webPushMsg = body.success
+        ? 'Test push sent — it should appear shortly.'
+        : 'Server accepted the request but no device received it. Enable notifications above first.';
+    } catch (error) {
+      webPushMsg = `Could not send test push: ${toErrorMessage(error)}`;
+    } finally {
+      webPushTesting = false;
+    }
+  }
+
   /** Load the registered-devices list from the server registry. */
   async function loadDevices(): Promise<void> {
     if (!apiKey.trim()) {
@@ -415,80 +507,144 @@
   <meta name="description" content="Configure notification system settings" />
 </svelte:head>
 
+<NavBar variant="drilldown" title="Settings" backHref="/" />
+
 <main class="main">
   <div class="settings-container">
-    <div style="margin-bottom: var(--space-4);">
-      <a href="/" class="back-link">← Back to Projects</a>
-    </div>
-    <div class="page-header">
-      <h1 class="page-title">Settings</h1>
-      <p class="page-description">Configure your API credentials and notification preferences</p>
-    </div>
-
     <div class="settings-grid">
       <section class="settings-section">
-        <Card
-          title="Server Configuration"
-          description="Configure server connection and credentials"
-        >
-          <Input
-            name="serverUrl"
-            label="Server URL"
-            bind:value={serverUrl}
-            dataType="text"
-            placeholder="https://shooter.breezehq.dev"
-            infoMessage="Base URL of your Shooter server. Apps will reload with this URL on next launch."
-          />
+        <div class="settings-group">
+          <span class="settings-caption">Server Configuration</span>
+          <span class="settings-footnote">Configure server connection and credentials</span>
+          <Card>
+            <Input
+              name="serverUrl"
+              label="Server URL"
+              bind:value={serverUrl}
+              dataType="text"
+              placeholder="https://shooter.breezehq.dev"
+              infoMessage="Base URL of your Shooter server. Apps will reload with this URL on next launch."
+            />
 
-          <Input
-            name="apiKey"
-            label="API Key"
-            bind:value={apiKey}
-            dataType="password"
-            placeholder="Enter your API key"
-            infoMessage="Required for sending notifications"
-          />
-          <p class="input-help">
-            Find this in your <code>~/.shooter/.env</code> file. Run <code>shooter setup</code> to generate
-            one.
-          </p>
-        </Card>
-
-        <Card title="Registered Devices" description="Phones that receive push notifications">
-          {#if loadingDevices}
-            <p class="input-help">Loading…</p>
-          {:else if loadDevicesError}
-            <p class="input-help" style="color: var(--color-error, #f87171);">{loadDevicesError}</p>
-          {:else if registeredDevices.length === 0}
+            <Input
+              name="apiKey"
+              label="API Key"
+              bind:value={apiKey}
+              dataType="password"
+              placeholder="Enter your API key"
+              infoMessage="Required for sending notifications"
+            />
             <p class="input-help">
-              No devices registered yet. Open the Shooter app on your phone with this server's URL +
-              API key — it registers automatically. Every notification fans out to all devices here.
+              Find this in your <code>~/.shooter/.env</code> file. Run <code>shooter setup</code> to generate
+              one.
             </p>
-          {:else}
-            <ul class="device-list">
-              {#each registeredDevices as device (device.id)}
-                <li class="device-row">
-                  <div class="device-meta">
-                    <span class="device-name">
-                      {device.friendlyName || device.deviceId || 'Unknown device'}
-                      {#if device.deviceId && device.deviceId === thisDeviceId}
-                        <span class="device-badge">this device</span>
-                      {/if}
-                    </span>
-                    <span class="device-sub"
-                      >{device.platform} · {device.appEnv} · {device.tokenMasked}</span
-                    >
-                  </div>
+          </Card>
+        </div>
+
+        <div class="settings-group">
+          <span class="settings-caption">Registered Devices</span>
+          <span class="settings-footnote">Phones that receive push notifications</span>
+          <Card>
+            {#if loadingDevices}
+              <p class="input-help">Loading…</p>
+            {:else if loadDevicesError}
+              <p class="input-help" style="color: var(--color-error, #f87171);">
+                {loadDevicesError}
+              </p>
+            {:else if registeredDevices.length === 0}
+              <p class="input-help">
+                No devices registered yet. Open the Shooter app on your phone with this server's URL
+                + API key — it registers automatically. Every notification fans out to all devices
+                here.
+              </p>
+            {:else}
+              <ul class="device-list">
+                {#each registeredDevices as device (device.id)}
+                  <li class="device-row">
+                    <div class="device-meta">
+                      <span class="device-name">
+                        {device.friendlyName || device.deviceId || 'Unknown device'}
+                        {#if device.deviceId && device.deviceId === thisDeviceId}
+                          <span class="device-badge">this device</span>
+                        {/if}
+                      </span>
+                      <span class="device-sub"
+                        >{device.platform} · {device.appEnv} · {device.tokenMasked}</span
+                      >
+                    </div>
+                    <Button
+                      classes="btn-secondary"
+                      onclick={(): void => void removeDevice(device.id)}
+                      text="Remove"
+                    />
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+          </Card>
+        </div>
+
+        <div class="settings-group">
+          <span class="settings-caption">Browser Notifications</span>
+          <span class="settings-footnote">
+            Push notifications to this browser or installed PWA — no app store needed
+          </span>
+          <Card>
+            {#if !webPushSupported}
+              <p class="input-help">
+                This browser doesn't support push notifications. On iOS, add Shooter to your Home
+                Screen first, then enable them from the installed app.
+              </p>
+            {:else}
+              <div class="webpush-row">
+                <div class="webpush-status">
+                  <span
+                    class="webpush-dot"
+                    class:on={webPushSubscribed && webPushPermission === 'granted'}
+                    class:blocked={webPushPermission === 'denied'}
+                  ></span>
+                  <span class="webpush-state">
+                    {#if webPushPermission === 'denied'}
+                      Blocked in browser settings
+                    {:else if webPushSubscribed && webPushPermission === 'granted'}
+                      Enabled on this device
+                    {:else}
+                      Not enabled on this device
+                    {/if}
+                  </span>
+                </div>
+                {#if webPushSubscribed && webPushPermission === 'granted'}
                   <Button
                     classes="btn-secondary"
-                    onclick={(): void => void removeDevice(device.id)}
-                    text="Remove"
+                    onclick={disableBrowserPush}
+                    disabled={webPushBusy}
+                    text="Turn off"
                   />
-                </li>
-              {/each}
-            </ul>
-          {/if}
-        </Card>
+                {:else}
+                  <Button
+                    classes="btn-primary"
+                    onclick={enableBrowserPush}
+                    disabled={webPushBusy || webPushPermission === 'denied' || !apiKey.trim()}
+                    showLoader={webPushBusy}
+                    text="Enable"
+                  />
+                {/if}
+              </div>
+              {#if webPushSubscribed && webPushPermission === 'granted'}
+                <Button
+                  classes="btn-secondary btn-block"
+                  onclick={sendTestPush}
+                  disabled={webPushTesting}
+                  showLoader={webPushTesting}
+                  text="Send test push"
+                />
+              {/if}
+              {#if webPushMsg}
+                <p class="input-help webpush-msg">{webPushMsg}</p>
+              {/if}
+            {/if}
+          </Card>
+        </div>
 
         {#if result}
           {@const bannerSvg =
@@ -526,110 +682,123 @@
       </section>
 
       <aside class="settings-sidebar">
-        <Card title="Setup Guide">
-          <Stepper
-            steps={[
-              { label: 'Get API Key' },
-              { label: 'Register a Device' },
-              { label: 'Test Connection' },
-            ]}
-            currentStepIndex={apiKey.trim() && registeredDevices.length > 0
-              ? 2
-              : apiKey.trim()
-                ? 1
-                : 0}
-            classes="setup-stepper"
-          />
-        </Card>
+        <div class="settings-group">
+          <span class="settings-caption">Setup Guide</span>
+          <Card>
+            <Stepper
+              steps={[
+                { label: 'Get API Key' },
+                { label: 'Register a Device' },
+                { label: 'Test Connection' },
+              ]}
+              currentStepIndex={apiKey.trim() && registeredDevices.length > 0
+                ? 2
+                : apiKey.trim()
+                  ? 1
+                  : 0}
+              classes="setup-stepper"
+            />
+          </Card>
+        </div>
 
-        <Card
-          title="Mobile App Setup"
-          description={canScan ? 'Scan a QR code to connect' : 'Scan to connect your mobile app'}
-        >
-          <div class="qr-section">
-            {#if canScan}
-              <p class="qr-description">
-                Scan the QR code shown on your server's settings page to auto-configure the
-                connection.
-              </p>
-              <Button
-                classes="btn-secondary btn-sm"
-                onclick={handleScanQR}
-                disabled={scanLoading}
-                text={scanLoading ? 'Scanning...' : 'Scan QR Code'}
-              />
-            {:else}
-              {#if qrDataUrl}
-                <div class="qr-container">
-                  <img src={qrDataUrl} alt="QR code for mobile app pairing" class="qr-image" />
-                </div>
-                <p class="qr-hint">
-                  Scan this QR code with the Shooter iOS or Android app to connect.
+        <div class="settings-group">
+          <span class="settings-caption">Mobile App Setup</span>
+          <span class="settings-footnote"
+            >{canScan ? 'Scan a QR code to connect' : 'Scan to connect your mobile app'}</span
+          >
+          <Card>
+            <div class="qr-section">
+              {#if canScan}
+                <p class="qr-description">
+                  Scan the QR code shown on your server's settings page to auto-configure the
+                  connection.
                 </p>
-                {#if qrServerUrl}
-                  <p class="qr-server-url">
-                    Server: <code>{qrServerUrl}</code>
+                <Button
+                  classes="btn-secondary btn-sm"
+                  onclick={handleScanQR}
+                  disabled={scanLoading}
+                  text={scanLoading ? 'Scanning...' : 'Scan QR Code'}
+                />
+              {:else}
+                {#if qrDataUrl}
+                  <div class="qr-container">
+                    <img src={qrDataUrl} alt="QR code for mobile app pairing" class="qr-image" />
+                  </div>
+                  <p class="qr-hint">
+                    Scan this QR code with the Shooter iOS or Android app to connect.
+                  </p>
+                  {#if qrServerUrl}
+                    <p class="qr-server-url">
+                      Server: <code>{qrServerUrl}</code>
+                    </p>
+                  {/if}
+                {:else if qrLoading}
+                  <div class="qr-placeholder">
+                    <p class="qr-loading-text">Generating QR code...</p>
+                  </div>
+                {:else if qrError}
+                  <p class="qr-error">{qrError}</p>
+                {:else}
+                  <p class="qr-description">
+                    Generate a QR code containing your server URL and API key. Your mobile app can
+                    scan it to auto-configure the connection.
                   </p>
                 {/if}
-              {:else if qrLoading}
-                <div class="qr-placeholder">
-                  <p class="qr-loading-text">Generating QR code...</p>
+                <Button
+                  classes="btn-secondary btn-sm"
+                  onclick={fetchQrCode}
+                  disabled={qrLoading || !apiKey.trim()}
+                  text={qrDataUrl ? 'Regenerate QR Code' : 'Generate QR Code'}
+                />
+              {/if}
+            </div>
+          </Card>
+        </div>
+
+        <div class="settings-group">
+          <span class="settings-caption">AI Providers</span>
+          <span class="settings-footnote">NeuroLink-powered summaries and AI features</span>
+          <Card>
+            <div class="ai-providers">
+              {#each PROVIDERS as provider (provider.id)}
+                <div class="provider-row">
+                  <Icon
+                    svg={data.aiProviders[provider.id] ? CheckCircleSvg : XCircleSvg}
+                    classes="icon-14"
+                  />
+                  <span class="provider-label">{provider.label}</span>
+                  <span class="provider-status" class:configured={data.aiProviders[provider.id]}>
+                    {data.aiProviders[provider.id] ? 'configured' : 'not configured'}
+                  </span>
                 </div>
-              {:else if qrError}
-                <p class="qr-error">{qrError}</p>
+              {/each}
+
+              {#if data.activeProvider}
+                <div class="active-provider">
+                  Active: <strong>{data.activeProvider}</strong>
+                </div>
+              {:else if Object.values(data.aiProviders).some(Boolean)}
+                <div class="active-provider">Auto-detected from configured keys</div>
               {:else}
-                <p class="qr-description">
-                  Generate a QR code containing your server URL and API key. Your mobile app can
-                  scan it to auto-configure the connection.
+                <p class="ai-help">
+                  Run <code>shooter setup</code> to configure AI providers for summaries.
                 </p>
               {/if}
-              <Button
-                classes="btn-secondary btn-sm"
-                onclick={fetchQrCode}
-                disabled={qrLoading || !apiKey.trim()}
-                text={qrDataUrl ? 'Regenerate QR Code' : 'Generate QR Code'}
-              />
-            {/if}
-          </div>
-        </Card>
+            </div>
+          </Card>
+        </div>
 
-        <Card title="AI Providers" description="NeuroLink-powered summaries and AI features">
-          <div class="ai-providers">
-            {#each PROVIDERS as provider (provider.id)}
-              <div class="provider-row">
-                <Icon
-                  svg={data.aiProviders[provider.id] ? CheckCircleSvg : XCircleSvg}
-                  classes="icon-14"
-                />
-                <span class="provider-label">{provider.label}</span>
-                <span class="provider-status" class:configured={data.aiProviders[provider.id]}>
-                  {data.aiProviders[provider.id] ? 'configured' : 'not configured'}
-                </span>
-              </div>
-            {/each}
-
-            {#if data.activeProvider}
-              <div class="active-provider">
-                Active: <strong>{data.activeProvider}</strong>
-              </div>
-            {:else if Object.values(data.aiProviders).some(Boolean)}
-              <div class="active-provider">Auto-detected from configured keys</div>
-            {:else}
-              <p class="ai-help">
-                Run <code>shooter setup</code> to configure AI providers for summaries.
-              </p>
-            {/if}
-          </div>
-        </Card>
-
-        <Card title="Danger Zone">
-          <p class="danger-description">Clear all saved configuration data from this device.</p>
-          <Button
-            classes="btn-danger btn-sm"
-            onclick={clearConfiguration}
-            text="Clear Configuration"
-          />
-        </Card>
+        <div class="settings-group settings-danger">
+          <span class="settings-caption">Danger Zone</span>
+          <Card>
+            <p class="danger-description">Clear all saved configuration data from this device.</p>
+            <Button
+              classes="btn-danger btn-sm"
+              onclick={clearConfiguration}
+              text="Clear Configuration"
+            />
+          </Card>
+        </div>
       </aside>
     </div>
   </div>
@@ -659,6 +828,29 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-4);
+  }
+
+  /* iOS-style grouped inset list: a short uppercase caption + muted footnote
+     sit above each content-only card (the rounded inset container). */
+  .settings-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+  .settings-caption {
+    font-size: var(--text-xs, 12px);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+    padding-left: var(--space-3);
+  }
+  .settings-footnote {
+    font-size: var(--text-xs, 12px);
+    color: var(--text-tertiary);
+    line-height: var(--leading-relaxed, 1.5);
+    padding-left: var(--space-3);
+    margin-top: calc(-1 * var(--space-1));
   }
 
   .button-group {
@@ -761,7 +953,7 @@
     line-height: var(--leading-relaxed);
   }
 
-  .settings-sidebar :global(.card):last-child {
+  .settings-danger :global(.card) {
     border-color: color-mix(in srgb, var(--ds-red-700) 30%, transparent);
   }
 
@@ -871,6 +1063,48 @@
     font-size: var(--text-xs);
     color: var(--text-tertiary);
     font-family: var(--font-mono);
+  }
+
+  .webpush-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+  .webpush-status {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+  .webpush-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--text-tertiary);
+    flex-shrink: 0;
+  }
+  .webpush-dot.on {
+    background: var(--status-live, var(--ds-green-700));
+    box-shadow: 0 0 6px var(--status-live, var(--ds-green-700));
+  }
+  .webpush-dot.blocked {
+    background: var(--status-danger, var(--ds-red-700));
+  }
+  .webpush-state {
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+  }
+  .webpush-msg {
+    margin-top: var(--space-3);
+  }
+  :global(.btn-block) {
+    width: 100%;
+    margin-top: var(--space-3);
+  }
+  :global(.btn-block .button-container),
+  :global(.btn-block button) {
+    width: 100%;
   }
 
   @media (max-width: 768px) {

--- a/src/routes/neurolink/+page.svelte
+++ b/src/routes/neurolink/+page.svelte
@@ -323,7 +323,6 @@
     --input-font-family: var(--font-mono);
     --input-background: var(--component-bg);
     --input-border: 1px solid var(--border-hover);
-    --input-focus-border: 1px solid var(--ds-blue-700);
     --input-container-margin: 0;
   }
 </style>

--- a/src/routes/project/+page.svelte
+++ b/src/routes/project/+page.svelte
@@ -15,7 +15,13 @@
     sourceLabel,
     sourceToCommand,
   } from '$lib/modules/client/common';
-  import { Banner, Button, EmptyState, Icon, Pill, Shimmer } from '@juspay/svelte-ui-components';
+  import Glyph from '$lib/modules/client/common/Glyph.svelte';
+  import SkeletonCard from '$lib/modules/client/common/SkeletonCard.svelte';
+  import EdgeSwipeBack from '$lib/modules/client/nav/EdgeSwipeBack.svelte';
+  import InfiniteScroll from '$lib/modules/client/nav/InfiniteScroll.svelte';
+  import NavBar from '$lib/modules/client/nav/NavBar.svelte';
+  import PullToRefresh from '$lib/modules/client/nav/PullToRefresh.svelte';
+  import { Banner, Button, EmptyState, Icon, Pill } from '@juspay/svelte-ui-components';
   import { onDestroy, onMount } from 'svelte';
 
   const POLL_INTERVAL_MS = 15_000;
@@ -229,123 +235,112 @@
   <meta name="description" content="Project sessions sorted by latest update" />
 </svelte:head>
 
-<main class="main">
-  {#if fetchError}
-    <Banner text={fetchError} classes="banner-error" />
-  {/if}
-
-  {#if loading && !project}
-    <div class="loading-container">
-      <Shimmer classes="shimmer-header" />
-      {#each Array(4) as _, i (i)}
-        <Shimmer classes="shimmer-card" />
-      {/each}
-    </div>
-  {:else if !project}
-    <div class="project-back-row">
-      <a href="/" class="back-link">
-        <span class="back-arrow">&larr;</span>
-        Back to Projects
-      </a>
-    </div>
-    <EmptyState title="Project Not Found" description="The requested project could not be found.">
-      {#snippet icon()}<Icon svg={AlertTriangleSvg} classes="icon-24" />{/snippet}
-    </EmptyState>
-  {:else}
-    <div class="chat-session-header">
-      <div class="chat-session-header-top">
-        <a href="/" class="back-link">&#8592; Back to Projects</a>
-        <Button classes="btn-secondary" onclick={forceRefresh} disabled={loading}>
-          <Icon svg={RefreshSvg} classes="icon-14" />
-          Refresh
+<EdgeSwipeBack backHref="/">
+  <NavBar variant="drilldown" title={project?.name ?? 'Project'} backHref="/">
+    {#snippet trailing()}
+      {#if project}
+        <Button
+          classes="btn-secondary"
+          onclick={forceRefresh}
+          disabled={loading}
+          ariaLabel="Refresh"
+        >
+          <Glyph svg={RefreshSvg} size={14} />
         </Button>
-      </div>
-      <h1 class="chat-session-title">{project.name}</h1>
-      <div class="chat-session-meta">
-        <span class="session-card-subtitle">{project.fullPath}</span>
-        <span>{project.sessionCount} sessions</span>
-      </div>
-    </div>
-
-    {#if project.sessions.length === 0}
-      <EmptyState title="No sessions yet" description="Sessions for this project will appear here">
-        {#snippet icon()}<Icon svg={BellSvg} classes="icon-24" />{/snippet}
-      </EmptyState>
-    {:else}
-      <div class="sessions-container">
-        {#each visibleSessions as session (session.id)}
-          <a href="/session/{session.id}?project={projectId}" class="session-card">
-            <div class="session-card-header">
-              <div>
-                <h3 class="session-card-title">{session.title}</h3>
-                {#if session.summary}
-                  <div class="session-card-subtitle">{truncate(session.summary, 80)}</div>
-                {/if}
-              </div>
-              <div class="session-card-actions">
-                <Pill text={formatRelativeTime(session.modified)} classes="pill-session-time" />
-                {#if runningSessionIds.has(session.id)}
-                  <Button
-                    classes="btn-connect btn-xs"
-                    onclick={(e: MouseEvent): void =>
-                      void connectToSession(e, session.id, sourceToCommand(session.source))}
-                    disabled={connectingSessionId === session.id}
-                    showLoader={connectingSessionId === session.id}
-                  >
-                    <span class="connect-dot"></span>
-                    Connect
-                  </Button>
-                {:else}
-                  <Button
-                    classes="btn-resume btn-xs"
-                    onclick={(e: MouseEvent): void =>
-                      void connectToSession(e, session.id, sourceToCommand(session.source))}
-                    disabled={connectingSessionId === session.id}
-                    showLoader={connectingSessionId === session.id}
-                    text="Resume"
-                  />
-                {/if}
-              </div>
-            </div>
-            <div class="session-stats">
-              <span><strong>{session.messageCount}</strong> messages</span>
-              {#if session.gitBranch}
-                <Pill text="🌿 {session.gitBranch}" classes="pill-git-branch" />
-              {/if}
-              <Pill text={sourceLabel(session.source)} classes="pill-source-{session.source}" />
-            </div>
-            <div class="session-meta-row">
-              <span class="session-modified">Last updated {formatDate(session.modified)}</span>
-              <span class="session-duration">Created {formatDate(session.created)}</span>
-            </div>
-          </a>
-        {/each}
-      </div>
-      {#if hasMore}
-        <div style="text-align: center; padding: 1rem;">
-          <Button
-            classes="btn-secondary"
-            onclick={loadMore}
-            text={`Load More (${project.sessions.length - visibleCount} remaining)`}
-          />
-        </div>
       {/if}
-    {/if}
-  {/if}
-</main>
+    {/snippet}
+  </NavBar>
+
+  <PullToRefresh onRefresh={forceRefresh}>
+    <main class="main">
+      {#if fetchError}
+        <Banner text={fetchError} classes="banner-error" />
+      {/if}
+
+      {#if loading && !project}
+        <div class="loading-container">
+          {#each Array(4) as _, i (i)}
+            <SkeletonCard lines={2} />
+          {/each}
+        </div>
+      {:else if !project}
+        <EmptyState
+          title="Project Not Found"
+          description="The requested project could not be found."
+        >
+          {#snippet icon()}<Icon svg={AlertTriangleSvg} classes="icon-24" />{/snippet}
+        </EmptyState>
+      {:else}
+        <div class="chat-session-meta">
+          <span class="session-card-subtitle">{project.fullPath}</span>
+          <span>{project.sessionCount} sessions</span>
+        </div>
+
+        {#if project.sessions.length === 0}
+          <EmptyState
+            title="No sessions yet"
+            description="Sessions for this project will appear here"
+          >
+            {#snippet icon()}<Icon svg={BellSvg} classes="icon-24" />{/snippet}
+          </EmptyState>
+        {:else}
+          <div class="sessions-container">
+            {#each visibleSessions as session (session.id)}
+              <a href="/session/{session.id}?project={projectId}" class="session-card">
+                <div class="session-card-header">
+                  <div>
+                    <h3 class="session-card-title">{session.title}</h3>
+                    {#if session.summary}
+                      <div class="session-card-subtitle">{truncate(session.summary, 80)}</div>
+                    {/if}
+                  </div>
+                  <div class="session-card-actions">
+                    <Pill text={formatRelativeTime(session.modified)} classes="pill-session-time" />
+                    {#if runningSessionIds.has(session.id)}
+                      <Button
+                        classes="btn-connect btn-xs"
+                        onclick={(e: MouseEvent): void =>
+                          void connectToSession(e, session.id, sourceToCommand(session.source))}
+                        disabled={connectingSessionId === session.id}
+                        showLoader={connectingSessionId === session.id}
+                      >
+                        <span class="connect-dot"></span>
+                        Connect
+                      </Button>
+                    {:else}
+                      <Button
+                        classes="btn-resume btn-xs"
+                        onclick={(e: MouseEvent): void =>
+                          void connectToSession(e, session.id, sourceToCommand(session.source))}
+                        disabled={connectingSessionId === session.id}
+                        showLoader={connectingSessionId === session.id}
+                        text="Resume"
+                      />
+                    {/if}
+                  </div>
+                </div>
+                <div class="session-stats">
+                  <span><strong>{session.messageCount}</strong> messages</span>
+                  {#if session.gitBranch}
+                    <Pill text="🌿 {session.gitBranch}" classes="pill-git-branch" />
+                  {/if}
+                  <Pill text={sourceLabel(session.source)} classes="pill-source-{session.source}" />
+                </div>
+                <div class="session-meta-row">
+                  <span class="session-modified">Last updated {formatDate(session.modified)}</span>
+                  <span class="session-duration">Created {formatDate(session.created)}</span>
+                </div>
+              </a>
+            {/each}
+          </div>
+          <InfiniteScroll {hasMore} onLoadMore={loadMore} />
+        {/if}
+      {/if}
+    </main>
+  </PullToRefresh>
+</EdgeSwipeBack>
 
 <style>
-  .project-back-row {
-    margin-bottom: var(--space-5);
-  }
-
-  .chat-session-header-top {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: var(--space-2);
-  }
-
   .sessions-container {
     display: flex;
     flex-direction: column;
@@ -383,12 +378,6 @@
   }
 
   @media (max-width: 480px) {
-    .chat-session-header-top {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--space-2);
-    }
-
     .session-card-actions {
       flex-wrap: wrap;
     }

--- a/src/routes/session/[id]/+page.svelte
+++ b/src/routes/session/[id]/+page.svelte
@@ -11,6 +11,8 @@
   import { browser } from '$app/environment';
   import { page } from '$app/state';
   import { getCached, setCache, sourceToCommand } from '$lib/modules/client/common';
+  import EdgeSwipeBack from '$lib/modules/client/nav/EdgeSwipeBack.svelte';
+  import NavBar from '$lib/modules/client/nav/NavBar.svelte';
   import ChatView from '$lib/modules/client/terminal/ChatView.svelte';
   import { Button } from '@juspay/svelte-ui-components';
   import { onMount } from 'svelte';
@@ -558,64 +560,67 @@
   <meta name="description" content="Session conversation view" />
 </svelte:head>
 
-<main class="main session-page-main">
-  {#if loading && messages.length === 0}
-    <div class="loading-container" aria-live="polite" aria-busy="true">
-      <div class="shimmer shimmer-header" aria-hidden="true"></div>
-      <div class="chat-container">
-        <div class="shimmer shimmer-bubble shimmer-bubble-user" aria-hidden="true"></div>
-        <div class="shimmer shimmer-bubble shimmer-bubble-assistant" aria-hidden="true"></div>
-        <div class="shimmer shimmer-bubble shimmer-bubble-user-short" aria-hidden="true"></div>
-        <div class="shimmer shimmer-bubble shimmer-bubble-assistant-wide" aria-hidden="true"></div>
-      </div>
-    </div>
-  {:else if error}
-    <div class="session-back-row">
-      <a href={projectId ? `/project?id=${projectId}` : '/'} class="back-link">← Back</a>
-    </div>
-    <p class="error-text">{error}</p>
-  {:else if session}
-    <!-- Compact header -->
-    <div class="session-header">
-      <div class="session-header-row">
-        <a href={projectId ? `/project?id=${projectId}` : '/'} class="back-link">← Back</a>
-        {#if sendStatus === 'connecting'}
-          <span class="resume-status">Connecting...</span>
-        {:else if sendStatus === 'resuming'}
-          <span class="resume-status">Resuming session...</span>
-        {:else if chatConnectionState === 'connected'}
-          <span class="connection-dot connected"></span>
-        {:else if chatConnectionState === 'reconnecting'}
-          <span class="connection-dot reconnecting"></span>
-        {/if}
-      </div>
-      <h1 class="session-title">{session.title}</h1>
-    </div>
-
-    <!-- Chat -->
-    <div class="session-chat-container">
-      {#if hasMoreMessages}
-        <div class="load-earlier-row">
-          <Button
-            text={loadingMore ? 'Loading...' : 'Load earlier messages'}
-            classes="btn-ghost btn-sm"
-            disabled={loadingMore}
-            onclick={loadEarlierMessages}
-          />
-        </div>
+<EdgeSwipeBack backHref={projectId ? `/project?id=${projectId}` : '/'}>
+  <NavBar
+    variant="drilldown"
+    title={session?.title ?? 'Session'}
+    backHref={projectId ? `/project?id=${projectId}` : '/'}
+  >
+    {#snippet trailing()}
+      {#if sendStatus === 'connecting'}
+        <span class="resume-status">Connecting...</span>
+      {:else if sendStatus === 'resuming'}
+        <span class="resume-status">Resuming session...</span>
+      {:else if chatConnectionState === 'connected'}
+        <span class="connection-dot connected"></span>
+      {:else if chatConnectionState === 'reconnecting'}
+        <span class="connection-dot reconnecting"></span>
       {/if}
-      <ChatView
-        messages={[...messages].reverse()}
-        newestFirst={true}
-        connectionState={chatConnectionState}
-        showInput={true}
-        {sendDisabled}
-        onSendInput={sendMessage}
-        sessionEnded={false}
-      />
-    </div>
-  {/if}
-</main>
+    {/snippet}
+  </NavBar>
+
+  <main class="main session-page-main">
+    {#if loading && messages.length === 0}
+      <div class="loading-container" aria-live="polite" aria-busy="true">
+        <div class="shimmer shimmer-header" aria-hidden="true"></div>
+        <div class="chat-container">
+          <div class="shimmer shimmer-bubble shimmer-bubble-user" aria-hidden="true"></div>
+          <div class="shimmer shimmer-bubble shimmer-bubble-assistant" aria-hidden="true"></div>
+          <div class="shimmer shimmer-bubble shimmer-bubble-user-short" aria-hidden="true"></div>
+          <div
+            class="shimmer shimmer-bubble shimmer-bubble-assistant-wide"
+            aria-hidden="true"
+          ></div>
+        </div>
+      </div>
+    {:else if error}
+      <p class="error-text">{error}</p>
+    {:else if session}
+      <!-- Chat -->
+      <div class="session-chat-container">
+        {#if hasMoreMessages}
+          <div class="load-earlier-row">
+            <Button
+              text={loadingMore ? 'Loading...' : 'Load earlier messages'}
+              classes="btn-ghost btn-sm"
+              disabled={loadingMore}
+              onclick={loadEarlierMessages}
+            />
+          </div>
+        {/if}
+        <ChatView
+          messages={[...messages].reverse()}
+          newestFirst={true}
+          connectionState={chatConnectionState}
+          showInput={true}
+          {sendDisabled}
+          onSendInput={sendMessage}
+          sessionEnded={false}
+        />
+      </div>
+    {/if}
+  </main>
+</EdgeSwipeBack>
 
 <style>
   .session-page-main {
@@ -624,37 +629,9 @@
     overflow: hidden;
   }
 
-  .session-back-row {
-    margin-bottom: var(--space-5);
-  }
-
   .error-text {
     color: var(--text-secondary);
     padding: var(--space-4);
-  }
-
-  /* Compact header */
-  .session-header {
-    padding: var(--space-3) var(--space-4);
-    border-bottom: 1px solid var(--border);
-    flex-shrink: 0;
-  }
-
-  .session-header-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: var(--space-1);
-  }
-
-  .session-title {
-    font-size: var(--text-base);
-    font-weight: 600;
-    color: var(--text-primary);
-    margin: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .resume-status {

--- a/src/routes/sos/+page.svelte
+++ b/src/routes/sos/+page.svelte
@@ -2,12 +2,16 @@
   import type { ShooterConfig, SuperSession } from '$lib/types';
 
   import { goto } from '$app/navigation';
+  import NavBar from '$lib/modules/client/nav/NavBar.svelte';
+  import PullToRefresh from '$lib/modules/client/nav/PullToRefresh.svelte';
   import { Banner, Button, EmptyState, Input, Pill } from '@juspay/svelte-ui-components';
   import { onMount } from 'svelte';
 
   let sessions = $state<SuperSession[]>([]);
   let loading = $state(true);
-  let error = $state('');
+  let loadError = $state(''); // list-load failures (owned by loadSessions)
+  let error = $state(''); // create failures (owned by create) — kept separate so a
+  // successful pull-to-refresh never wipes a still-relevant create error
   let newLabel = $state('');
   let creating = $state(false);
 
@@ -23,7 +27,7 @@
   async function loadSessions(): Promise<void> {
     const config = getConfig();
     if (!config) {
-      error = 'No configuration found. Open Settings first.';
+      loadError = 'No configuration found. Open Settings first.';
       loading = false;
       return;
     }
@@ -32,13 +36,14 @@
         headers: { Authorization: `Bearer ${config.apiKey}` },
       });
       if (!res.ok) {
-        error = `Failed to load (${res.status})`;
+        loadError = `Failed to load (${res.status})`;
         return;
       }
       const data = (await res.json()) as { superSessions: SuperSession[] };
       sessions = data.superSessions ?? [];
+      loadError = ''; // clear only the load error once a refresh succeeds
     } catch {
-      error = 'Network error — is the server running?';
+      loadError = 'Network error — is the server running?';
     } finally {
       loading = false;
     }
@@ -77,57 +82,63 @@
 
 <svelte:head><title>Session Over Sessions - Shooter</title></svelte:head>
 
-<main class="main sos-list">
-  <div class="page-head">
-    <div>
-      <h1>Session Over Sessions</h1>
-      <p class="subtitle">Coordinate multiple running agents as one super-session.</p>
+<NavBar variant="root" title="Session Over Sessions" />
+
+<PullToRefresh onRefresh={loadSessions}>
+  <main class="main sos-list">
+    <p class="subtitle">Coordinate multiple running agents as one super-session.</p>
+
+    <div class="create-row">
+      <Input
+        bind:value={newLabel}
+        dataType="text"
+        placeholder="New super-session label…"
+        classes="sos-create-input"
+      />
+      <Button
+        text={creating ? 'Creating…' : 'Create'}
+        disabled={creating || !newLabel.trim()}
+        onclick={create}
+        classes="btn-create"
+      />
     </div>
-  </div>
 
-  <div class="create-row">
-    <Input
-      bind:value={newLabel}
-      dataType="text"
-      placeholder="New super-session label…"
-      classes="sos-create-input"
-    />
-    <Button
-      text={creating ? 'Creating…' : 'Create'}
-      disabled={creating || !newLabel.trim()}
-      onclick={create}
-      classes="btn-create"
-    />
-  </div>
+    {#if error || loadError}
+      <div class="sos-banners">
+        {#if error}
+          <Banner text={error} classes="banner-error" />
+        {/if}
+        {#if loadError}
+          <Banner text={loadError} classes="banner-error" />
+        {/if}
+      </div>
+    {/if}
 
-  {#if error}
-    <Banner text={error} classes="banner-error" />
-  {/if}
-
-  {#if loading}
-    <p class="muted">Loading…</p>
-  {:else if sessions.length === 0}
-    <EmptyState
-      title="No super-sessions yet"
-      description="Create one above, then add running agent sessions as members."
-    />
-  {:else}
-    <div class="ss-grid">
-      {#each sessions as ss (ss.id)}
-        <a class="ss-card" href={`/sos/${ss.id}`}>
-          <div class="ss-card-head">
-            <span class="ss-label">{ss.label}</span>
-            <Pill text={ss.status} classes="pill-status-unknown" />
-          </div>
-          <div class="ss-meta">
-            <span>{ss.members.length} member{ss.members.length === 1 ? '' : 's'}</span>
-            <span>{ss.routingRules.length} rule{ss.routingRules.length === 1 ? '' : 's'}</span>
-          </div>
-        </a>
-      {/each}
-    </div>
-  {/if}
-</main>
+    {#if loading}
+      <p class="muted">Loading…</p>
+    {:else if sessions.length === 0}
+      <EmptyState
+        title="No super-sessions yet"
+        description="Create one above, then add running agent sessions as members."
+      />
+    {:else}
+      <div class="ss-grid">
+        {#each sessions as ss (ss.id)}
+          <a class="ss-card" href={`/sos/${ss.id}`}>
+            <div class="ss-card-head">
+              <span class="ss-label">{ss.label}</span>
+              <Pill text={ss.status} classes="pill-status-unknown" />
+            </div>
+            <div class="ss-meta">
+              <span>{ss.members.length} member{ss.members.length === 1 ? '' : 's'}</span>
+              <span>{ss.routingRules.length} rule{ss.routingRules.length === 1 ? '' : 's'}</span>
+            </div>
+          </a>
+        {/each}
+      </div>
+    {/if}
+  </main>
+</PullToRefresh>
 
 <style>
   .sos-list {
@@ -135,11 +146,11 @@
     margin: 0 auto;
     padding: var(--space-5) var(--space-4);
   }
-  .page-head h1 {
-    font-size: var(--text-2xl);
-    font-weight: 600;
-    color: var(--text-primary);
-    margin: 0;
+  /* Stack of error banners (create vs load) — keep them visually separated. */
+  .sos-banners {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
   }
   .subtitle {
     color: var(--text-secondary);

--- a/src/routes/terminals/+page.svelte
+++ b/src/routes/terminals/+page.svelte
@@ -12,6 +12,12 @@
     isShooterConfig,
     setCache,
   } from '$lib/modules/client/common';
+  import Glyph from '$lib/modules/client/common/Glyph.svelte';
+  import SkeletonCard from '$lib/modules/client/common/SkeletonCard.svelte';
+  import Fab from '$lib/modules/client/nav/Fab.svelte';
+  import NavBar from '$lib/modules/client/nav/NavBar.svelte';
+  import PullToRefresh from '$lib/modules/client/nav/PullToRefresh.svelte';
+  import SwipeToDelete from '$lib/modules/client/nav/SwipeToDelete.svelte';
   import LaunchSheet from '$lib/modules/client/terminal/LaunchSheet.svelte';
   import {
     Banner,
@@ -20,7 +26,6 @@
     Icon,
     Pill,
     RelativeTime,
-    Shimmer,
     Tooltip,
   } from '@juspay/svelte-ui-components';
   import { onDestroy, onMount } from 'svelte';
@@ -214,10 +219,7 @@
     return command.split('/').pop() || command;
   }
 
-  async function removeTerminal(event: MouseEvent, id: string): Promise<void> {
-    event.preventDefault();
-    event.stopPropagation();
-
+  async function deleteTerminalById(id: string): Promise<void> {
     if (!config?.apiKey) {
       return;
     }
@@ -238,6 +240,12 @@
       console.error('Failed to remove terminal:', err);
     }
   }
+
+  async function removeTerminal(event: MouseEvent, id: string): Promise<void> {
+    event.preventDefault();
+    event.stopPropagation();
+    await deleteTerminalById(id);
+  }
 </script>
 
 <svelte:head>
@@ -245,135 +253,129 @@
   <meta name="description" content="Active terminal sessions on this machine" />
 </svelte:head>
 
-<main class="main">
-  <div class="page-header">
-    <div class="page-header-content">
-      <div>
-        <h1 class="page-title">Terminals</h1>
-        <p class="page-description">Active terminal sessions on this machine</p>
+<NavBar variant="root" title="Terminals">
+  {#snippet trailing()}
+    <Button classes="btn-secondary" onclick={forceRefresh} disabled={loading} ariaLabel="Refresh">
+      <Glyph svg={RefreshSvg} size={14} />
+    </Button>
+  {/snippet}
+</NavBar>
+
+<PullToRefresh onRefresh={forceRefresh}>
+  <main class="main">
+    {#if fetchError}
+      <Banner text={fetchError} classes="banner-error" />
+    {/if}
+
+    {#if loading && terminals.length === 0}
+      <div class="loading-container">
+        {#each Array(4) as _, i (i)}
+          <SkeletonCard lines={1} />
+        {/each}
       </div>
-      <div class="page-actions">
-        <Button classes="btn-secondary" onclick={forceRefresh} disabled={loading}>
-          <Icon svg={RefreshSvg} classes="icon-14" />
-          Refresh
-        </Button>
+    {:else if !config?.apiKey}
+      <EmptyState
+        title="Configuration Required"
+        description="Set up your API credentials to view terminal sessions"
+      >
+        {#snippet icon()}<Icon svg={SettingsSvg} classes="icon-24" />{/snippet}
+        <Button classes="btn-primary" onclick={navigateToConfig} text="Configure Settings" />
+      </EmptyState>
+    {:else if terminals.length === 0}
+      <EmptyState
+        title="No terminals"
+        description="Launch a new terminal session to get started. Terminal sessions will appear here once created."
+      >
+        {#snippet icon()}<Icon svg={TerminalSvg} classes="icon-24" />{/snippet}
         <Button classes="btn-primary" onclick={handleNewTerminal}>
           <span class="plus-icon">+</span>
           New Terminal
         </Button>
-      </div>
-    </div>
-  </div>
-
-  {#if fetchError}
-    <Banner text={fetchError} classes="banner-error" />
-  {/if}
-
-  {#if loading && terminals.length === 0}
-    <div class="loading-container">
-      {#each Array(4) as _, i (i)}
-        <Shimmer classes="shimmer-card" />
-      {/each}
-    </div>
-  {:else if !config?.apiKey}
-    <EmptyState
-      title="Configuration Required"
-      description="Set up your API credentials to view terminal sessions"
-    >
-      {#snippet icon()}<Icon svg={SettingsSvg} classes="icon-24" />{/snippet}
-      <Button classes="btn-primary" onclick={navigateToConfig} text="Configure Settings" />
-    </EmptyState>
-  {:else if terminals.length === 0}
-    <EmptyState
-      title="No terminals"
-      description="Launch a new terminal session to get started. Terminal sessions will appear here once created."
-    >
-      {#snippet icon()}<Icon svg={TerminalSvg} classes="icon-24" />{/snippet}
-      <Button classes="btn-primary" onclick={handleNewTerminal}>
-        <span class="plus-icon">+</span>
-        New Terminal
-      </Button>
-    </EmptyState>
-  {:else}
-    <div class="terminals-container">
-      <!-- Running terminals first -->
-      {#each runningTerminals as terminal (terminal.id)}
-        {@const badge = getBadgeInfo(terminal)}
-        <a href="/terminals/{terminal.id}" class="terminal-card">
-          <div class="terminal-card-header">
-            <div class="terminal-card-left">
-              <span class="status-indicator status-running">
-                <span class={terminal.isActive ? 'status-dot-active' : 'status-dot-idle'}></span>
-              </span>
-              <span class="terminal-command">{getCommandName(terminal.command)}</span>
-              <Pill text={badge.label} classes={badge.class} />
+      </EmptyState>
+    {:else}
+      <div class="terminals-container">
+        <!-- Running terminals first -->
+        {#each runningTerminals as terminal (terminal.id)}
+          {@const badge = getBadgeInfo(terminal)}
+          <a href="/terminals/{terminal.id}" class="terminal-card">
+            <div class="terminal-card-header">
+              <div class="terminal-card-left">
+                <span class="status-indicator status-running">
+                  <span class={terminal.isActive ? 'status-dot-active' : 'status-dot-idle'}></span>
+                </span>
+                <span class="terminal-command">{getCommandName(terminal.command)}</span>
+                <Pill text={badge.label} classes={badge.class} />
+              </div>
+              <RelativeTime date={terminal.createdAt} format="narrow" classes="terminal-time" />
             </div>
-            <RelativeTime date={terminal.createdAt} format="narrow" classes="terminal-time" />
-          </div>
 
-          <div class="terminal-card-meta">
-            <Tooltip text={terminal.currentCwd || terminal.cwd} position="bottom">
-              <span class="terminal-cwd">{truncatePath(terminal.currentCwd || terminal.cwd)}</span>
-            </Tooltip>
-            <span class="terminal-pid">PID {terminal.pid}</span>
-          </div>
-
-          {#if terminal.lastOutput}
-            <div class="terminal-preview">
-              <span class="terminal-preview-text">{truncateOutput(terminal.lastOutput)}</span>
+            <div class="terminal-card-meta">
+              <Tooltip text={terminal.currentCwd || terminal.cwd} position="bottom">
+                <span class="terminal-cwd">{truncatePath(terminal.currentCwd || terminal.cwd)}</span
+                >
+              </Tooltip>
+              <span class="terminal-pid">PID {terminal.pid}</span>
             </div>
-          {/if}
-        </a>
-      {/each}
 
-      <!-- Exited terminals at lower opacity -->
-      {#each exitedTerminals as terminal (terminal.id)}
-        {@const badge = getBadgeInfo(terminal)}
-        <a href="/terminals/{terminal.id}" class="terminal-card terminal-card-exited">
-          <div class="terminal-card-header">
-            <div class="terminal-card-left">
-              <span class="status-indicator status-exited">
-                <span class="status-dot-static"></span>
-              </span>
-              <span class="terminal-command">{getCommandName(terminal.command)}</span>
-              <Pill text={badge.label} classes={badge.class} />
-              {#if terminal.exitCode !== null}
-                <Pill
-                  text="exit {terminal.exitCode}"
-                  classes={terminal.exitCode !== 0 ? 'pill-exit-error' : 'pill-exit-ok'}
-                />
+            {#if terminal.lastOutput}
+              <div class="terminal-preview">
+                <span class="terminal-preview-text">{truncateOutput(terminal.lastOutput)}</span>
+              </div>
+            {/if}
+          </a>
+        {/each}
+
+        <!-- Exited terminals at lower opacity — swipe-to-delete on touch -->
+        {#each exitedTerminals as terminal (terminal.id)}
+          {@const badge = getBadgeInfo(terminal)}
+          <SwipeToDelete onDelete={(): void => void deleteTerminalById(terminal.id)}>
+            <a href="/terminals/{terminal.id}" class="terminal-card terminal-card-exited">
+              <div class="terminal-card-header">
+                <div class="terminal-card-left">
+                  <span class="status-indicator status-exited">
+                    <span class="status-dot-static"></span>
+                  </span>
+                  <span class="terminal-command">{getCommandName(terminal.command)}</span>
+                  <Pill text={badge.label} classes={badge.class} />
+                  {#if terminal.exitCode !== null}
+                    <Pill
+                      text="exit {terminal.exitCode}"
+                      classes={terminal.exitCode !== 0 ? 'pill-exit-error' : 'pill-exit-ok'}
+                    />
+                  {/if}
+                </div>
+                <div class="terminal-card-right">
+                  <RelativeTime
+                    date={terminal.exitedAt || terminal.createdAt}
+                    format="narrow"
+                    classes="terminal-time"
+                  />
+                  <Button
+                    classes="btn-ghost btn-sm btn-remove"
+                    onclick={(e: MouseEvent): void => void removeTerminal(e, terminal.id)}
+                    text="&times;"
+                  />
+                </div>
+              </div>
+
+              <div class="terminal-card-meta">
+                <Tooltip text={terminal.cwd} position="bottom">
+                  <span class="terminal-cwd">{truncatePath(terminal.cwd)}</span>
+                </Tooltip>
+              </div>
+
+              {#if terminal.lastOutput}
+                <div class="terminal-preview">
+                  <span class="terminal-preview-text">{truncateOutput(terminal.lastOutput)}</span>
+                </div>
               {/if}
-            </div>
-            <div class="terminal-card-right">
-              <RelativeTime
-                date={terminal.exitedAt || terminal.createdAt}
-                format="narrow"
-                classes="terminal-time"
-              />
-              <Button
-                classes="btn-ghost btn-sm btn-remove"
-                onclick={(e: MouseEvent): void => void removeTerminal(e, terminal.id)}
-                text="&times;"
-              />
-            </div>
-          </div>
-
-          <div class="terminal-card-meta">
-            <Tooltip text={terminal.cwd} position="bottom">
-              <span class="terminal-cwd">{truncatePath(terminal.cwd)}</span>
-            </Tooltip>
-          </div>
-
-          {#if terminal.lastOutput}
-            <div class="terminal-preview">
-              <span class="terminal-preview-text">{truncateOutput(terminal.lastOutput)}</span>
-            </div>
-          {/if}
-        </a>
-      {/each}
-    </div>
-  {/if}
-</main>
+            </a>
+          </SwipeToDelete>
+        {/each}
+      </div>
+    {/if}
+  </main>
+</PullToRefresh>
 
 {#if config?.apiKey}
   <LaunchSheet
@@ -382,6 +384,7 @@
     onClose={handleLaunchClose}
     onLaunch={handleLaunchComplete}
   />
+  <Fab onclick={handleNewTerminal} ariaLabel="New terminal" />
 {/if}
 
 <style>

--- a/src/routes/terminals/[id]/+page.svelte
+++ b/src/routes/terminals/[id]/+page.svelte
@@ -14,7 +14,9 @@
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import AlertTriangleSvg from '$lib/assets/icons/alert-triangle.svg?raw';
+  import ArrowLeftSvg from '$lib/assets/icons/arrow-left.svg?raw';
   import { AI_COMMANDS } from '$lib/modules/client/common';
+  import Glyph from '$lib/modules/client/common/Glyph.svelte';
   import ChatView from '$lib/modules/client/terminal/ChatView.svelte';
   import CommandPalette from '$lib/modules/client/terminal/CommandPalette.svelte';
   import ConnectionStatus from '$lib/modules/client/terminal/ConnectionStatus.svelte';
@@ -790,7 +792,7 @@
   <main class="main">
     <div class="session-back-row">
       <a href="/terminals" class="back-link">
-        <span class="back-arrow">&larr;</span>
+        <Glyph svg={ArrowLeftSvg} size={14} />
         Terminals
       </a>
     </div>
@@ -804,7 +806,9 @@
     <div class="term-topbar">
       <div class="term-topbar-left">
         {#if isOwner}
-          <a href="/terminals" class="term-back" aria-label="Back to terminals">&larr;</a>
+          <a href="/terminals" class="term-back" aria-label="Back to terminals"
+            ><Glyph svg={ArrowLeftSvg} size={18} /></a
+          >
         {/if}
         <span class="term-command-name">{commandName}</span>
         <Pill text={badgeLabel} classes={badgeClass} />
@@ -972,10 +976,13 @@
   .term-page {
     display: flex;
     flex-direction: column;
-    height: calc(100vh - var(--header-height) - 64px);
-    height: calc(100dvh - var(--header-height) - 64px);
+    height: calc(100vh - 64px);
+    /* Shrink by the software-keyboard overlap so the input bar + quick keys
+       ride above the on-screen keyboard on phones (see keyboard-inset store). */
+    height: calc(100dvh - 64px - var(--keyboard-inset, 0px));
     overflow: hidden;
     background: var(--ds-background-200);
+    transition: height 0.2s ease;
   }
 
   /* Top bar */
@@ -984,7 +991,9 @@
     align-items: center;
     justify-content: space-between;
     gap: var(--space-3);
-    padding: var(--space-2) var(--space-4);
+    /* Reserve the notch/status-bar inset: this route has no NavBar, and the
+       global header (which used to reserve it) was removed. */
+    padding: calc(var(--space-2) + env(safe-area-inset-top, 0px)) var(--space-4) var(--space-2);
     background: var(--ds-background-100);
     border-bottom: 1px solid var(--border);
     flex-shrink: 0;
@@ -1006,27 +1015,31 @@
     flex-shrink: 1;
   }
 
-  /* Back button */
+  /* Back button — amber chevron to match the native NavBar (amber = action). */
   .term-back {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 44px;
     height: 44px;
+    margin-left: -8px;
     border-radius: var(--radius-md);
     background: transparent;
-    color: var(--text-secondary);
+    color: var(--accent);
     text-decoration: none;
     font-size: 18px;
+    -webkit-tap-highlight-color: transparent;
     transition:
       background var(--transition-fast),
-      color var(--transition-fast);
+      transform 60ms ease;
     flex-shrink: 0;
   }
 
   .term-back:hover {
-    background: var(--ds-gray-alpha-100);
-    color: var(--text-primary);
+    background: var(--accent-dim, var(--ds-gray-alpha-100));
+  }
+  .term-back:active {
+    transform: scale(0.9);
   }
 
   /* Command name */
@@ -1214,7 +1227,8 @@
 
   @media (max-width: 768px) {
     .term-topbar {
-      padding: var(--space-2) var(--space-3);
+      /* keep reserving the notch inset — the shorthand would otherwise erase it */
+      padding: calc(var(--space-2) + env(safe-area-inset-top, 0px)) var(--space-3) var(--space-2);
       gap: var(--space-2);
     }
 
@@ -1227,7 +1241,7 @@
   @media (max-width: 480px) {
     .term-topbar {
       min-height: 44px;
-      padding: var(--space-1) var(--space-2);
+      padding: calc(var(--space-1) + env(safe-area-inset-top, 0px)) var(--space-2) var(--space-1);
     }
 
     .term-command-name {

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,0 +1,61 @@
+/* Shooter service worker — Web Push delivery for PWA / browser.
+ * Plain JS served from /sw.js (scope "/"). Registered by the client push module.
+ * Kept intentionally minimal: no offline caching here, only push + click. */
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('push', (event) => {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch (_) {
+    payload = { title: 'Shooter', body: event.data ? event.data.text() : '' };
+  }
+
+  const title = payload.title || 'Shooter';
+  const options = {
+    body: payload.body || '',
+    icon: '/pwa-192x192.png',
+    badge: '/favicon.png',
+    tag: payload.tag || undefined,
+    renotify: Boolean(payload.tag),
+    data: payload.data || {},
+    timestamp: Date.now(),
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const target = (event.notification.data && event.notification.data.url) || '/';
+
+  event.waitUntil(
+    (async () => {
+      const windows = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+      });
+      for (const client of windows) {
+        if ('focus' in client) {
+          try {
+            await client.navigate(target);
+          } catch (_) {
+            /* cross-origin or navigation blocked — fall back to focus */
+          }
+          return client.focus();
+        }
+      }
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(target);
+      }
+      return undefined;
+    })()
+  );
+});

--- a/tests/apns-liveactivity.test.cjs
+++ b/tests/apns-liveactivity.test.cjs
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for src/lib/modules/server/apn/apns-liveactivity.ts
+ *
+ * The APNs Live Activity (ActivityKit) `aps` envelope and topic are what APNs is
+ * strict about, so the pure builders get deterministic coverage: topic suffix,
+ * required timestamp/event/content-state, and the event-conditional fields
+ * (dismissal-date only on 'end', optional stale-date / relevance-score / alert).
+ */
+
+'use strict';
+
+require('tsx/cjs');
+const path = require('path');
+const { buildLiveActivityBody, liveActivityTopic } = require(
+  path.join(__dirname, '..', 'src', 'lib', 'modules', 'server', 'apn', 'apns-liveactivity.ts')
+);
+
+let passed = 0;
+let failed = 0;
+function ok(cond, name) {
+  if (cond) {
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL  ${name}`);
+    failed++;
+  }
+}
+
+console.log('\nAPNs Live Activity builders\n');
+
+// topic
+ok(
+  liveActivityTopic('com.shooter.app') === 'com.shooter.app.push-type.liveactivity',
+  'topic appends the liveactivity push-type suffix'
+);
+
+const cs = { title: 'claude', status: 'Running', detail: 'Edit', updatedAt: '2026-07-11T00:00:00Z' };
+
+// update
+const upd = buildLiveActivityBody({ event: 'update', contentState: cs }, 1_780_000_000);
+ok(upd.aps.event === 'update', 'update: event set');
+ok(upd.aps.timestamp === 1_780_000_000, 'update: timestamp is the injected nowSec');
+ok(upd.aps['content-state'] === cs, 'update: content-state carried through');
+ok(!('dismissal-date' in upd.aps), 'update: no dismissal-date on a non-end event');
+ok(!('stale-date' in upd.aps), 'update: no stale-date unless provided');
+
+// end with dismissal + stale + relevance + alert
+const end = buildLiveActivityBody(
+  {
+    event: 'end',
+    contentState: cs,
+    dismissalDate: 1_780_000_600,
+    staleDate: 1_780_000_300,
+    relevanceScore: 75,
+    alert: { title: 'Done', body: 'Session complete' },
+  },
+  1_780_000_000
+);
+ok(end.aps.event === 'end', 'end: event set');
+ok(end.aps['dismissal-date'] === 1_780_000_600, 'end: dismissal-date included');
+ok(end.aps['stale-date'] === 1_780_000_300, 'end: stale-date included');
+ok(end.aps['relevance-score'] === 75, 'end: relevance-score included');
+ok(end.aps.alert && end.aps.alert.title === 'Done', 'end: alert carried through');
+
+// dismissal-date is ignored on a non-end event
+const updWithDismissal = buildLiveActivityBody(
+  { event: 'update', contentState: cs, dismissalDate: 1_780_000_600 },
+  1_780_000_000
+);
+ok(!('dismissal-date' in updWithDismissal.aps), 'dismissal-date is dropped on update events');
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tests/edge-swipe.test.cjs
+++ b/tests/edge-swipe.test.cjs
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for src/lib/modules/client/common/edge-swipe.ts
+ *
+ * Pure decision helpers for the edge-swipe-back gesture: edge engagement,
+ * axis lock (dead-zone), and the commit-back threshold. The touch plumbing in
+ * EdgeSwipeBack.svelte calls these; testing them here makes the gesture logic
+ * deterministically verifiable without a DOM.
+ */
+
+'use strict';
+
+require('tsx/cjs');
+const path = require('path');
+const { shouldEngageEdge, resolveSwipeAxis, shouldCommitBack } = require(
+  path.join(__dirname, '..', 'src', 'lib', 'modules', 'client', 'common', 'edge-swipe.ts')
+);
+
+let passed = 0;
+let failed = 0;
+function ok(cond, name) {
+  if (cond) {
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL  ${name}`);
+    failed++;
+  }
+}
+
+console.log('\nedge-swipe gesture logic\n');
+
+// shouldEngageEdge
+ok(shouldEngageEdge(0, 28) === true, 'engages at the very edge (x=0)');
+ok(shouldEngageEdge(28, 28) === true, 'engages exactly at the edge width');
+ok(shouldEngageEdge(29, 28) === false, 'does not engage just past the edge');
+ok(shouldEngageEdge(200, 28) === false, 'does not engage mid-screen');
+
+// resolveSwipeAxis
+ok(resolveSwipeAxis(3, 2) === '', 'undecided inside the 8px dead-zone');
+ok(resolveSwipeAxis(20, 4) === 'x', 'horizontal drag locks to x');
+ok(resolveSwipeAxis(4, 20) === 'y', 'vertical drag locks to y');
+ok(resolveSwipeAxis(10, 10) === 'x', 'a tie favours horizontal (back-swipe)');
+ok(resolveSwipeAxis(-20, 3) === 'x', 'leftward horizontal still locks x (rejected later by sign)');
+
+// shouldCommitBack (default threshold 0.32)
+ok(shouldCommitBack(200, 500) === true, 'commits past 32% of width');
+ok(shouldCommitBack(100, 500) === false, 'does not commit below 32%');
+ok(shouldCommitBack(160, 500) === false, 'exactly at threshold does not commit (strict >)');
+ok(shouldCommitBack(161, 500) === true, 'just past threshold commits');
+ok(shouldCommitBack(100, 0) === false, 'zero width never commits (avoids div-by-zero engage)');
+ok(shouldCommitBack(50, 100, 0.4) === true, 'custom threshold honoured');
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tests/keyboard.test.cjs
+++ b/tests/keyboard.test.cjs
@@ -1,0 +1,57 @@
+'use strict';
+
+require('tsx/cjs');
+
+const path = require('path');
+const mod = require(
+  path.join(__dirname, '..', 'src', 'lib', 'modules', 'client', 'common', 'keyboard.ts')
+);
+const { computeKeyboardInset } = mod;
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(
+      `${label || 'assertEqual'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+    );
+  }
+}
+
+console.log('keyboard inset geometry\n');
+
+runTest('no inset when the keyboard is closed (viewport equals layout)', () => {
+  assertEqual(computeKeyboardInset(844, 844, 0), 0, 'closed');
+});
+
+runTest('inset equals the keyboard height when open', () => {
+  assertEqual(computeKeyboardInset(844, 500, 0), 344, 'open');
+});
+
+runTest('subtracts the visual-viewport offsetTop', () => {
+  assertEqual(computeKeyboardInset(844, 500, 44), 300, 'with offset');
+});
+
+runTest('clamps to 0 when the viewport is taller than the layout', () => {
+  assertEqual(computeKeyboardInset(844, 900, 0), 0, 'clamped');
+});
+
+runTest('clamps to 0 when offset alone would push it negative', () => {
+  assertEqual(computeKeyboardInset(844, 844, 100), 0, 'clamped offset');
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/live-activity-store.test.cjs
+++ b/tests/live-activity-store.test.cjs
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for src/lib/modules/server/apn/live-activity-store.ts
+ *
+ * Maps a session to its current ActivityKit push token. Covers idempotent
+ * upsert (latest token wins as ActivityKit rotates it), lookup, remove by
+ * session and by token, and non-empty validation.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+process.env.SHOOTER_HOME = path.join(os.tmpdir(), 'shooter-test-la-home');
+require('tsx/cjs');
+
+const { LiveActivityStore } = require(
+  path.join(__dirname, '..', 'src', 'lib', 'modules', 'server', 'apn', 'live-activity-store.ts')
+);
+
+const DATA_DIR = path.join(os.tmpdir(), 'shooter-test-liveactivity');
+function freshStore() {
+  fs.rmSync(DATA_DIR, { recursive: true, force: true });
+  return new LiveActivityStore(DATA_DIR);
+}
+
+let passed = 0;
+let failed = 0;
+function run(name, fn) {
+  let store;
+  try {
+    store = freshStore();
+    fn(store);
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  } finally {
+    if (store) store.close();
+  }
+}
+function eq(a, b, label) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(`${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`);
+  }
+}
+function throws(fn, label) {
+  let t = false;
+  try {
+    fn();
+  } catch {
+    t = true;
+  }
+  if (!t) throw new Error(`${label}: expected throw`);
+}
+
+console.log('\nLiveActivityStore unit tests\n');
+
+run('upsert + getBySession round-trips', (s) => {
+  s.upsert('sess-1', 'tok-abc');
+  eq(s.getBySession('sess-1').activityPushToken, 'tok-abc', 'token');
+});
+
+run('upsert rotates the token for the same session (no dup)', (s) => {
+  s.upsert('sess-1', 'tok-old');
+  s.upsert('sess-1', 'tok-new');
+  eq(s.getBySession('sess-1').activityPushToken, 'tok-new', 'latest token wins');
+});
+
+run('getBySession returns null for unknown session', (s) => {
+  eq(s.getBySession('nope'), null, 'unknown');
+});
+
+run('remove deletes by session', (s) => {
+  s.upsert('sess-1', 'tok');
+  eq(s.remove('sess-1'), 1, 'removed');
+  eq(s.getBySession('sess-1'), null, 'gone');
+});
+
+run('removeByToken drops the holder (410 cleanup)', (s) => {
+  s.upsert('sess-1', 'dead-tok');
+  s.upsert('sess-2', 'live-tok');
+  eq(s.removeByToken('dead-tok'), 1, 'removed by token');
+  eq(s.getBySession('sess-1'), null, 'dead session gone');
+  eq(s.getBySession('sess-2').activityPushToken, 'live-tok', 'live session kept');
+});
+
+run('upsert rejects empty session or token', (s) => {
+  throws(() => s.upsert('', 'tok'), 'empty session');
+  throws(() => s.upsert('sess', ''), 'empty token');
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tests/motion.test.cjs
+++ b/tests/motion.test.cjs
@@ -1,0 +1,76 @@
+'use strict';
+
+require('tsx/cjs');
+
+const path = require('path');
+const mod = require(
+  path.join(__dirname, '..', 'src', 'lib', 'modules', 'client', 'common', 'motion.ts')
+);
+const { prefersReducedMotion, resolveMotionDuration } = mod;
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(
+      `${label || 'assertEqual'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+    );
+  }
+}
+
+runTest('resolveMotionDuration returns 0 when reduced motion is requested', () => {
+  assertEqual(resolveMotionDuration(220, true), 0, 'reduced');
+});
+
+runTest('resolveMotionDuration returns the base duration when motion is allowed', () => {
+  assertEqual(resolveMotionDuration(220, false), 220, 'allowed');
+});
+
+runTest('resolveMotionDuration passes through a zero base unchanged', () => {
+  assertEqual(resolveMotionDuration(0, false), 0, 'zero base');
+});
+
+runTest('prefersReducedMotion returns false when window is unavailable (SSR/Node)', () => {
+  assertEqual(typeof window, 'undefined', 'no window in this test process');
+  assertEqual(prefersReducedMotion(), false, 'ssr fallback');
+});
+
+runTest('prefersReducedMotion reflects matchMedia(prefers-reduced-motion: reduce).matches', () => {
+  global.window = {
+    matchMedia: (query) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+    }),
+  };
+  try {
+    assertEqual(prefersReducedMotion(), true, 'matches true');
+  } finally {
+    delete global.window;
+  }
+});
+
+runTest('prefersReducedMotion returns false when the media query does not match', () => {
+  global.window = {
+    matchMedia: () => ({ matches: false }),
+  };
+  try {
+    assertEqual(prefersReducedMotion(), false, 'matches false');
+  } finally {
+    delete global.window;
+  }
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/native-bridge.test.cjs
+++ b/tests/native-bridge.test.cjs
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for src/lib/modules/client/common/native-bridge.ts — haptic()
+ *
+ * haptic() resolution order: window.ShooterBridge.haptic (iOS) →
+ * window.ShooterNativeBridge.haptic (Android) → navigator.vibrate (web) →
+ * no-op. Must be SSR/desktop-safe and never throw.
+ *
+ * Loads the real TS module via tsx/cjs. window/navigator are faked as
+ * globals before the require (the module reads them at call time, not at
+ * import time, so each test can reassign them freely).
+ */
+
+'use strict';
+
+const path = require('path');
+
+require('tsx/cjs');
+
+function setWindow(value) {
+  global.window = value;
+}
+
+// Node 24 defines a built-in `navigator` global getter (configurable, but
+// not a plain writable property) — must use defineProperty, not assignment.
+function setNavigator(value) {
+  Object.defineProperty(global, 'navigator', { configurable: true, value, writable: true });
+}
+
+setWindow({});
+setNavigator({});
+
+const { haptic } = require(
+  path.join(__dirname, '..', 'src', 'lib', 'modules', 'client', 'common', 'native-bridge.ts')
+);
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(`${label}: expected ${e}, got ${a}`);
+  }
+}
+
+console.log('\nnative-bridge haptic() unit tests\n');
+
+runTest('Test 1: prefers window.ShooterBridge.haptic (iOS) when present', () => {
+  const calls = [];
+  setWindow({ ShooterBridge: { haptic: (kind) => calls.push(kind) } });
+  setNavigator({
+    vibrate: () => {
+      throw new Error('navigator.vibrate should not be called when ShooterBridge.haptic exists');
+    },
+  });
+  haptic('selection');
+  assertEqual(calls, ['selection'], 'ShooterBridge.haptic called with kind');
+});
+
+runTest(
+  'Test 2: falls back to window.ShooterNativeBridge.haptic (Android) when ShooterBridge lacks it',
+  () => {
+    const calls = [];
+    setWindow({ ShooterNativeBridge: { haptic: (kind) => calls.push(kind) } });
+    setNavigator({
+      vibrate: () => {
+        throw new Error(
+          'navigator.vibrate should not be called when ShooterNativeBridge.haptic exists'
+        );
+      },
+    });
+    haptic('heavy');
+    assertEqual(calls, ['heavy'], 'ShooterNativeBridge.haptic called with kind');
+  }
+);
+
+runTest('Test 3: falls back to navigator.vibrate when neither native bridge is present', () => {
+  const calls = [];
+  setWindow({});
+  setNavigator({ vibrate: (ms) => calls.push(ms) });
+  haptic('light');
+  assertEqual(calls, [10], 'navigator.vibrate called with mapped ms for "light"');
+});
+
+runTest('Test 4: default kind is "light" when called with no argument', () => {
+  const calls = [];
+  setWindow({});
+  setNavigator({ vibrate: (ms) => calls.push(ms) });
+  haptic();
+  assertEqual(calls, [10], 'navigator.vibrate called with the light duration by default');
+});
+
+runTest('Test 5: silent no-op when window is undefined (SSR)', () => {
+  const original = global.window;
+  setWindow(undefined);
+  try {
+    haptic('error'); // must not throw
+  } finally {
+    setWindow(original);
+  }
+});
+
+runTest(
+  'Test 6: silent no-op when neither bridge nor navigator.vibrate exist (desktop browser)',
+  () => {
+    setWindow({});
+    setNavigator({});
+    haptic('medium'); // must not throw
+  }
+);
+
+runTest('Test 7: never throws even if the native bridge itself throws', () => {
+  setWindow({
+    ShooterBridge: {
+      haptic: () => {
+        throw new Error('native crash');
+      },
+    },
+  });
+  setNavigator({ vibrate: () => {} });
+  haptic('warning'); // must not throw
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total\n`);
+
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/pull-refresh.test.cjs
+++ b/tests/pull-refresh.test.cjs
@@ -1,0 +1,81 @@
+'use strict';
+
+require('tsx/cjs');
+
+const path = require('path');
+const mod = require(
+  path.join(__dirname, '..', 'src', 'lib', 'modules', 'client', 'common', 'pull-refresh.ts')
+);
+const { resistPull, shouldTriggerRefresh } = mod;
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(
+      `${label || 'assertEqual'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+    );
+  }
+}
+
+function assertTrue(cond, label) {
+  if (!cond) {
+    throw new Error(label || 'assertTrue failed');
+  }
+}
+
+console.log('pull-refresh gesture math\n');
+
+runTest('resistPull returns 0 for no drag', () => {
+  assertEqual(resistPull(0), 0, 'zero');
+});
+
+runTest('resistPull returns 0 for an upward (negative) drag', () => {
+  assertEqual(resistPull(-80), 0, 'negative');
+});
+
+runTest('resistPull returns 0 when max is non-positive', () => {
+  assertEqual(resistPull(100, 0), 0, 'zero max');
+});
+
+runTest('resistPull is monotonically increasing with drag', () => {
+  assertTrue(resistPull(100) > resistPull(50), 'monotonic 100>50');
+  assertTrue(resistPull(50) > resistPull(20), 'monotonic 50>20');
+});
+
+runTest('resistPull never exceeds the max cap', () => {
+  assertTrue(resistPull(10_000, 120) <= 120, 'never above cap');
+  assertTrue(resistPull(10_000, 120) > 119.9, 'approaches cap');
+});
+
+runTest('resistPull moves nearly 1:1 for a small initial drag', () => {
+  // At 12px with max 120, eased ~= 11.4px — within 10% of raw.
+  const eased = resistPull(12, 120);
+  assertTrue(eased > 10.8 && eased < 12, `small-drag easing (${eased})`);
+});
+
+runTest('shouldTriggerRefresh is true at and above the threshold', () => {
+  assertEqual(shouldTriggerRefresh(64), true, 'at threshold');
+  assertEqual(shouldTriggerRefresh(100), true, 'above threshold');
+});
+
+runTest('shouldTriggerRefresh is false below the threshold', () => {
+  assertEqual(shouldTriggerRefresh(63.9), false, 'just below');
+  assertEqual(shouldTriggerRefresh(0), false, 'zero');
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/web-push-store.test.cjs
+++ b/tests/web-push-store.test.cjs
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for src/lib/modules/server/webpush/web-push-store.ts
+ *
+ * WebPushStore is the SQLite-backed registry for browser/PWA push subscriptions
+ * (endpoint + p256dh/auth keys), separate from the APNs/FCM device_tokens table.
+ * Covers idempotent upsert keyed by endpoint, key rotation, listActive, lazy
+ * pruning by endpoint, touchLastSeen, explicit delete, and the 30-day cleanup.
+ *
+ * Loads the REAL TS module via tsx/cjs (the $lib/types import is type-only →
+ * erased). Each test runs against an isolated temp data dir so ~/.shooter is
+ * never touched; `now` is injected for determinism.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SINGLETON_HOME = path.join(os.tmpdir(), 'shooter-test-webpush-home');
+process.env.SHOOTER_HOME = SINGLETON_HOME;
+
+require('tsx/cjs');
+
+const { WebPushStore } = require(
+  path.join(__dirname, '..', 'src', 'lib', 'modules', 'server', 'webpush', 'web-push-store.ts')
+);
+
+const DATA_DIR = path.join(os.tmpdir(), 'shooter-test-webpush');
+
+function freshStore() {
+  fs.rmSync(DATA_DIR, { recursive: true, force: true });
+  return new WebPushStore(DATA_DIR);
+}
+
+function makeInput(overrides = {}) {
+  const n = Math.random().toString(36).slice(2, 10);
+  return {
+    endpoint: 'https://push.example.com/' + n,
+    keys: { auth: 'auth-' + n, p256dh: 'p256-' + n },
+    ...overrides,
+  };
+}
+
+const T0 = new Date('2025-01-01T00:00:00.000Z');
+const T1 = new Date('2025-01-02T00:00:00.000Z');
+
+function assertEqual(actual, expected, label) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(`${label}: expected ${e}, got ${a}`);
+  }
+}
+
+function assertThrows(fn, label) {
+  let threw = false;
+  try {
+    fn();
+  } catch {
+    threw = true;
+  }
+  if (!threw) {
+    throw new Error(`${label}: expected a throw, but none occurred`);
+  }
+}
+
+let passed = 0;
+let failed = 0;
+
+function runTest(name, fn) {
+  let store;
+  try {
+    store = freshStore();
+    fn(store);
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  } finally {
+    if (store) store.close();
+  }
+}
+
+console.log('\nWebPushStore unit tests\n');
+
+runTest('upsert inserts a subscription; listActive returns it', (s) => {
+  s.upsert(makeInput({ endpoint: 'https://push/1', friendlyName: 'Chrome' }));
+  const list = s.listActive();
+  assertEqual(list.length, 1, 'count');
+  assertEqual(list[0].endpoint, 'https://push/1', 'endpoint');
+  assertEqual(list[0].friendlyName, 'Chrome', 'friendlyName');
+  assertEqual(list[0].isActive, true, 'isActive');
+  assertEqual(list[0].failureCount, 0, 'failureCount');
+});
+
+runTest('upsert same endpoint rotates keys, no duplicate row', (s) => {
+  s.upsert(makeInput({ endpoint: 'https://push/2', keys: { auth: 'a1', p256dh: 'k1' } }), T0);
+  s.upsert(makeInput({ endpoint: 'https://push/2', keys: { auth: 'a2', p256dh: 'k2' } }), T1);
+  const list = s.listActive();
+  assertEqual(list.length, 1, 'no duplicate');
+  assertEqual(list[0].auth, 'a2', 'auth rotated');
+  assertEqual(list[0].p256dh, 'k2', 'p256dh rotated');
+  assertEqual(list[0].lastSeenAt, T1.toISOString(), 'last_seen bumped');
+});
+
+runTest('upsert preserves friendlyName when re-sent without one (COALESCE)', (s) => {
+  s.upsert(makeInput({ endpoint: 'https://push/3', friendlyName: 'iOS Safari' }));
+  s.upsert(makeInput({ endpoint: 'https://push/3', friendlyName: null }));
+  const list = s.listActive();
+  assertEqual(list[0].friendlyName, 'iOS Safari', 'name preserved');
+});
+
+runTest('pruneByEndpoints soft-deletes; listActive drops it', (s) => {
+  s.upsert(makeInput({ endpoint: 'https://push/dead' }));
+  s.upsert(makeInput({ endpoint: 'https://push/live' }));
+  const pruned = s.pruneByEndpoints(['https://push/dead']);
+  assertEqual(pruned, 1, 'pruned count');
+  const list = s.listActive();
+  assertEqual(list.length, 1, 'only live remains');
+  assertEqual(list[0].endpoint, 'https://push/live', 'live endpoint');
+});
+
+runTest('re-subscribing a pruned endpoint reactivates it', (s) => {
+  s.upsert(makeInput({ endpoint: 'https://push/back' }));
+  s.pruneByEndpoints(['https://push/back']);
+  assertEqual(s.listActive().length, 0, 'pruned');
+  s.upsert(makeInput({ endpoint: 'https://push/back' }));
+  assertEqual(s.listActive().length, 1, 'reactivated');
+});
+
+runTest('touchLastSeen bumps timestamp for delivered endpoints', (s) => {
+  s.upsert(makeInput({ endpoint: 'https://push/t' }), T0);
+  s.touchLastSeen(['https://push/t'], T1);
+  assertEqual(s.listActive()[0].lastSeenAt, T1.toISOString(), 'bumped');
+});
+
+runTest('deleteByEndpoint hard-removes the row', (s) => {
+  s.upsert(makeInput({ endpoint: 'https://push/x' }));
+  const removed = s.deleteByEndpoint('https://push/x');
+  assertEqual(removed, 1, 'removed');
+  assertEqual(s.listActive().length, 0, 'gone');
+});
+
+runTest('startupCleanup deletes only inactive rows older than 30 days', (s) => {
+  s.upsert(makeInput({ endpoint: 'https://push/old' }), T0);
+  s.pruneByEndpoints(['https://push/old']); // inactive
+  s.upsert(makeInput({ endpoint: 'https://push/active' }), T0); // active, old
+  const now = new Date(T0.getTime() + 31 * 24 * 60 * 60 * 1000);
+  const deleted = s.startupCleanup(now);
+  assertEqual(deleted, 1, 'only the inactive old row deleted');
+  assertEqual(s.listActive().length, 1, 'active old row kept');
+});
+
+runTest('upsert rejects empty endpoint / keys', (s) => {
+  assertThrows(() => s.upsert(makeInput({ endpoint: '' })), 'empty endpoint');
+  assertThrows(
+    () => s.upsert(makeInput({ endpoint: 'https://push/y', keys: { auth: '', p256dh: 'k' } })),
+    'empty auth'
+  );
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Make Shooter feel native — the full 6-slice program

Turns the phone-first Shooter UI from "a responsive website" into "an app you want to open." Locked directions: **native shell + terminal soul**, **PWA/Safari first-class** (real Web Push in scope), **Amber Phosphor `#F5B14C`** accent (distinct from the live-status green).

Stacked slices, each committed and gated independently. Slices 1–2 (amber re-theme, haptics, per-screen nav shell, pull-to-refresh, grouped settings, badged Activity bell) landed earlier on this branch; this PR completes the program with slices 3–6.

### Slice 4 — Motion & haptics depth
- **Sliding amber tab indicator** glides between Dashboard/Terminals/SoS (exact-thirds geometry, reduced-motion-guarded).
- **`SwipeToDelete`** on exited terminals — iOS swipe-reveal + full-swipe commit; touch-only, delete still reachable via button (a11y-safe).
- **Content-shaped `SkeletonCard`** replaces featureless grey blocks; global shimmer now reduced-motion-guarded.
- **Connection-status ripple** — self-contained breathing (connected) / insistent (reconnecting) animation, no global-keyframe dependency.

### Slice 5 — Web Push (PWA / browser) — third notify channel
- `static/sw.js` service worker (push → notification, click → focus/open).
- VAPID keys auto-generate + persist to `~/.shooter/vapid.json` (0600); env override honored.
- Separate `web_push_subscriptions` SQLite store (APNs/FCM `device_tokens` untouched): idempotent upsert by endpoint, key rotation, lazy 404/410 prune, 30-day cleanup — **9 unit tests**.
- Folded into the `/api/notify` parallel fan-out (skipped on single-token override; stale endpoints pruned; counts merged into the summary).
- Endpoints: `GET /api/web-push/vapid-public-key` (public), `POST/DELETE /api/web-push/subscribe` (auth).
- Client module + Settings **Browser Notifications** section (rehearse permission → subscribe → send test push).

### Slice 3 immersion (keyboard-aware core landed earlier)
- **`EdgeSwipeBack`** iOS edge-swipe-from-left back gesture on Session + Project (arms only within 28px of the edge; commits past 32% width with a light haptic; `transform:none` at rest so the sticky NavBar isn't broken). Decision logic extracted to a pure module — **15 unit tests**.
- Terminal back-chevron retinted grey → amber (matches the native NavBar).

### Slice 6 — Ambient status / Live Activity
- APNs gains a `liveactivity` push type + topic override (`<bundleId>.push-type.liveactivity`); alert/background paths unchanged.
- Pure `apns-liveactivity.ts` body builder (**12 tests**) + session→token store (**6 tests**).
- `POST/DELETE /api/live-activity/register` + `POST /api/live-activity` (targets a token or a registered `sessionId`; forgets the token on `end`/410).
- Complete iOS **ActivityKit reference** (`ios/Shooter/LiveActivityReference/`: attributes, Lock Screen + Dynamic Island SwiftUI, widget bundle, `LiveActivityManager`) + step-by-step Xcode integration guide. The widget-extension **target must be created in Xcode** — hand-editing `pbxproj` to add an app-extension target blind would corrupt the project.

## Verification
- **Gates:** `pnpm check` 0 errors/0 warnings · `pnpm build` clean · `pnpm test` all pass (exit 0, **+42 new unit tests**) · eslint `--max-warnings 0` clean.
- **Browser-verified (screenshots + curl):** tab indicator sliding, content-shaped skeletons, ONLINE ripple, amber FAB, Web Push settings UI + subscribe→store→notify→prune round-trip, Live Activity register→store→resolve→APNs path.

### Needs your device (mechanism-verified here, on-device acceptance pending)
- **Web Push live delivery** — needs a real Notification-permission grant + push-service roundtrip (automated Chrome keeps permission at `default`).
- **Edge-swipe feel** — real touch swipe on a phone (gesture *decision* logic is unit-covered; a hydrated instance was observed committing during testing).
- **Live Activity UI / Dynamic Island / push updates** — create the widget target in Xcode per `ios/Shooter/LiveActivityReference/README.md`, build for a device (iOS 16.2+).

Design specs for every slice live under `docs/superpowers/specs/2026-07-*`.
