### PR TITLE
feat(ios): deep links — tapping the widget / Live Activity opens the session

### DIFF
--- a/docs/superpowers/specs/2026-07-11-widget-deep-links-design.md
+++ b/docs/superpowers/specs/2026-07-11-widget-deep-links-design.md
@@ -1,0 +1,39 @@
+# Widget / Live Activity Deep Links — Design
+
+Tapping the home-screen widget or the Lock Screen Live Activity opens the app to
+the session it represents.
+
+## Flow
+
+1. **Widget / Live Activity** carry a `.widgetURL(shooter://session/<id>)`
+   (home widget nil-guards an empty sessionId → opens the app; Live Activity uses
+   `context.attributes.sessionId`).
+2. **URL scheme `shooter`** is registered via a partial `ios/Shooter/Shooter/Info.plist`
+   (`CFBundleURLTypes`) with `INFOPLIST_FILE` set while `GENERATE_INFOPLIST_FILE`
+   stays `YES` — the generated keys merge on top. Verified by inspecting the built
+   `Info.plist`: it contains both the `shooter` scheme AND every generated key
+   (`NSSupportsLiveActivities`, `CFBundleName`, `UILaunchScreen`).
+3. **`ContentView.onOpenURL`** parses `shooter://session/<id>` / `shooter://terminal/<id>`
+   into a path, joins it to the stored `serverUrl` (trailing-slash-safe), and posts
+   `.shooterDeepLink { url }`.
+4. **The WebView coordinator** observes `.shooterDeepLink` (same pattern as the
+   existing `.shooterSilentWake`) and `webView.load(URLRequest(url:))` — navigating
+   to `<serverUrl>/session/<id>`.
+
+Unrecognized links just bring the app forward; if the app is unpaired (no WebView)
+the link is safely dropped.
+
+## Verification
+
+- `xcodebuild -scheme Shooter -sdk iphonesimulator` → `** BUILD SUCCEEDED **` (twice).
+- Built `Info.plist` merge inspected (scheme + generated keys coexist).
+- Adversarial review (3 dimensions → verify): 3 candidate findings, **0 confirmed**
+  — the id-in-URL and observer-lifecycle concerns were refuted (UUID ids are
+  URL-safe; iOS 9+ auto-removes selector observers); the "generic scheme" note is
+  defense-in-depth, not a defect.
+
+## On-device caveat
+
+The actual tap→open→navigate round-trip is the on-device acceptance step (custom
+schemes require a real launch). Scheme registration + navigation wiring are
+compile- and Info.plist-verified.

--- a/ios/Shooter/Shooter.xcodeproj/project.pbxproj
+++ b/ios/Shooter/Shooter.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		1596767D9C6A296E6DDF07DE /* ShooterLiveActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShooterLiveActivity.swift; sourceTree = "<group>"; };
 		386826547C4FC8536CB58FC4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		513CA31DE7FB674403C08675 /* ShooterWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShooterWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		5920E3B83FEC63FF5556A0F0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		68A36FE1EC09C89CA2E4CF80 /* ShooterActivityAttributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShooterActivityAttributes.swift; sourceTree = "<group>"; };
 		6BF921E2E5F0934B4CC8F7E6 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		74E4E8E3D19DF78BE6632FD7 /* ShooterWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShooterWidgetBundle.swift; sourceTree = "<group>"; };
@@ -151,6 +152,7 @@
 				A7B8E1A42C5F1A3C00123456 /* Assets.xcassets */,
 				A7B8E1A62C5F1A3C00123456 /* Preview Content */,
 				AE672EB5DE4A681A39D88AFC /* LiveActivityManager.swift */,
+				5920E3B83FEC63FF5556A0F0 /* Info.plist */,
 			);
 			path = Shooter;
 			sourceTree = "<group>";
@@ -437,6 +439,7 @@
 				DEVELOPMENT_TEAM = YM9U73Z2JM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Shooter/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Camera access is needed to scan QR codes for server configuration";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -472,6 +475,7 @@
 				DEVELOPMENT_TEAM = YM9U73Z2JM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Shooter/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Camera access is needed to scan QR codes for server configuration";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/ios/Shooter/Shooter/ContentView.swift
