### PR TITLE
fix(ios): repair nav-bar title truncation + UI cosmetics

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -150,6 +150,11 @@ html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+  /* iOS WKWebView auto-inflates text (Text Autosizing) even with a
+     width=device-width viewport, unlike Chrome — pin it so the app renders at the
+     CSS-specified sizes and layouts don't overflow/truncate on iOS. */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 body {
@@ -1045,6 +1050,14 @@ body {
   .session-card-header {
     flex-direction: column;
     gap: var(--space-2, 0.5rem);
+  }
+
+  /* In the stacked (column) layout the title wrapper is no longer flex-shrunk
+     against a sibling, so it sizes to its content and a long title overflows
+     the card without an ellipsis. Pin it to the header width so the title's
+     own text-overflow: ellipsis takes effect. */
+  .session-card-header > div:first-child {
+    width: 100%;
   }
 
   .session-badge {

--- a/src/lib/modules/client/common/markdown.ts
+++ b/src/lib/modules/client/common/markdown.ts
@@ -28,7 +28,7 @@ export function renderMarkdown(text: string): string {
     return cached;
   }
 
-  const html = marked.parse(text) as string;
+  const html = marked.parse(stripAnsi(text)) as string;
   const result = DOMPurify.sanitize(html);
 
   // Evict oldest entry when cache is full
@@ -41,4 +41,16 @@ export function renderMarkdown(text: string): string {
   markdownCache.set(text, result);
 
   return result;
+}
+
+/**
+ * Strip ANSI/VT escape sequences (CSI, OSC, and lone escapes). Some system
+ * messages — e.g. Claude Code's "Set model to \x1b[1mFable 5\x1b[22m …" —
+ * carry terminal styling codes that would otherwise leak into the rendered
+ * chat as literal "[1m…[22m" noise. Every branch is anchored on the ESC
+ * (\x1b) byte, so ordinary text such as a markdown "[link]" is never touched.
+ */
+function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07|\x1b[@-Z\\-_]/g, '');
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,6 @@
 
   import { goto } from '$app/navigation';
   import BellSvg from '$lib/assets/icons/bell.svg?raw';
-  import RefreshSvg from '$lib/assets/icons/refresh.svg?raw';
   import SettingsSvg from '$lib/assets/icons/settings.svg?raw';
   import {
     clearCache,
@@ -12,7 +11,6 @@
     isShooterConfig,
     setCache,
   } from '$lib/modules/client/common';
-  import Glyph from '$lib/modules/client/common/Glyph.svelte';
   import SkeletonCard from '$lib/modules/client/common/SkeletonCard.svelte';
   import {
     AutopilotPanel,
@@ -161,13 +159,7 @@
   <meta name="description" content="Active terminals and Claude Code sessions" />
 </svelte:head>
 
-<NavBar variant="root" title="Dashboard">
-  {#snippet trailing()}
-    <Button classes="btn-secondary" onclick={forceRefresh} disabled={loading} ariaLabel="Refresh">
-      <Glyph svg={RefreshSvg} size={14} />
-    </Button>
-  {/snippet}
-</NavBar>
+<NavBar variant="root" title="Dashboard" />
 
 <PullToRefresh onRefresh={forceRefresh}>
   <main class="main">

--- a/src/routes/project/+page.svelte
+++ b/src/routes/project/+page.svelte
@@ -5,7 +5,6 @@
   import { page } from '$app/state';
   import AlertTriangleSvg from '$lib/assets/icons/alert-triangle.svg?raw';
   import BellSvg from '$lib/assets/icons/bell.svg?raw';
-  import RefreshSvg from '$lib/assets/icons/refresh.svg?raw';
   import {
     clearCache,
     formatRelativeTime,
@@ -15,7 +14,6 @@
     sourceLabel,
     sourceToCommand,
   } from '$lib/modules/client/common';
-  import Glyph from '$lib/modules/client/common/Glyph.svelte';
   import SkeletonCard from '$lib/modules/client/common/SkeletonCard.svelte';
   import EdgeSwipeBack from '$lib/modules/client/nav/EdgeSwipeBack.svelte';
   import InfiniteScroll from '$lib/modules/client/nav/InfiniteScroll.svelte';
@@ -236,20 +234,7 @@
 </svelte:head>
 
 <EdgeSwipeBack backHref="/">
-  <NavBar variant="drilldown" title={project?.name ?? 'Project'} backHref="/">
-    {#snippet trailing()}
-      {#if project}
-        <Button
-          classes="btn-secondary"
-          onclick={forceRefresh}
-          disabled={loading}
-          ariaLabel="Refresh"
-        >
-          <Glyph svg={RefreshSvg} size={14} />
-        </Button>
-      {/if}
-    {/snippet}
-  </NavBar>
+  <NavBar variant="drilldown" title={project?.name ?? 'Project'} backHref="/" />
 
   <PullToRefresh onRefresh={forceRefresh}>
     <main class="main">

--- a/src/routes/terminals/+page.svelte
+++ b/src/routes/terminals/+page.svelte
@@ -2,7 +2,6 @@
   import type { ShooterConfig, TerminalListItem } from '$lib/types';
 
   import { goto } from '$app/navigation';
-  import RefreshSvg from '$lib/assets/icons/refresh.svg?raw';
   import SettingsSvg from '$lib/assets/icons/settings.svg?raw';
   import TerminalSvg from '$lib/assets/icons/terminal.svg?raw';
   import {
@@ -12,7 +11,6 @@
     isShooterConfig,
     setCache,
   } from '$lib/modules/client/common';
-  import Glyph from '$lib/modules/client/common/Glyph.svelte';
   import SkeletonCard from '$lib/modules/client/common/SkeletonCard.svelte';
   import Fab from '$lib/modules/client/nav/Fab.svelte';
   import NavBar from '$lib/modules/client/nav/NavBar.svelte';
@@ -253,13 +251,7 @@
   <meta name="description" content="Active terminal sessions on this machine" />
 </svelte:head>
 
-<NavBar variant="root" title="Terminals">
-  {#snippet trailing()}
-    <Button classes="btn-secondary" onclick={forceRefresh} disabled={loading} ariaLabel="Refresh">
-      <Glyph svg={RefreshSvg} size={14} />
-    </Button>
-  {/snippet}
-</NavBar>
+<NavBar variant="root" title="Terminals" />
 
 <PullToRefresh onRefresh={forceRefresh}>
   <main class="main">


### PR DESCRIPTION
## The reported problem

> "The UI is completely broken … the tab bar itself in the mobile view looks broken."

## Root cause (one real defect)

The root pages (Dashboard, Terminals, Project) fed an extra **Refresh** button into the `NavBar` trailing slot alongside the bell, the wide `ONLINE` pill, and the gear. `.navbar-title` is `flex:1; min-width:0` with an ellipsis and the trailing group is `flex-shrink:0`, so the extra button consumed the title's width. **iOS WebKit renders text wider than Chrome**, so at iPhone width the title truncated (`"Dashboar…"`) next to a cramped status pill — which read as a "broken tab bar."

The bottom tab bar itself was never broken; it rendered cleanly on every screen.

## Changes

- **Remove the redundant Refresh button** from Dashboard / Terminals / Project (pull-to-refresh already covers refresh) so titles render in full on iOS.
- Pin `-webkit-text-size-adjust: 100%` as iOS text-inflation hardening.
- **Ellipsize long session-card titles** — in the stacked (column) mobile header the title wrapper sized to its content and overflowed the card with no ellipsis; pin it to `100%` width so `text-overflow: ellipsis` takes effect.
- **Strip ANSI/VT escapes in `renderMarkdown`** so Claude Code system messages don't leak literal `[1m…[22m` into the rendered chat (regex anchored on ESC, so markdown like `[link]` is untouched).

`5 files changed, +29 / −35`.

## Verification

Every screen driven with **real data**, on the **iPhone 17 Pro simulator** and in Chrome at mobile width: Dashboard, Project sessions, Session chat, Terminals list, **live terminal streaming** (command → output over WebSocket, confirmed on device), SoS, and Settings. Console clean on every page.

| Gate | Result |
|---|---|
| build | ✓ vite build |
| check | ✓ 0 errors / 0 warnings / 999 files |
| lint | ✓ eslint exit 0 |
| test | ✓ 41 test files, 0 failures |

> Note: an early terminal test showed a blank pane — that was a stray raw `vite dev` (no WebSocket layer), **not an app bug**. Streaming was verified against a real `server.ts` build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented mobile browsers from automatically enlarging text.
  - Fixed long session titles overflowing in stacked mobile layouts.
  - Removed terminal escape codes from rendered Markdown output.

- **Interface Updates**
  - Removed refresh buttons from dashboard, project, and terminal navigation bars.
  - Pull-to-refresh functionality remains available on supported pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->