### PR TITLE
feat(ios): drive the Live Activity from session notifications (compile-verified)

### DIFF
--- a/ios/Shooter/Shooter/LiveActivityManager.swift
+++ b/ios/Shooter/Shooter/LiveActivityManager.swift
@@ -16,8 +16,21 @@ final class LiveActivityManager {
     private var current: Activity<ShooterActivityAttributes>?
     private var tokenTask: Task<Void, Never>?
 
-    /// Start a Live Activity for a session and stream its push token to the server.
+    /// Start a Live Activity for a session — or, if one is already running for the
+    /// same session, just update it. Safe to call repeatedly from a notification
+    /// tap (must be foreground; iOS only permits `Activity.request` there). Once
+    /// started, the streamed push token lets the SERVER drive later updates + end.
     func start(sessionId: String, title: String, status: String, detail: String? = nil) {
+        // Already showing this session → update in place instead of stacking a
+        // second activity.
+        if let activity = current, activity.attributes.sessionId == sessionId {
+            update(status: status, title: title, detail: detail)
+            return
+        }
+        // A different session is showing → retire it before starting the new one.
+        if current != nil {
+            end()
+        }
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
         let attributes = ShooterActivityAttributes(sessionId: sessionId)
         let state = ShooterActivityAttributes.ContentState(
@@ -41,6 +54,16 @@ final class LiveActivityManager {
         } catch {
             print("[LiveActivity] start failed: \(error)")
         }
+    }
+
+    /// Update the current activity's content locally (the server also updates via push).
+    func update(status: String, title: String? = nil, detail: String? = nil) {
+        guard let activity = current else { return }
+        let state = ShooterActivityAttributes.ContentState(
+            title: title ?? activity.content.state.title, status: status, detail: detail,
+            progress: nil, updatedAt: ISO8601DateFormatter().string(from: Date())
+        )
+        Task { await activity.update(.init(state: state, staleDate: nil)) }
     }
 
     /// End the current activity (optionally showing a final state briefly).

--- a/ios/Shooter/Shooter/NotificationManager.swift
+++ b/ios/Shooter/Shooter/NotificationManager.swift
@@ -421,12 +421,15 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
             // User explicitly asked to make the decision in-app — show
             // the Decide screen for richer context / unlimited options.
             DispatchQueue.main.async { self.decideRequestId = DecideRequestId(value: requestId) }
-        } else if actionIdentifier == UNNotificationDefaultActionIdentifier,
-                  let requestId = requestId {
+            syncLiveActivity(response.notification.request.content)
+        } else if actionIdentifier == UNNotificationDefaultActionIdentifier {
             // User tapped the notification body (not an action button).
-            // Open the Decide screen so they see context before
-            // choosing.
-            DispatchQueue.main.async { self.decideRequestId = DecideRequestId(value: requestId) }
+            // Open the Decide screen when there's a decision to make, and
+            // reflect the session in a Live Activity now that we're foreground.
+            if let requestId = requestId {
+                DispatchQueue.main.async { self.decideRequestId = DecideRequestId(value: requestId) }
+            }
+            syncLiveActivity(response.notification.request.content)
         } else if actionIdentifier == UNNotificationDismissActionIdentifier {
             // Dismissed -- hook will timeout and fall through to the
             // local CC permission dialog. No-op on our side.
@@ -445,5 +448,41 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
     ) {
         // Show the banner even when the app is in the foreground
         completionHandler([.banner, .sound, .badge])
+    }
+
+    /// Reflect a tapped session in a Live Activity. Called only from foreground-
+    /// bringing taps (default / open-in-app), because iOS only permits starting
+    /// an activity in the foreground. Once started, the push token this streams to
+    /// the server lets the server drive precise updates + the eventual end.
+    private func syncLiveActivity(_ content: UNNotificationContent) {
+        guard #available(iOS 16.2, *) else { return }
+        let userInfo = content.userInfo
+        guard let sessionId = userInfo["sessionId"] as? String, !sessionId.isEmpty else { return }
+        let eventType = userInfo["eventType"] as? String ?? ""
+        let source = userInfo["source"] as? String ?? ""
+        let title = content.title.isEmpty ? "Session" : content.title
+
+        // A completion notification ends the activity; everything else starts/updates it.
+        if source.contains("completion") || eventType == "session.complete" {
+            LiveActivityManager.shared.end(finalStatus: "Done")
+            return
+        }
+        LiveActivityManager.shared.start(
+            sessionId: sessionId,
+            title: title,
+            status: liveActivityStatus(for: eventType),
+            detail: content.body.isEmpty ? nil : content.body
+        )
+    }
+
+    private func liveActivityStatus(for eventType: String) -> String {
+        switch eventType {
+        case "permission", "permission_notification": return "Permission needed"
+        case "question": return "Awaiting answer"
+        case "idle_input", "session.idle": return "Awaiting input"
+        case "error": return "Error"
+        case "tool.before", "tool.after", "session.status": return "Running"
+        default: return "Active"
+        }
     }
 }


### PR DESCRIPTION
## Drive the Live Activity from session notifications

Follow-up to #118 (which created the `ShooterWidget` target). This adds the **call sites** so a Live Activity actually appears — the target existed but nothing invoked it.

iOS only permits *starting* an activity in the **foreground**, so the trigger is a notification **tap** (which foregrounds the app), after which the server drives updates + end via the push token the app streams.

### Changes
- **`NotificationManager.didReceive`** — on a foreground-bringing tap (default action / open-in-app) carrying a `sessionId`, `syncLiveActivity()` starts (or updates) a Live Activity with a status derived from `eventType` (`permission` → "Permission needed", `question` → "Awaiting answer", `idle`/`session.idle` → "Awaiting input", `tool.*` → "Running", `error` → "Error"). A completion notification ends it.
- **`LiveActivityManager.start()`** is now idempotent — updates in place for the same session, retires a different session's activity first; adds `update()`. Once started, the streamed push token lets the server drive precise updates + the eventual end via `POST /api/live-activity`.

### Verified
`xcodebuild -scheme Shooter -sdk iphonesimulator` → **`** BUILD SUCCEEDED **`** (app + `ShooterWidget`, iOS 26 SDK).

On-device render/update (real device, iOS 16.2+, notifications + Live Activities enabled) remains the acceptance step — see the on-device checklist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live Activities now update in place when the same session receives new information.
  * Starting a different session automatically replaces the previous Live Activity.
  * Live Activities can refresh their status, title, details, and timestamp without restarting.
  * Tapping session notifications now synchronizes the related Live Activity.
  * Completed sessions display a final status and end their Live Activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->