### PR TITLE
fix(ios): shorten SoS nav title to 'SoS' so it fits on iOS

### DIFF
--- a/src/routes/sos/+page.svelte
+++ b/src/routes/sos/+page.svelte
@@ -82,7 +82,7 @@
 
 <svelte:head><title>Session Over Sessions - Shooter</title></svelte:head>
 
-<NavBar variant="root" title="Session Over Sessions" />
+<NavBar variant="root" title="SoS" />
 
 <PullToRefresh onRefresh={loadSessions}>
   <main class="main sos-list">


### PR DESCRIPTION
## Problem

The `/sos` root page set its nav title to **"Session Over Sessions"** (21 chars). On iOS WebKit — which renders text wider than Chrome — that overran the available title width beside the bell + `ONLINE` pill + gear trailing group and truncated to **"Session Over …"**.

This surfaced during the on-device verification of the nav-bar fix in #123: Dashboard and Terminals now show full titles, but SoS still ellipsized.

## Fix

Set the SoS nav title to **"SoS"**, matching its bottom-tab label. This mirrors the existing convention where the tab label and nav title agree (Dashboard-tab ↔ "Dashboard", Terminals-tab ↔ "Terminals"), and guarantees the title fits (shorter than the 9-char titles that already render in full).

The descriptive document `<title>` (`Session Over Sessions - Shooter`) is left unchanged.

## Verification

- `pnpm build` ✓
- `pnpm check` ✓ (0 errors / 999 files)
- `pnpm lint` ✓
- `pnpm test` ✓ (0 failed)
- **On-device (iPhone 17 Pro simulator, iOS WebKit):** `/sos` nav renders full "SoS" title, no truncation, clean top + bottom nav.

Net diff: **1 file, +1 / −1**.