### PR TITLE
feat(ios): home-screen widget (latest session status) + Live Activity status-bug fix

### DIFF
--- a/docs/superpowers/specs/2026-07-11-home-screen-widget-design.md
+++ b/docs/superpowers/specs/2026-07-11-home-screen-widget-design.md
@@ -1,0 +1,55 @@
+# Home-Screen Widget — Design (Slice 6 extra)
+
+A WidgetKit home-screen widget for `ShooterWidget` showing the latest coding
+session and its status, alongside the Live Activity from #118/#119.
+
+## Data flow — App Group shared snapshot (no network in the widget)
+
+The widget is network- and credential-free: the **app writes** a tiny snapshot to
+an App Group `UserDefaults`; the **widget reads** it in its timeline provider.
+
+- **App Group:** `group.in.juspay.shooter` — declared identically in the app
+  entitlements, the widget entitlements, and `WidgetShared.appGroup`; the widget
+  target's `CODE_SIGN_ENTITLEMENTS` points at `ShooterWidget/ShooterWidget.entitlements`.
+- **`WidgetShared` (both targets):** a `Snapshot { sessionId, title, status,
+hasActivity, updatedAt }` Codable, `write()` (persist + `WidgetCenter.reloadAllTimelines()`)
+  and `read()` (→ `.empty` sentinel when nothing written yet).
+- **`ShooterHomeWidget` (widget target):** `StaticConfiguration` + `TimelineProvider`
+  reading the snapshot; small + medium families, Amber Phosphor; `.after(15m)`
+  fallback refresh; `containerBackground` guarded behind `#available(iOS 17)`.
+- **App write path (`NotificationManager`):** `updateWidgetSnapshot()` runs on
+  foreground arrival (`willPresent`), tap (`syncLiveActivity`), and lock-screen
+  decision actions.
+
+## Correctness — the 5 fixes from adversarial review
+
+A 4-dimension review (9 agents) found 5 confirmed defects; all fixed:
+
+1. **(HIGH) Status derivation read `userInfo["eventType"]`, which the server never
+   sends.** The delivered push carries session state in top-level `data.category`
+   (`permission`/`question`/`idle_input`/`intervention`/`completion`). Now reads
+   `category` (eventType as fallback). **This also repairs the same bug in the
+   already-merged #119 Live Activity wiring** (shared `syncLiveActivity` path).
+2. **(HIGH) Completion was unreachable** — keyed on `source.contains("completion")`,
+   but the server overwrites `source` with `"modern-apns-api"`. Now `category ==
+"completion"` drives `isDone` / `LiveActivityManager.end()`.
+3. **(MED) Decision-button taps didn't refresh the widget** — now call
+   `updateWidgetSnapshot()` in the decision branch (cheap App-Group write).
+4. **(LOW) Redundant double-write** (arrival + tap) — deduped by `requestId|status`.
+5. **(LOW) `sessionId` was discarded** — added to the snapshot with a session-affinity
+   - urgency rule so a lower-urgency event from another session can't downgrade an
+     unacted urgent snapshot (with a 1h staleness escape hatch).
+
+## Verification
+
+- `xcodebuild -scheme Shooter -sdk iphonesimulator` → `** BUILD SUCCEEDED **`
+  (app + `ShooterWidget` with both widgets, iOS 26 SDK).
+- App Group id verified identical across app/widget entitlements + `WidgetShared.appGroup`.
+- Root cause of the status/completion fixes verified against `.claude/hooks/notifier.cjs`
+  (category values) and `src/routes/api/notify/+server.ts` (payload spread).
+
+## On-device caveat
+
+Widget rendering on the Home Screen (small/medium), the App Group hand-off, and
+timeline refresh are the on-device acceptance step (real device; App Group must be
+registered in the Apple Developer portal for signed builds). Compile-verified here.