+++ b/ios/Shooter/Shooter/ContentView.swift
@@ -8,6 +8,11 @@ extension Notification.Name {
     /// serverUrl/apiKey no longer leaves the user stuck on the error
     /// page — needsPairing flips true and PairingView takes over.
     static let shooterWebViewLoadFailed = Notification.Name("ShooterWebViewLoadFailed")
+
+    /// Posted by ContentView.onOpenURL when a shooter:// deep link (widget /
+    /// Live Activity tap) resolves to a target URL; the WebView coordinator
+    /// navigates there. userInfo["url"] is the fully-qualified target URL.
+    static let shooterDeepLink = Notification.Name("ShooterDeepLink")
 }
 
 struct ContentView: View {
@@ -56,6 +61,27 @@ struct ContentView: View {
             lastWebViewError = note.userInfo?["message"] as? String
             webViewLoadFailed = true
         }
+        .onOpenURL { handleDeepLink($0) }
+    }
+
+    /// Translate a shooter:// deep link (widget / Live Activity tap) into a WebView
+    /// navigation. Supported:
+    ///   shooter://session/<id>   → /session/<id>
+    ///   shooter://terminal[/<id>] → /terminals[/<id>]
+    /// Unrecognized links just bring the app forward at its current location.
+    private func handleDeepLink(_ url: URL) {
+        guard url.scheme == "shooter" else { return }
+        let id = url.pathComponents.first(where: { $0 != "/" }) ?? ""
+        let path: String
+        switch url.host {
+        case "session" where !id.isEmpty: path = "/session/\(id)"
+        case "terminal", "terminals": path = id.isEmpty ? "/terminals" : "/terminals/\(id)"
+        default: return
+        }
+        let rawBase = UserDefaults.standard.string(forKey: "serverUrl") ?? AppConfig.defaultServerURL
+        let base = rawBase.hasSuffix("/") ? String(rawBase.dropLast()) : rawBase
+        guard let target = URL(string: base + path) else { return }
+        NotificationCenter.default.post(name: .shooterDeepLink, object: nil, userInfo: ["url": target])
     }
 
     private var needsPairing: Bool {
@@ -529,6 +555,18 @@ struct WebView: UIViewRepresentable {
                 name: .shooterSilentWake,
                 object: nil
             )
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleDeepLink(_:)),
+                name: .shooterDeepLink,
+                object: nil
+            )
+        }
+
+        /// Navigate the WebView to a deep-link target (widget / Live Activity tap).
+        @objc func handleDeepLink(_ note: Notification) {
+            guard let url = note.userInfo?["url"] as? URL else { return }
+            webView?.load(URLRequest(url: url))
         }
 
         @objc func handleRefresh(_ refreshControl: UIRefreshControl) {

--- a/ios/Shooter/Shooter/Info.plist
+++ b/ios/Shooter/Shooter/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Partial Info.plist: GENERATE_INFOPLIST_FILE=YES merges the standard
+	     generated keys (bundle name/version, launch screen, orientations, and the
+	     INFOPLIST_KEY_* build settings) on top of this. Only the keys that can't be
+	     expressed as flat INFOPLIST_KEY_* build settings live here — the custom URL
+	     scheme used by widget / Live Activity deep links. -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>in.juspay.shooter</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>shooter</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/Shooter/ShooterWidget/ShooterHomeWidget.swift
+++ b/ios/Shooter/ShooterWidget/ShooterHomeWidget.swift
@@ -72,6 +72,14 @@ struct ShooterHomeWidgetView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         .padding()
         .widgetBackground(Color.black.opacity(0.9))
+        .widgetURL(deepLink)
+    }
+
+    /// Tapping the widget opens the session it shows (nil when empty → opens the app).
+    private var deepLink: URL? {
+        entry.snapshot.sessionId.isEmpty
+            ? nil
+            : URL(string: "shooter://session/\(entry.snapshot.sessionId)")
     }
 }
 

--- a/ios/Shooter/ShooterWidget/ShooterLiveActivity.swift
+++ b/ios/Shooter/ShooterWidget/ShooterLiveActivity.swift
@@ -35,6 +35,8 @@ struct ShooterLiveActivity: Widget {
             .padding()
             .activityBackgroundTint(Color.black.opacity(0.85))
             .activitySystemActionForegroundColor(amber)
+            // Tapping the Lock Screen activity opens its session in the app.
+            .widgetURL(URL(string: "shooter://session/\(context.attributes.sessionId)"))
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {


### PR DESCRIPTION
## Deep links — tapping the widget / Live Activity opens the session

Completes the widget/Live Activity story from #118–#120: a tap now opens the app **to that session**, not just to the app.

- **`.widgetURL(shooter://session/<id>)`** on the home widget (nil-guarded when empty → opens the app) and the Live Activity Lock Screen (`context.attributes.sessionId`).
- **URL scheme `shooter`** registered via a partial `Shooter/Info.plist` (`CFBundleURLTypes`) with `INFOPLIST_FILE` set while `GENERATE_INFOPLIST_FILE` stays `YES`. **Verified by inspecting the built `Info.plist`** — the `shooter` scheme AND every generated key (`NSSupportsLiveActivities`, `CFBundleName`, `UILaunchScreen`) coexist, so the app keeps a complete plist.
- **`ContentView.onOpenURL`** parses `session`/`terminal` links → joins to the stored `serverUrl` (trailing-slash-safe) → posts `.shooterDeepLink`; the WebView coordinator observes it (same pattern as `.shooterSilentWake`) and navigates. Unpaired app drops the link safely.

### Verified
- `xcodebuild -scheme Shooter -sdk iphonesimulator` → **`** BUILD SUCCEEDED **`** (×3); built `Info.plist` merge inspected.
- Adversarial review (3 dimensions → verify) → **0 confirmed findings** (id-in-URL and observer-lifecycle concerns refuted; UUID ids are URL-safe, iOS 9+ auto-removes selector observers).

The tap→open→navigate round-trip is the on-device acceptance step (custom schemes need a real launch).