--- a/ios/Shooter/Shooter.xcodeproj/project.pbxproj
+++ b/ios/Shooter/Shooter.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		6688A2930C474D6F027FBE6E /* ShooterWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E4E8E3D19DF78BE6632FD7 /* ShooterWidgetBundle.swift */; };
 		83F5D5F3DE62B4F0BB9B9DA8 /* ShooterLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1596767D9C6A296E6DDF07DE /* ShooterLiveActivity.swift */; };
 		996FE2FDCEF01939AB52730A /* ShooterWidget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 513CA31DE7FB674403C08675 /* ShooterWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		A735C8F12721EC7A3349FB56 /* ShooterHomeWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44B06EBC651A2F667E78D6D /* ShooterHomeWidget.swift */; };
 		A7B8E1A12C5F1A3B00123456 /* ShooterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8E1A02C5F1A3B00123456 /* ShooterApp.swift */; };
 		A7B8E1A32C5F1A3B00123456 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8E1A22C5F1A3B00123456 /* ContentView.swift */; };
 		A7B8E1A52C5F1A3C00123456 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A7B8E1A42C5F1A3C00123456 /* Assets.xcassets */; };
@@ -23,6 +24,8 @@
 		A7B8E1B82C5F1AAB00123456 /* QRScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8E1B72C5F1AAB00123456 /* QRScannerViewController.swift */; };
 		B4380A8B0DC470913DEEB5A3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 386826547C4FC8536CB58FC4 /* Foundation.framework */; };
 		BCD81249CD7FBA0EEC7D5D2E /* ShooterActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A36FE1EC09C89CA2E4CF80 /* ShooterActivityAttributes.swift */; };
+		C96CEEFF21A89822B8B6CCC8 /* WidgetSharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E837258E53910626CAE61D /* WidgetSharedStore.swift */; };
+		E1F277689E54A866F6D5A655 /* WidgetSharedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E837258E53910626CAE61D /* WidgetSharedStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +71,9 @@
 		A7B8E1B52C5F1A9B00123456 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		A7B8E1B72C5F1AAB00123456 /* QRScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerViewController.swift; sourceTree = "<group>"; };
 		AE672EB5DE4A681A39D88AFC /* LiveActivityManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
+		B0E837258E53910626CAE61D /* WidgetSharedStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WidgetSharedStore.swift; sourceTree = "<group>"; };
+		E44B06EBC651A2F667E78D6D /* ShooterHomeWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShooterHomeWidget.swift; sourceTree = "<group>"; };
+		F54D62983A3015F6FFB2D6A6 /* ShooterWidget.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = ShooterWidget.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,6 +110,9 @@
 				1596767D9C6A296E6DDF07DE /* ShooterLiveActivity.swift */,
 				74E4E8E3D19DF78BE6632FD7 /* ShooterWidgetBundle.swift */,
 				6BF921E2E5F0934B4CC8F7E6 /* Info.plist */,
+				B0E837258E53910626CAE61D /* WidgetSharedStore.swift */,
+				E44B06EBC651A2F667E78D6D /* ShooterHomeWidget.swift */,
+				F54D62983A3015F6FFB2D6A6 /* ShooterWidget.entitlements */,
 			);
 			name = ShooterWidget;
 			path = ShooterWidget;
@@ -268,6 +277,7 @@
 				A7B8E1B82C5F1AAB00123456 /* QRScannerViewController.swift in Sources */,
 				009D7D9F5F305CDE8B905422 /* LiveActivityManager.swift in Sources */,
 				BCD81249CD7FBA0EEC7D5D2E /* ShooterActivityAttributes.swift in Sources */,
+				E1F277689E54A866F6D5A655 /* WidgetSharedStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -278,6 +288,8 @@
 				2921B131D8453A0D42B36B53 /* ShooterActivityAttributes.swift in Sources */,
 				83F5D5F3DE62B4F0BB9B9DA8 /* ShooterLiveActivity.swift in Sources */,
 				6688A2930C474D6F027FBE6E /* ShooterWidgetBundle.swift in Sources */,
+				C96CEEFF21A89822B8B6CCC8 /* WidgetSharedStore.swift in Sources */,
+				A735C8F12721EC7A3349FB56 /* ShooterHomeWidget.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -486,6 +498,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = ShooterWidget/ShooterWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = YM9U73Z2JM;
@@ -512,6 +525,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = ShooterWidget/ShooterWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = YM9U73Z2JM;

--- a/ios/Shooter/Shooter/NotificationManager.swift
+++ b/ios/Shooter/Shooter/NotificationManager.swift
@@ -24,6 +24,10 @@ class NotificationManager: NSObject, ObservableObject {
     /// (String isn't Identifiable on its own).
     @Published var decideRequestId: DecideRequestId?
 
+    // Dedup key for the home-screen widget snapshot (requestId|status) so the same
+    // notification written on arrival and again on tap doesn't do redundant work.
+    private var lastWidgetKey: String?
+
     private var serverUrl: String {
         UserDefaults.standard.string(forKey: "serverUrl") ?? AppConfig.defaultServerURL
     }
@@ -436,6 +440,10 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         } else if let decision = decisionFor(actionIdentifier: actionIdentifier),
                   let requestId = requestId {
             sendDecisionResponse(requestId: requestId, decision: decision)
+            // Answering from the lock screen doesn't foreground the app (so we
+            // can't touch the Live Activity), but the widget snapshot is a cheap
+            // App-Group write — refresh it so the home screen reflects the action.
+            updateWidgetSnapshot(response.notification.request.content)
         }
 
         completionHandler()
@@ -446,43 +454,97 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
-        // Show the banner even when the app is in the foreground
+        // Show the banner even when the app is in the foreground, and refresh the
+        // home-screen widget from the arriving session event (no tap required).
+        updateWidgetSnapshot(notification.request.content)
         completionHandler([.banner, .sound, .badge])
     }
 
-    /// Reflect a tapped session in a Live Activity. Called only from foreground-
-    /// bringing taps (default / open-in-app), because iOS only permits starting
-    /// an activity in the foreground. Once started, the push token this streams to
-    /// the server lets the server drive precise updates + the eventual end.
+    /// Persist the latest session state for the home-screen widget (App Group).
+    /// Cheap + WidgetKit-only (16.1+), so it runs regardless of Live Activity support.
+    ///
+    /// The delivered push carries the session's state in `data.category` (spread to
+    /// the top level of userInfo) — NOT `eventType` (a WS-only field) or `source`
+    /// (the server overwrites it with a transport label). `completion` marks a
+    /// finished session.
+    private func updateWidgetSnapshot(_ content: UNNotificationContent) {
+        let userInfo = content.userInfo
+        guard let sessionId = userInfo["sessionId"] as? String, !sessionId.isEmpty else { return }
+        let category = notificationCategory(userInfo)
+        let title = content.title.isEmpty ? "Session" : content.title
+        let isDone = category == "completion"
+        let status = isDone ? "Done" : sessionStatus(forCategory: category)
+
+        // Dedup (finding: redundant double-write) — the same push written on arrival
+        // and again on tap has the same requestId+status, so skip the repeat.
+        let requestId = (userInfo["requestId"] as? String) ?? sessionId
+        let key = "\(requestId)|\(status)"
+        if key == lastWidgetKey { return }
+
+        // Session affinity — don't let a lower-urgency event from a DIFFERENT
+        // session silently downgrade an unacted urgent snapshot. Same session, a
+        // finished/stale stored state, or equal-or-higher urgency all overwrite.
+        let current = WidgetShared.read()
+        let staleOrDone = !current.hasActivity || Date().timeIntervalSince(current.updatedAt) > 3600
+        guard current.sessionId == sessionId || staleOrDone
+                || urgency(status) >= urgency(current.status) else { return }
+
+        lastWidgetKey = key
+        WidgetShared.write(WidgetShared.Snapshot(
+            sessionId: sessionId, title: title, status: status,
+            hasActivity: !isDone, updatedAt: Date()
+        ))
+    }
+
+    /// Reflect a tapped session in a Live Activity + the widget. Called only from
+    /// foreground-bringing taps (default / open-in-app), because iOS only permits
+    /// starting an activity in the foreground. Once started, the push token this
+    /// streams to the server lets the server drive precise updates + the end.
     private func syncLiveActivity(_ content: UNNotificationContent) {
+        updateWidgetSnapshot(content)
         guard #available(iOS 16.2, *) else { return }
         let userInfo = content.userInfo
         guard let sessionId = userInfo["sessionId"] as? String, !sessionId.isEmpty else { return }
-        let eventType = userInfo["eventType"] as? String ?? ""
-        let source = userInfo["source"] as? String ?? ""
+        let category = notificationCategory(userInfo)
         let title = content.title.isEmpty ? "Session" : content.title
 
         // A completion notification ends the activity; everything else starts/updates it.
-        if source.contains("completion") || eventType == "session.complete" {
+        if category == "completion" {
             LiveActivityManager.shared.end(finalStatus: "Done")
             return
         }
         LiveActivityManager.shared.start(
             sessionId: sessionId,
             title: title,
-            status: liveActivityStatus(for: eventType),
+            status: sessionStatus(forCategory: category),
             detail: content.body.isEmpty ? nil : content.body
         )
     }
 
-    private func liveActivityStatus(for eventType: String) -> String {
-        switch eventType {
+    /// The session state category the server actually delivers (top-level
+    /// `data.category`), falling back to the WS-only `eventType` for completeness.
+    private func notificationCategory(_ userInfo: [AnyHashable: Any]) -> String {
+        (userInfo["category"] as? String) ?? (userInfo["eventType"] as? String) ?? ""
+    }
+
+    private func sessionStatus(forCategory category: String) -> String {
+        switch category {
         case "permission", "permission_notification": return "Permission needed"
         case "question": return "Awaiting answer"
         case "idle_input", "session.idle": return "Awaiting input"
-        case "error": return "Error"
-        case "tool.before", "tool.after", "session.status": return "Running"
+        case "intervention": return "Attention needed"
+        case "completion": return "Done"
         default: return "Active"
+        }
+    }
+
+    /// How urgently a status wants to be surfaced (higher = don't let another
+    /// session downgrade it). Attention states outrank Running/Active outrank Done.
+    private func urgency(_ status: String) -> Int {
+        switch status {
+        case "Permission needed", "Awaiting answer", "Awaiting input", "Attention needed": return 3
+        case "Done": return 1
+        default: return 2
         }
     }
 }

--- a/ios/Shooter/ShooterWidget/ShooterHomeWidget.swift
+++ b/ios/Shooter/ShooterWidget/ShooterHomeWidget.swift
@@ -1,0 +1,101 @@
+// ShooterHomeWidget.swift
+//
+// Home-screen WidgetKit widget showing the latest Shooter session's status.
+// Reads the App Group snapshot the app writes (WidgetSharedStore); no network.
+// Small + medium families, Amber Phosphor accent. Widget-extension target only.
+//
+// Requires iOS 16.1+ (WidgetKit).
+
+import SwiftUI
+import WidgetKit
+
+private let amber = Color(red: 0.961, green: 0.694, blue: 0.298) // #F5B14C
+
+struct ShooterHomeEntry: TimelineEntry {
+    let date: Date
+    let snapshot: WidgetShared.Snapshot
+}
+
+struct ShooterHomeProvider: TimelineProvider {
+    func placeholder(in context: Context) -> ShooterHomeEntry {
+        ShooterHomeEntry(date: Date(), snapshot: .empty)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (ShooterHomeEntry) -> Void) {
+        completion(ShooterHomeEntry(date: Date(), snapshot: WidgetShared.read()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<ShooterHomeEntry>) -> Void) {
+        let entry = ShooterHomeEntry(date: Date(), snapshot: WidgetShared.read())
+        // The app reloads the timeline on every write; this .after is only a
+        // fallback so a long-idle widget still re-reads (and re-renders "stale").
+        let next = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date()
+        completion(Timeline(entries: [entry], policy: .after(next)))
+    }
+}
+
+struct ShooterHomeWidgetView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: ShooterHomeEntry
+
+    private var dotColor: Color {
+        entry.snapshot.hasActivity ? Color.green : Color.secondary
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: family == .systemSmall ? 6 : 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "terminal.fill").foregroundColor(amber).font(.caption)
+                Text("Shooter").font(.caption2.weight(.semibold)).foregroundColor(.secondary)
+                Spacer()
+                Circle().fill(dotColor).frame(width: 8, height: 8)
+            }
+
+            Spacer(minLength: 0)
+
+            Text(entry.snapshot.title)
+                .font(family == .systemSmall ? .headline : .title3)
+                .fontWeight(.semibold)
+                .lineLimit(family == .systemSmall ? 2 : 1)
+
+            Text(entry.snapshot.status)
+                .font(.subheadline)
+                .foregroundColor(amber)
+                .lineLimit(1)
+
+            if entry.snapshot.updatedAt.timeIntervalSince1970 > 0 {
+                Text(entry.snapshot.updatedAt, style: .relative)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .padding()
+        .widgetBackground(Color.black.opacity(0.9))
+    }
+}
+
+private extension View {
+    /// iOS 17 requires `containerBackground`; earlier versions use a plain background.
+    @ViewBuilder
+    func widgetBackground(_ color: Color) -> some View {
+        if #available(iOS 17.0, *) {
+            containerBackground(for: .widget) { color }
+        } else {
+            background(color)
+        }
+    }
+}
+
+struct ShooterHomeWidget: Widget {
+    let kind = "ShooterHomeWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: ShooterHomeProvider()) { entry in
+            ShooterHomeWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Shooter Session")
+        .description("The latest coding session and its status.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}

--- a/ios/Shooter/ShooterWidget/ShooterWidget.entitlements
+++ b/ios/Shooter/ShooterWidget/ShooterWidget.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>production</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.in.juspay.shooter</string>

--- a/ios/Shooter/ShooterWidget/ShooterWidgetBundle.swift
+++ b/ios/Shooter/ShooterWidget/ShooterWidgetBundle.swift
@@ -11,6 +11,7 @@ import WidgetKit
 @main
 struct ShooterWidgetBundle: WidgetBundle {
     var body: some Widget {
+        ShooterHomeWidget()
         ShooterLiveActivity()
     }
 }

--- a/ios/Shooter/ShooterWidget/WidgetSharedStore.swift
+++ b/ios/Shooter/ShooterWidget/WidgetSharedStore.swift
@@ -1,0 +1,51 @@
+// WidgetSharedStore.swift
+//
+// A tiny session snapshot shared between the main app (writer) and the widget
+// extension (reader) via an App Group UserDefaults. The app writes the latest
+// session state as notifications arrive; the home-screen widget reads it. Keeps
+// the widget network- and credential-free.
+//
+// Add this file to BOTH the app target and the widget-extension target.
+
+import Foundation
+import WidgetKit
+
+enum WidgetShared {
+    static let appGroup = "group.in.juspay.shooter"
+    private static let snapshotKey = "widget.snapshot"
+
+    /// The data the home-screen widget renders. Codable so it round-trips through
+    /// the shared UserDefaults; kept small (a widget timeline entry, not a feed).
+    struct Snapshot: Codable {
+        var sessionId: String // which session this snapshot is about (affinity)
+        var title: String     // latest session / terminal name
+        var status: String    // "Running", "Awaiting input", "Done", …
+        var hasActivity: Bool // true while something is running or awaiting input
+        var updatedAt: Date
+
+        static let empty = Snapshot(sessionId: "", title: "No sessions", status: "Idle",
+                                    hasActivity: false, updatedAt: Date(timeIntervalSince1970: 0))
+    }
+
+    private static var defaults: UserDefaults? {
+        UserDefaults(suiteName: appGroup)
+    }
+
+    /// Called by the APP whenever session state changes. Persists the snapshot and
+    /// asks WidgetKit to refresh the timeline so the widget updates promptly.
+    static func write(_ snapshot: Snapshot) {
+        guard let d = defaults, let data = try? JSONEncoder().encode(snapshot) else { return }
+        d.set(data, forKey: snapshotKey)
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    /// Called by the WIDGET's timeline provider. Returns `.empty` when nothing has
+    /// been written yet (first install, or app never ran).
+    static func read() -> Snapshot {
+        guard let d = defaults, let data = d.data(forKey: snapshotKey),
+              let snap = try? JSONDecoder().decode(Snapshot.self, from: data) else {
+            return .empty
+        }
+        return snap
+    }
+}


### PR DESCRIPTION
## Home-screen widget — latest session status (App Group)

Adds a WidgetKit **home-screen widget** to `ShooterWidget`, alongside the Live Activity (#118/#119). It shows the latest coding session + its status (small + medium, Amber Phosphor), fed by an **App Group shared snapshot** the app writes — so the widget is network- and credential-free.

### Design
- **App Group `group.in.juspay.shooter`** on both targets (matching entitlements; `WidgetShared.appGroup`); widget `CODE_SIGN_ENTITLEMENTS` wired.
- **`WidgetShared`** (shared app↔widget): `Snapshot { sessionId, title, status, hasActivity, updatedAt }` + `write()` (persist + `reloadAllTimelines()`) / `read()`.
- **`ShooterHomeWidget`** (widget target): `StaticConfiguration` + `TimelineProvider`; `containerBackground` guarded behind `#available(iOS 17)` for the 16.2 deployment target.
- **App writes** the snapshot from `NotificationManager` on foreground arrival, tap, and lock-screen decision actions.

### Adversarial review — 5 confirmed defects, all fixed
A 4-dimension review (9 agents) ran over the diff before this PR:
1. **HIGH** — status read `userInfo["eventType"]`, which the server never sends over the wire; the delivered push carries state in top-level **`data.category`** (`permission`/`question`/`idle_input`/`intervention`/`completion`). Now reads `category`. **This also repairs the same latent bug in the already-merged #119 Live Activity wiring** (shared `syncLiveActivity` path — status was always falling through to "Active").
2. **HIGH** — completion was unreachable (`source` is overwritten server-side to `"modern-apns-api"`); now keyed on `category == "completion"`.
3. **MED** — decision-button taps now refresh the widget.
4. **LOW** — dedup the arrival+tap double-write by `requestId|status`.
5. **LOW** — `sessionId` affinity + urgency rule so a lower-urgency event from another session can't downgrade an unacted urgent snapshot (1h staleness escape hatch).

Root cause verified against `.claude/hooks/notifier.cjs` (category values) and `src/routes/api/notify/+server.ts` (payload spread).

### Verified
`xcodebuild -scheme Shooter -sdk iphonesimulator` → **`** BUILD SUCCEEDED **`** (app + `ShooterWidget` with both widgets, iOS 26 SDK). On-device render + App Group hand-off remain the acceptance step (App Group must be registered in the Apple Developer portal for signed builds).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a home-screen widget displaying the latest Shooter session status, title, activity indicator, and update time.
  * Widget supports small and medium layouts on iOS 16.1+.
  * Widget updates automatically when session notifications arrive or decisions are made.
  * Added shared app and widget data access for immediate, network-free refreshes.

* **Bug Fixes**
  * Improved session status, completion, deduplication, urgency, and stale-update handling for widget and Live Activity displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->